### PR TITLE
fix bap loader with missing proc address

### DIFF
--- a/src/main/scala/translating/BAPToIR.scala
+++ b/src/main/scala/translating/BAPToIR.scala
@@ -37,7 +37,7 @@ class BAPToIR(var program: BAPProgram, mainAddress: BigInt) {
       for (p <- s.out) {
         procedure.out.append(translateParameter(p))
       }
-      if (s.address.get == mainAddress) {
+      if (s.address.contains(mainAddress)) {
         mainProcedure = Some(procedure)
       }
       procedures.append(procedure)


### PR DESCRIPTION
- this occurs when bap emits intrinsic functions (e.g. AtomicStart)