### PR TITLE
frontend fixes to support CAS 

### DIFF
--- a/scripts/lift.mk
+++ b/scripts/lift.mk
@@ -1,0 +1,28 @@
+
+
+BIN ?= a.out
+DDISASM ?= ddisasm
+BAP ?= bap
+GTIRB_SEM ?= gtirb-semantics
+READELF ?= aarch64-unknown-linux-gnu-readelf
+
+all: $(BIN).gts $(BIN).adt $(BIN).relf
+
+bap: $(BIN).adt $(BIN).relf
+gtirb: $(BIN).gts $(BIN).relf
+
+
+$(BIN).gtirb : $(BIN)
+	$(DDISASM) $(BIN) --ir $(BIN).gtirb
+
+$(BIN).gts : $(BIN).gtirb
+	$(GTIRB_SEM) $(BIN).gtirb $(BIN).gts
+
+$(BIN).adt : $(BIN)
+	$(BAP) $(BIN) -d adt:$(BIN).adt -d bil:$(BIN).bil
+
+$(BIN).relf : $(BIN)
+	$(READELF) -s -r -W $(BIN) > $(BIN).relf
+
+clean: 
+	rm -f $(BIN).relf $(BIN).adt $(BIN).bil $(BIN).gts $(BIN).gtirb

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -246,7 +246,7 @@ object IRTransform {
     val renamer = Renamer(boogieReserved)
     renamer.visitProgram(ctx.program)
 
-    assert(invariant.singleCallBlockEnd(ctx.program))
+    assert(invariant.singleCallBlockEnd(ctx.program), "Single call at block end")
   }
 
   def generateProcedureSummaries(
@@ -562,7 +562,7 @@ object RunUtils {
       val boogieTranslator = IRToBoogie(ctx.program, ctx.specification, None, q.outputPrefix, regionInjector, q.boogieTranslation)
       ArrayBuffer(boogieTranslator.translate)
     }
-    assert(invariant.singleCallBlockEnd(ctx.program))
+    assert(invariant.singleCallBlockEnd(ctx.program), "Single call at block end")
 
     BASILResult(ctx, analysis, boogiePrograms)
   }
@@ -643,7 +643,7 @@ object RunUtils {
       None
     }
 
-    assert(invariant.singleCallBlockEnd(ctx.program))
+    assert(invariant.singleCallBlockEnd(ctx.program), "Single call at block end")
     Logger.debug(s"[!] Finished indirect call resolution after $iteration iterations")
     analysisResult.last.copy(
       symbolicAddresses = symResults,


### PR DESCRIPTION
- fix bug: requiring all symbol table entries to have an address
- frontend: allow loads in binary expressions and branch conditions to support CAS instruction
- frontend (gtirb): wip; support AtomicStart and AtomicEnd intrinsics, split blocks into multiple across call boundaries 

addresses #281 