### PR TITLE
frontend fixes

### DIFF
--- a/src/main/antlr4/ReadELF.g4
+++ b/src/main/antlr4/ReadELF.g4
@@ -9,7 +9,7 @@ syms : NEWLINE* relocationTable+ symbolTable+ ;
     Sym value is the addend to be added to the symbol resolution
     Sym name and addend - a pretty printing of the symbol name + addend.
 */
-relocationTable : relocationTableHeader NEWLINE relocationTableRow* NEWLINE*;
+relocationTable : (empty='There are no relocations in this file.') NEWLINE* | (relocationTableHeader NEWLINE relocationTableRow* NEWLINE*);
 relocationTableHeader :
   'Relocation section' tableName 'at offset 0x' HEX 'contains' HEX 'entries:' NEWLINE
   'Offset' 'Info' 'Type' ('Sym. Value' | 'Symbol\'s Value') ('Symbol\'s Name + Addend' | 'Sym. Name + Addend')

--- a/src/main/scala/translating/ReadELFLoader.scala
+++ b/src/main/scala/translating/ReadELFLoader.scala
@@ -16,6 +16,7 @@ enum ELFSymType:
   case FILE
   case OBJECT
   case FUNC /* code function */
+  case TLS /* ??? */
 
 
 enum ELFBind:
@@ -26,6 +27,7 @@ enum ELFBind:
 enum ELFVis:
   case HIDDEN
   case DEFAULT
+  case PROTECTED
 
 enum ELFNDX:
   case Section(num: Int) /* Section containing the symbol */
@@ -43,8 +45,8 @@ case class ELFSymbol(num: Int,  /* symbol number */
 
 object ReadELFLoader {
   def visitSyms(ctx: SymsContext, config: ILLoadingConfig): (List[ELFSymbol], Set[ExternalFunction], Set[SpecGlobal], Map[BigInt, BigInt], BigInt) = {
-    val externalFunctions = ctx.relocationTable.asScala.flatMap(r => visitRelocationTableExtFunc(r)).toSet
-    val relocationOffsets = ctx.relocationTable.asScala.flatMap(r => visitRelocationTableOffsets(r)).toMap
+    val externalFunctions = ctx.relocationTable.asScala.filter(_.relocationTableHeader != null).flatMap(r => visitRelocationTableExtFunc(r)).toSet
+    val relocationOffsets = ctx.relocationTable.asScala.filter(_.relocationTableHeader != null).flatMap(r => visitRelocationTableOffsets(r)).toMap
     val mainAddress = ctx.symbolTable.asScala.flatMap(s => getFunctionAddress(s, config.mainProcedureName))
 
     val symbolTable = ctx.symbolTable.asScala.flatMap(s => visitSymbolTable(s)).toList
@@ -59,12 +61,16 @@ object ReadELFLoader {
   }
 
   def visitRelocationTableExtFunc(ctx: RelocationTableContext): Set[ExternalFunction] = {
-    val sectionName = ctx.relocationTableHeader.tableName.STRING.getText
-    if (sectionName == ".rela.plt" || sectionName == ".rela.dyn") {
-      val rows = ctx.relocationTableRow.asScala
-      rows.filter(r => r.name != null).map(r => visitRelocationTableRowExtFunc(r)).toSet
-    } else {
+    if (ctx.relocationTableHeader == null) {
       Set()
+    } else {
+      val sectionName = ctx.relocationTableHeader.tableName.STRING.getText
+      if (sectionName == ".rela.plt" || sectionName == ".rela.dyn") {
+        val rows = ctx.relocationTableRow.asScala
+        rows.filter(r => r.name != null).map(r => visitRelocationTableRowExtFunc(r)).toSet
+      } else {
+        Set()
+      }
     }
   }
 

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -221,6 +221,13 @@ object IRTransform {
     Logger.debug(
       s"[!] Removed ${before - ctx.program.procedures.size} functions (${ctx.program.procedures.size} remaining)"
     )
+    val dupProcNames = (ctx.program.procedures.groupBy(_.name).filter((n,p) => p.size > 1)).toList.flatMap(_._2)
+
+    var dupCounter = 0 
+    for (p <- dupProcNames) {
+      dupCounter += 1
+      p.name = p.name + "$" + p.address.map(_.toString).getOrElse(dupCounter.toString)
+    }
 
     val stackIdentification = StackSubstituter()
     stackIdentification.visitProgram(ctx.program)


### PR DESCRIPTION


- handle unsupported opcodes from https://github.com/UQ-PAC/gtirb-semantics/pull/22
- disambiguate functions with local binding (c `static`) which have the same name but different addresses in the boogie output
- handle relf files with empty relocation table
- some missing relf enum values