### PR TITLE
make ssa lazy dependent on mra or vsa

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -53,7 +53,9 @@ object Main {
     @arg(name = "memory-regions", doc = "Performs static analysis to separate memory into discrete regions in Boogie output (requires --analyse flag) (mra|dsa) (dsa is recommended over mra)")
     memoryRegions: Option[String],
     @arg(name = "no-irreducible-loops", doc = "Disable producing irreducible loops when --analyse is passed (does nothing without --analyse)")
-    noIrreducibleLoops: Flag
+    noIrreducibleLoops: Flag,
+    @arg(name = "resolve-indirect-calls", doc = "Enable indirect call resolution (does not currently support code containing loops).")
+    resolveCalls: Flag
   )
 
   def main(args: Array[String]): Unit = {
@@ -96,7 +98,8 @@ object Main {
         conf.threadSplit.value,
         conf.summariseProcedures.value,
         memoryRegionsMode,
-        !conf.noIrreducibleLoops.value
+        !conf.noIrreducibleLoops.value,
+        conf.resolveCalls.value
       ))
     } else {
       None

--- a/src/main/scala/util/BASILConfig.scala
+++ b/src/main/scala/util/BASILConfig.scala
@@ -27,7 +27,8 @@ case class StaticAnalysisConfig(
   threadSplit: Boolean = false,
   summariseProcedures: Boolean = false,
   memoryRegions: MemoryRegionsMode = MemoryRegionsMode.Disabled,
-  irreducibleLoops: Boolean = true
+  irreducibleLoops: Boolean = true,
+  indirectCalls: Boolean = false,
 )
 
 enum BoogieMemoryAccessMode {

--- a/src/test/scala/PointsToTest.scala
+++ b/src/test/scala/PointsToTest.scala
@@ -47,10 +47,10 @@ class PointsToTest extends AnyFunSuite with OneInstancePerTest {
     cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
 
     val results = runAnalyses(program)
-    results.mmmResults.pushContext("main")
-    assert(results.mmmResults.findStackObject(BigInt(4)).isDefined)
-    assert(results.mmmResults.findStackObject(BigInt(4)).get.start == BigInt(4))
-    assert(results.mmmResults.findStackObject(BigInt(4)).get.regionIdentifier == "stack_1")
+    results.mmmResults().pushContext("main")
+    assert(results.mmmResults().findStackObject(BigInt(4)).isDefined)
+    assert(results.mmmResults().findStackObject(BigInt(4)).get.start == BigInt(4))
+    assert(results.mmmResults().findStackObject(BigInt(4)).get.regionIdentifier == "stack_1")
   }
 
   /**
@@ -76,16 +76,16 @@ class PointsToTest extends AnyFunSuite with OneInstancePerTest {
     cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
 
     val results = runAnalyses(program)
-    results.mmmResults.pushContext("main")
-    assert(results.mmmResults.findStackObject(BigInt(4)).isDefined)
-    assert(results.mmmResults.findStackObject(BigInt(5)).isDefined)
-    assert(results.mmmResults.findStackObject(BigInt(6)).isDefined)
-    assert(results.mmmResults.findStackObject(BigInt(10)).isDefined)
+    results.mmmResults().pushContext("main")
+    assert(results.mmmResults().findStackObject(BigInt(4)).isDefined)
+    assert(results.mmmResults().findStackObject(BigInt(5)).isDefined)
+    assert(results.mmmResults().findStackObject(BigInt(6)).isDefined)
+    assert(results.mmmResults().findStackObject(BigInt(10)).isDefined)
 
-    assert(results.mmmResults.findStackObject(BigInt(4)).get.start == BigInt(4))
-    assert(results.mmmResults.findStackObject(BigInt(5)).get.start == BigInt(4))
-    assert(results.mmmResults.findStackObject(BigInt(6)).get.start == BigInt(6))
-    assert(results.mmmResults.findStackObject(BigInt(10)).get.start == BigInt(6))
+    assert(results.mmmResults().findStackObject(BigInt(4)).get.start == BigInt(4))
+    assert(results.mmmResults().findStackObject(BigInt(5)).get.start == BigInt(4))
+    assert(results.mmmResults().findStackObject(BigInt(6)).get.start == BigInt(6))
+    assert(results.mmmResults().findStackObject(BigInt(10)).get.start == BigInt(6))
   }
 
 //  /**
@@ -115,17 +115,17 @@ class PointsToTest extends AnyFunSuite with OneInstancePerTest {
 //    )
 //
 //    runSteensgaardAnalysis(program)
-//    results.mmmResults.pushContext("main")
-//    assert(results.mmmResults.findStackObject(BigInt(4)).isDefined) // Explicit memStore
-//    assert(results.mmmResults.findStackObject(BigInt(6)).isDefined) // Explicit memLoad
-//    assert(results.mmmResults.findStackObject(BigInt(10)).isDefined) // Implicit memLoad
-//    assert(results.mmmResults.findStackObject(BigInt(20)).isDefined) // Implicit memStore
+//    results.mmmResults().pushContext("main")
+//    assert(results.mmmResults().findStackObject(BigInt(4)).isDefined) // Explicit memStore
+//    assert(results.mmmResults().findStackObject(BigInt(6)).isDefined) // Explicit memLoad
+//    assert(results.mmmResults().findStackObject(BigInt(10)).isDefined) // Implicit memLoad
+//    assert(results.mmmResults().findStackObject(BigInt(20)).isDefined) // Implicit memStore
 //
 //
-//    assert(results.mmmResults.findStackObject(BigInt(4)).get.start == bv64(4))
-//    assert(results.mmmResults.findStackObject(BigInt(6)).get.start == bv64(6))
-//    assert(results.mmmResults.findStackObject(BigInt(10)).get.start == bv64(10))
-//    assert(results.mmmResults.findStackObject(BigInt(20)).get.start == bv64(20))
+//    assert(results.mmmResults().findStackObject(BigInt(4)).get.start == bv64(4))
+//    assert(results.mmmResults().findStackObject(BigInt(6)).get.start == bv64(6))
+//    assert(results.mmmResults().findStackObject(BigInt(10)).get.start == bv64(10))
+//    assert(results.mmmResults().findStackObject(BigInt(20)).get.start == bv64(20))
 //  }
 
   /**
@@ -162,19 +162,19 @@ class PointsToTest extends AnyFunSuite with OneInstancePerTest {
     cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
 
     val results = runAnalyses(program)
-    results.mmmResults.pushContext("main")
-    assert(results.mmmResults.findStackObject(BigInt(6)).isDefined)
+    results.mmmResults().pushContext("main")
+    assert(results.mmmResults().findStackObject(BigInt(6)).isDefined)
 
-    assert(results.mmmResults.findStackObject(BigInt(6)).get.start == BigInt(6))
+    assert(results.mmmResults().findStackObject(BigInt(6)).get.start == BigInt(6))
 
     /* ------------------------------------------------------------------------- */
 
-    results.mmmResults.pushContext("p2")
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).nonEmpty)
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).nonEmpty)
+    results.mmmResults().pushContext("p2")
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).nonEmpty)
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).nonEmpty)
 
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).head.start == BigInt(6))
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).head.start == BigInt(10))
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).head.start == BigInt(6))
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).head.start == BigInt(10))
   }
 
   /**
@@ -221,24 +221,24 @@ class PointsToTest extends AnyFunSuite with OneInstancePerTest {
     cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
 
     val results = runAnalyses(program)
-    results.mmmResults.pushContext("main")
-    assert(results.mmmResults.findStackObject(BigInt(6)).isDefined)
+    results.mmmResults().pushContext("main")
+    assert(results.mmmResults().findStackObject(BigInt(6)).isDefined)
 
-    assert(results.mmmResults.findStackObject(BigInt(6)).get.start == BigInt(6))
+    assert(results.mmmResults().findStackObject(BigInt(6)).get.start == BigInt(6))
 
     /* ------------------------------------------------------------------------- */
 
-    results.mmmResults.pushContext("p2")
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).nonEmpty)
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).nonEmpty)
+    results.mmmResults().pushContext("p2")
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).nonEmpty)
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).nonEmpty)
 
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).size == 2)
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).size == 2)
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).size == 2)
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).size == 2)
 
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).exists(_.parent.name == "main"))
-    assert(results.mmmResults.findSharedStackObject(BigInt(6)).exists(_.parent.name == "foo"))
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).exists(_.parent.name == "main"))
-    assert(results.mmmResults.findSharedStackObject(BigInt(10)).exists(_.parent.name == "foo"))
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).exists(_.parent.name == "main"))
+    assert(results.mmmResults().findSharedStackObject(BigInt(6)).exists(_.parent.name == "foo"))
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).exists(_.parent.name == "main"))
+    assert(results.mmmResults().findSharedStackObject(BigInt(10)).exists(_.parent.name == "foo"))
   }
 
 //  /**


### PR DESCRIPTION
Workaround for https://github.com/UQ-PAC/BASIL/issues/305 that disables SSA,mmm,steensgaard if not needed. SSA is required now only for the flags --resolve-indirect-calls (which uses vsa) and --memory-regions mra. 

In the long term we will instead probably want DSA-based indirect call resolution in a separate analysis pipeline to the generic --analyse.