### PR TITLE
Support new lifter unsupported opcode format

### DIFF
--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -39,9 +39,11 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
       constMap.clear
       varMap.clear
 
-      val s = instsem match {
+      instsem match {
         case InsnSemantics.Error(op, err) => {
-          statements.append(Assert(FalseLiteral, Some(s"Decode error: $op ${err.replace("\n", " :: ")}")))
+          val message = s"$op ${err.replace("\n", " :: ")}"
+          Logger.warn(s"Program contains lifter unsupported opcode: $message")
+          statements.append(Assert(FalseLiteral, Some(s"Lifter error: $message")))
           instructionCount += 1
         }
         case InsnSemantics.Result(instruction) => {
@@ -492,7 +494,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         // AArch64.MemTag.read, AArch64.MemTag.set - allocation tag operations, can't model as uninterpreted functions
         // and will require some research into their semantics
         // AtomicStart, AtomicEnd - can't model as uninterpreted functions, requires modelling atomic section
-        Logger.debug(s"unidentified call to $function: ${ctx.getText}")
+        Logger.error(s"unidentified call to $function: ${ctx.getText}")
         (None, None)
     }
 

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -49,7 +49,7 @@ class TempIf(val cond: Expr,
   * @param mainAddress: The address of the main function
   *
   */
-class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, Array[Array[StmtContext]]], cfg: CFG, mainAddress: BigInt) {
+class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, List[Either[(String, String), List[StmtContext]]]], cfg: CFG, mainAddress: BigInt) {
   private val functionNames = MapDecoder.decode_uuid(mods.map(_.auxData("functionNames").data))
   private val functionEntries = MapDecoder.decode_set(mods.map(_.auxData("functionEntries").data))
   private val functionBlocks = MapDecoder.decode_set(mods.map(_.auxData("functionBlocks").data))

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -49,7 +49,7 @@ class TempIf(val cond: Expr,
   * @param mainAddress: The address of the main function
   *
   */
-class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, List[Either[(String, String), List[StmtContext]]]], cfg: CFG, mainAddress: BigInt) {
+class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, List[InsnSemantics]], cfg: CFG, mainAddress: BigInt) {
   private val functionNames = MapDecoder.decode_uuid(mods.map(_.auxData("functionNames").data))
   private val functionEntries = MapDecoder.decode_set(mods.map(_.auxData("functionEntries").data))
   private val functionBlocks = MapDecoder.decode_set(mods.map(_.auxData("functionBlocks").data))

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -120,9 +120,29 @@ object IRLoading {
     val mods = ir.modules
     val cfg = ir.cfg.get
 
-    val semantics = mods.map(_.auxData("ast").data.toStringUtf8.parseJson.convertTo[Map[String, Array[Array[String]]]])
+    enum InsnSemantics {
+      case Result(value: Array[String])
+      case Error(opcode: String, error: String)
+    }
 
-    def parse_insn(line: String): StmtContext = {
+    implicit object InsnSemanticsFormat extends JsonFormat[InsnSemantics] {
+      def write(m: InsnSemantics) =  ???
+      def read(json: JsValue) = json match {
+        case JsObject(fields) => {
+          val m : Map[String, JsValue] = fields.get("decode_error") match {
+            case Some(JsObject(m)) => m
+            case _ => deserializationError(s"Bad sem format $json")
+          }
+          InsnSemantics.Error(m("opcode").convertTo[String], m("error").convertTo[String])
+        }
+        case array @ JsArray(_) => InsnSemantics.Result(array.convertTo[Array[String]])
+        case s => deserializationError(s"Bad sem format $s")
+      }
+    }
+
+    val semantics = mods.map(_.auxData("ast").data.toStringUtf8.parseJson.convertTo[Map[String, Array[InsnSemantics]]])
+
+    def parse_asl_stmt(line: String): StmtContext = {
       val lexer = ASLpLexer(CharStreams.fromString(line))
       val tokens = CommonTokenStream(lexer)
       val parser = ASLpParser(tokens)
@@ -143,16 +163,20 @@ object IRLoading {
               ${line.replace('\n', ' ')}
               ${" " * token.getStartIndex}^ here!
               """.stripIndent
-            case _ => ""
+            case o => o.toString
           }
           Logger.error(s"""Semantics parse error:\n  line: $line\n$extra""")
           throw e
       }
     }
 
-    val parserMap = semantics.map(_.map((k: String, v: Array[Array[String]]) => (k, v.map(_.map(parse_insn)))))
+    val parserMap : Map[String, List[Either[(String,String), List[StmtContext]]]] =
+      semantics.toList.map(_.map((k: String, v: Array[InsnSemantics]) => (k, v.toList.map {
+      case InsnSemantics.Result(s) => Right(s.toList.map(parse_asl_stmt))
+      case InsnSemantics.Error(op, err) => Left((op, err))
+      }))).flatten.toMap
 
-    val GTIRBConverter = GTIRBToIR(mods, parserMap.flatten.toMap, cfg, mainAddress)
+    val GTIRBConverter = GTIRBToIR(mods, parserMap, cfg, mainAddress)
     GTIRBConverter.createIR()
   }
 
@@ -163,6 +187,7 @@ object IRLoading {
     val lexer = ReadELFLexer(CharStreams.fromFileName(fileName))
     val tokens = CommonTokenStream(lexer)
     val parser = ReadELFParser(tokens)
+    parser.setErrorHandler(BailErrorStrategy())
     parser.setBuildParseTree(true)
     ReadELFLoader.visitSyms(parser.syms(), config)
   }


### PR DESCRIPTION
Updates frontend to support the format in  https://github.com/UQ-PAC/gtirb-semantics/pull/22

Test code: [gate_server_example.tar.gz](https://github.com/user-attachments/files/18194266/gate_server_example.tar.gz)

Also adds a case to loading `cvt_bool_bv` that wasn't covered previously. 