### PR TITLE
Add block info, interproc solver, analysis prettyprinter

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -173,10 +173,11 @@ object Main {
       }
     }
 
-    if (conf.analysisResults.isDefined || conf.analysisResultsDot.isDefined) {
+    if (conf.analysisResults.isDefined || conf.dumpIL.isDefined) {
       DebugDumpIRLogger.setLevel(LogLevel.INFO)
-    } else {
-      DebugDumpIRLogger.setLevel(LogLevel.OFF)
+    }
+    if (conf.analysisResultsDot.isDefined) {
+      AnalysisResultDotLogger.setLevel(LogLevel.INFO)
     }
 
     val rely = conf.procedureRG match {

--- a/src/main/scala/analysis/IrreducibleLoops.scala
+++ b/src/main/scala/analysis/IrreducibleLoops.scala
@@ -71,6 +71,15 @@ object LoopDetector {
     def reducibleTransformIR(): State = {
       this.copy(loops = LoopTransform.llvm_transform(loops.values).map(l => l.header -> l).toMap)
     }
+
+    def updateIrWithLoops() = {
+      for ((hd, l) <- loops) {
+        hd.inLoop = Set(l)
+        for (participant <- l.nodes) {
+          participant.inLoop = participant.inLoop + l
+        }
+      }
+    }
   }
 
   def identify_loops(entryBlock: Block): State = {

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -3,7 +3,7 @@ package ir
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{IterableOnceExtensionMethods, View, immutable, mutable}
 import boogie.*
-import analysis.{MergedRegion}
+import analysis.{MergedRegion, Loop}
 import util.intrusive_list.*
 import translating.serialiseIL
 import eval.BitVectorEval
@@ -398,6 +398,10 @@ class Block private (
 
   def isReturn: Boolean = parent.returnBlock.contains(this)
   def isEntry: Boolean = parent.entryBlock.contains(this)
+
+  var inLoop: Set[Loop] = Set()
+  def isLoopHeader () = inLoop.exists(x => x.header == this)
+  def isLoopParticipant () = inLoop.nonEmpty
 
   def jump: Jump = _jump
 

--- a/src/main/scala/ir/transforms/AbsInt.scala
+++ b/src/main/scala/ir/transforms/AbsInt.scala
@@ -85,7 +85,7 @@ class DomainWithFunctionSummaries[L, Summary](d: AbstractDomain[L],
     }
 }
 
-trait ProcedureSummaryGenerator[L, LocalDomain] extends GenericAbstractDomain[Procedure, Procedure, L] {
+trait ProcedureSummaryGenerator[L, LocalDomain] extends ProcAbstractDomain[L] {
   def localTransferCall(l: LocalDomain, summaryForTarget: L, p: DirectCall) : LocalDomain
   def updateSummary(prevSummary: L, p: Procedure,  resBefore: Map[Block, LocalDomain], resAfter: Map[Block, LocalDomain]) : L
 }

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -52,6 +52,7 @@ class GenericLogger(
 
   def writeToFile(file: File, content: => String) = {
     if (level.id < LogLevel.OFF.id) {
+      this.debug(s"Writing $file")
       val l = deriveLogger(file.getName(), file)
       l.print(content)
       l.close()
@@ -132,13 +133,15 @@ class GenericLogger(
     writeLog(LogLevel.INFO, arg, line, file, name)
   }
 
-  def setLevel(logLevel: LogLevel, setChildren: Boolean = true): Unit = {
+  def setLevel(logLevel: LogLevel, setChildren: Boolean = true) : GenericLogger = {
+    println(s"Set level $name $logLevel")
     level = logLevel
     if (setChildren) {
       for (c <- children) {
         c.setLevel(logLevel, setChildren)
       }
     }
+    this
   }
 
   def findLoggerByName(s: String): Option[GenericLogger] = allLoggers.find(_.name == s)
@@ -159,11 +162,8 @@ def isAConsole = System.console() != null
 val Logger = GenericLogger("log", LogLevel.DEBUG, System.out, isAConsole)
 val StaticAnalysisLogger = Logger.deriveLogger("analysis", System.out)
 val SimplifyLogger = Logger.deriveLogger("simplify", System.out)
-val DebugDumpIRLogger = {
-  val l = Logger.deriveLogger("debugdumpir")
-  l.setLevel(LogLevel.OFF)
-  l
-}
+val DebugDumpIRLogger = Logger.deriveLogger("debugdumpir").setLevel(LogLevel.OFF)
+val AnalysisResultDotLogger = Logger.deriveLogger("analysis-results-dot").setLevel(LogLevel.OFF)
 val VSALogger = StaticAnalysisLogger.deriveLogger("vsa")
 val MRALogger = StaticAnalysisLogger.deriveLogger("mra")
 val SteensLogger = StaticAnalysisLogger.deriveLogger("steensgaard")


### PR DESCRIPTION
- add loop information to the IR so you can easily implement widening heuristic in the AbstractDomain.join function without proper solver support

```scala
class Block {
  var inLoop: Set[Loop]
  def isLoopHeader () : Bool
  def isLoopParticipant () : Bool
}
```

- Add simple interprocedural solver which takes a fixed-point over the call graph (very naive inefficient implementation but seems OK for definitely-returns analysis in cntlm-noduk). 

This applies an interprocedural analysis to each procedure, abstracts the results to a summary for the procedure-level, and takes this to a fixed point.

To use this define a local analysis `AbstractDomain[LocalDomain]`, and a summary generator:

```scala
trait ProcedureSummaryGenerator[L, LocalDomain] extends GenericAbstractDomain[Procedure, Procedure, L] {
  def localTransferCall(l: LocalDomain, summaryForTarget: L, p: DirectCall) : LocalDomain
  def updateSummary(prevSummary: L, p: Procedure,  resBefore: Map[Block, LocalDomain], resAfter: Map[Block, LocalDomain]) : L
}
```

And pass them to the solver:

```scala
class interprocSummaryFixpointSolver[SummaryAbsVal, LocalAbsVal, 
  A <: AbstractDomain[LocalAbsVal]](localDomain : A, 
    sg: ProcedureSummaryGenerator[SummaryAbsVal, LocalAbsVal]) {
   ...
    solveProgInterproc(p: Program, backwards: Boolean): Map[Procedure, SummaryAbsVal]
}
```

This is a bit confusing possibly because it overrides the local AbstractDomain.transfer for directCalls to inject the summary provided by localTransferCall. 

- Add analysis result printing api to `PrettyPrinter`:

```scala
pp_prog_with_analysis_results(beforeLive, afterLive, ctx.program, x => s"Live vars: ${x.map(_.name).toList.sorted.mkString(", ")}")
```

```
    block www_authenticate_4218176_basil_return [
      // Live vars: R0, R29, R31
      return (R0:bv64, R29:bv64, R31:bv64)
      // Live vars: 
    ]
```