### PR TITLE
BAPLoader produces unique block names

### DIFF
--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -113,7 +113,9 @@ object IRLoading {
 
     parser.setBuildParseTree(true)
 
-    BAPLoader.visitProject(parser.project())
+    val bapLoader = BAPLoader()
+
+    bapLoader.visitProject(parser.project())
   }
 
   def loadGTIRB(fileName: String, mainAddress: BigInt): Program = {

--- a/src/test/correct/arrays_simple/clang/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang/arrays_simple.expected
@@ -79,8 +79,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     R8, Gamma_R8 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 20bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 20bv64), Gamma_R8);

--- a/src/test/correct/basic_arrays_read/clang/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang/basic_arrays_read.expected
@@ -92,8 +92,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002d1"} true;

--- a/src/test/correct/basic_arrays_read/clang_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang_pic/basic_arrays_read.expected
@@ -101,8 +101,8 @@ implementation main()
   var $load$19: bv32;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002d5"} true;

--- a/src/test/correct/basic_arrays_read/gcc/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc/basic_arrays_read.expected
@@ -84,8 +84,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     call rely();

--- a/src/test/correct/basic_arrays_read/gcc_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc_pic/basic_arrays_read.expected
@@ -95,8 +95,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4080bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4080bv64)) || L(mem, bvadd64(R0, 4080bv64)));

--- a/src/test/correct/basic_arrays_write/clang/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang/basic_arrays_write.expected
@@ -96,8 +96,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R9, Gamma_R9 := 69632bv64, true;
     R9, Gamma_R9 := bvadd64(R9, 52bv64), Gamma_R9;

--- a/src/test/correct/basic_arrays_write/clang_O2/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_O2/basic_arrays_write.expected
@@ -84,8 +84,8 @@ procedure main();
 implementation main()
 {
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R9, Gamma_R9 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
@@ -105,8 +105,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();

--- a/src/test/correct/basic_arrays_write/gcc/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc/basic_arrays_write.expected
@@ -94,8 +94,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002da"} true;

--- a/src/test/correct/basic_arrays_write/gcc_O2/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_O2/basic_arrays_write.expected
@@ -84,8 +84,8 @@ procedure main();
 implementation main()
 {
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
@@ -103,8 +103,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var arr$0_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002da"} true;

--- a/src/test/correct/basic_assign_assign/clang/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang/basic_assign_assign.expected
@@ -84,8 +84,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 5bv64, true;
     call rely();

--- a/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
@@ -93,8 +93,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/basic_assign_assign/gcc/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc/basic_assign_assign.expected
@@ -82,8 +82,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 5bv64, true;

--- a/src/test/correct/basic_assign_assign/gcc_O2/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_O2/basic_assign_assign.expected
@@ -84,8 +84,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := 5bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
@@ -91,8 +91,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/correct/basic_assign_increment/clang/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang/basic_assign_increment.expected
@@ -92,8 +92,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R9, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R9, 52bv64)) || L(mem, bvadd64(R9, 52bv64)));

--- a/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
@@ -101,8 +101,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/basic_assign_increment/gcc/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc/basic_assign_increment.expected
@@ -90,8 +90,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();

--- a/src/test/correct/basic_assign_increment/gcc_O2/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_O2/basic_assign_increment.expected
@@ -92,8 +92,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R2, Gamma_R2 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;
     call rely();

--- a/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
@@ -101,8 +101,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
@@ -129,8 +129,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -142,9 +142,9 @@ implementation main()
     assume {:captureState "%00000318"} true;
     R30, Gamma_R30 := 1840bv64, true;
     call zero();
-    goto l00000321;
-  l00000321:
-    assume {:captureState "l00000321"} true;
+    goto $00000321;
+  $00000321:
+    assume {:captureState "$00000321"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 52bv64)) ==> Gamma_R0);
@@ -196,8 +196,8 @@ procedure zero();
 
 implementation zero()
 {
-  lzero:
-    assume {:captureState "lzero"} true;
+  $zero:
+    assume {:captureState "$zero"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto zero_basil_return;
   zero_basil_return:

--- a/src/test/correct/basic_function_call_caller/clang_O2/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_O2/basic_function_call_caller.expected
@@ -97,8 +97,8 @@ implementation main()
 {
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
     R9, Gamma_R9 := 69632bv64, true;

--- a/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
@@ -139,8 +139,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -152,9 +152,9 @@ implementation main()
     assume {:captureState "%00000320"} true;
     R30, Gamma_R30 := 1904bv64, true;
     call zero();
-    goto l00000329;
-  l00000329:
-    assume {:captureState "l00000329"} true;
+    goto $00000329;
+  $00000329:
+    assume {:captureState "$00000329"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
@@ -216,8 +216,8 @@ procedure zero();
 
 implementation zero()
 {
-  lzero:
-    assume {:captureState "lzero"} true;
+  $zero:
+    assume {:captureState "$zero"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto zero_basil_return;
   zero_basil_return:

--- a/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
@@ -125,8 +125,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000302"} true;
@@ -138,9 +138,9 @@ implementation main()
     assume {:captureState "%0000031a"} true;
     R30, Gamma_R30 := 1836bv64, true;
     call zero();
-    goto l00000323;
-  l00000323:
-    assume {:captureState "l00000323"} true;
+    goto $00000323;
+  $00000323:
+    assume {:captureState "$00000323"} true;
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
@@ -194,8 +194,8 @@ procedure zero();
 
 implementation zero()
 {
-  lzero:
-    assume {:captureState "lzero"} true;
+  $zero:
+    assume {:captureState "$zero"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto zero_basil_return;
   zero_basil_return:

--- a/src/test/correct/basic_function_call_caller/gcc_O2/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_O2/basic_function_call_caller.expected
@@ -97,8 +97,8 @@ implementation main()
 {
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R3, Gamma_R3 := zero_extend32_32(R0[32:0]), Gamma_R0;

--- a/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
@@ -135,8 +135,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_y_old: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000302"} true;
@@ -148,9 +148,9 @@ implementation main()
     assume {:captureState "%0000031a"} true;
     R30, Gamma_R30 := 1900bv64, true;
     call zero();
-    goto l00000323;
-  l00000323:
-    assume {:captureState "l00000323"} true;
+    goto $00000323;
+  $00000323:
+    assume {:captureState "$00000323"} true;
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
@@ -212,8 +212,8 @@ procedure zero();
 
 implementation zero()
 {
-  lzero:
-    assume {:captureState "lzero"} true;
+  $zero:
+    assume {:captureState "$zero"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto zero_basil_return;
   zero_basil_return:

--- a/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
@@ -122,8 +122,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000301"} true;
@@ -144,56 +144,56 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000342, lmain_goto_l00000345;
-  l00000345:
-    assume {:captureState "l00000345"} true;
+    goto $main_goto_$00000342, $main_goto_$00000345;
+  $00000345:
+    assume {:captureState "$00000345"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000348;
-  l00000342:
-    assume {:captureState "l00000342"} true;
+    goto $00000348;
+  $00000342:
+    assume {:captureState "$00000342"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000348;
-  l00000348:
-    assume {:captureState "l00000348"} true;
+    goto $00000348;
+  $00000348:
+    assume {:captureState "$00000348"} true;
     assert Gamma_R8;
-    goto l00000348_goto_l00000350, l00000348_goto_l0000037a;
-  l00000350:
-    assume {:captureState "l00000350"} true;
+    goto $00000348_goto_$00000350, $00000348_goto_$0000037a;
+  $00000350:
+    assume {:captureState "$00000350"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := zero_extend32_32($load$20), Gamma_$load$20;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%00000362"} true;
-    goto l00000365;
-  l0000037a:
-    assume {:captureState "l0000037a"} true;
-    goto l0000037b;
-  l0000037b:
-    assume {:captureState "l0000037b"} true;
+    goto $00000365;
+  $0000037a:
+    assume {:captureState "$0000037a"} true;
+    goto $0000037b;
+  $0000037b:
+    assume {:captureState "$0000037b"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000383"} true;
-    goto l00000365;
-  l00000365:
-    assume {:captureState "l00000365"} true;
+    goto $00000365;
+  $00000365:
+    assume {:captureState "$00000365"} true;
     $load$21, Gamma_$load$21 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$21), Gamma_$load$21;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000342:
-    assume {:captureState "lmain_goto_l00000342"} true;
+  $main_goto_$00000342:
+    assume {:captureState "$main_goto_$00000342"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000342;
-  lmain_goto_l00000345:
-    assume {:captureState "lmain_goto_l00000345"} true;
+    goto $00000342;
+  $main_goto_$00000345:
+    assume {:captureState "$main_goto_$00000345"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000345;
-  l00000348_goto_l00000350:
-    assume {:captureState "l00000348_goto_l00000350"} true;
+    goto $00000345;
+  $00000348_goto_$00000350:
+    assume {:captureState "$00000348_goto_$00000350"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000350;
-  l00000348_goto_l0000037a:
-    assume {:captureState "l00000348_goto_l0000037a"} true;
+    goto $00000350;
+  $00000348_goto_$0000037a:
+    assume {:captureState "$00000348_goto_$0000037a"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000037a;
+    goto $0000037a;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
@@ -106,8 +106,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
@@ -122,26 +122,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002f9, lmain_goto_l000002fd;
-  l000002fd:
-    assume {:captureState "l000002fd"} true;
+    goto $main_goto_$000002f9, $main_goto_$000002fd;
+  $000002fd:
+    assume {:captureState "$000002fd"} true;
     R0, Gamma_R0 := zero_extend32_32(R9[32:0]), Gamma_R9;
-    goto l00000300;
-  l000002f9:
-    assume {:captureState "l000002f9"} true;
+    goto $00000300;
+  $000002f9:
+    assume {:captureState "$000002f9"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000300;
-  l00000300:
-    assume {:captureState "l00000300"} true;
+    goto $00000300;
+  $00000300:
+    assume {:captureState "$00000300"} true;
     goto main_basil_return;
-  lmain_goto_l000002f9:
-    assume {:captureState "lmain_goto_l000002f9"} true;
+  $main_goto_$000002f9:
+    assume {:captureState "$main_goto_$000002f9"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002f9;
-  lmain_goto_l000002fd:
-    assume {:captureState "lmain_goto_l000002fd"} true;
+    goto $000002f9;
+  $main_goto_$000002fd:
+    assume {:captureState "$main_goto_$000002fd"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000002fd;
+    goto $000002fd;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
@@ -136,8 +136,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000309"} true;
@@ -164,56 +164,56 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000358, lmain_goto_l0000035b;
-  l0000035b:
-    assume {:captureState "l0000035b"} true;
+    goto $main_goto_$00000358, $main_goto_$0000035b;
+  $0000035b:
+    assume {:captureState "$0000035b"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000035e;
-  l00000358:
-    assume {:captureState "l00000358"} true;
+    goto $0000035e;
+  $00000358:
+    assume {:captureState "$00000358"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000035e;
-  l0000035e:
-    assume {:captureState "l0000035e"} true;
+    goto $0000035e;
+  $0000035e:
+    assume {:captureState "$0000035e"} true;
     assert Gamma_R8;
-    goto l0000035e_goto_l00000366, l0000035e_goto_l00000390;
-  l00000366:
-    assume {:captureState "l00000366"} true;
+    goto $0000035e_goto_$00000366, $0000035e_goto_$00000390;
+  $00000366:
+    assume {:captureState "$00000366"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := zero_extend32_32($load$22), Gamma_$load$22;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%00000378"} true;
-    goto l0000037b;
-  l00000390:
-    assume {:captureState "l00000390"} true;
-    goto l00000391;
-  l00000391:
-    assume {:captureState "l00000391"} true;
+    goto $0000037b;
+  $00000390:
+    assume {:captureState "$00000390"} true;
+    goto $00000391;
+  $00000391:
+    assume {:captureState "$00000391"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000399"} true;
-    goto l0000037b;
-  l0000037b:
-    assume {:captureState "l0000037b"} true;
+    goto $0000037b;
+  $0000037b:
+    assume {:captureState "$0000037b"} true;
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$23), Gamma_$load$23;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000358:
-    assume {:captureState "lmain_goto_l00000358"} true;
+  $main_goto_$00000358:
+    assume {:captureState "$main_goto_$00000358"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000358;
-  lmain_goto_l0000035b:
-    assume {:captureState "lmain_goto_l0000035b"} true;
+    goto $00000358;
+  $main_goto_$0000035b:
+    assume {:captureState "$main_goto_$0000035b"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000035b;
-  l0000035e_goto_l00000366:
-    assume {:captureState "l0000035e_goto_l00000366"} true;
+    goto $0000035b;
+  $0000035e_goto_$00000366:
+    assume {:captureState "$0000035e_goto_$00000366"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000366;
-  l0000035e_goto_l00000390:
-    assume {:captureState "l0000035e_goto_l00000390"} true;
+    goto $00000366;
+  $0000035e_goto_$00000390:
+    assume {:captureState "$0000035e_goto_$00000390"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000390;
+    goto $00000390;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
@@ -118,8 +118,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
@@ -139,28 +139,28 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000332, lmain_goto_l00000349;
-  l00000332:
-    assume {:captureState "l00000332"} true;
+    goto $main_goto_$00000332, $main_goto_$00000349;
+  $00000332:
+    assume {:captureState "$00000332"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
-    goto l0000033e;
-  l00000349:
-    assume {:captureState "l00000349"} true;
+    goto $0000033e;
+  $00000349:
+    assume {:captureState "$00000349"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l0000033e;
-  l0000033e:
-    assume {:captureState "l0000033e"} true;
+    goto $0000033e;
+  $0000033e:
+    assume {:captureState "$0000033e"} true;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000332:
-    assume {:captureState "lmain_goto_l00000332"} true;
+  $main_goto_$00000332:
+    assume {:captureState "$main_goto_$00000332"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000332;
-  lmain_goto_l00000349:
-    assume {:captureState "lmain_goto_l00000349"} true;
+    goto $00000332;
+  $main_goto_$00000349:
+    assume {:captureState "$main_goto_$00000349"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000349;
+    goto $00000349;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
@@ -87,32 +87,32 @@ implementation main()
   var $load$19: bv32;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R1, Gamma_R1 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R0, 20bv64)), (gamma_load32(Gamma_mem, bvadd64(R0, 20bv64)) || L(mem, bvadd64(R0, 20bv64)));
     R0, Gamma_R0 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R0;
-    goto lmain_goto_l000001bc, lmain_goto_l00000398;
-  l00000398:
-    assume {:captureState "l00000398"} true;
+    goto $main_goto_$000001bc, $main_goto_$00000398;
+  $00000398:
+    assume {:captureState "$00000398"} true;
     call rely();
     $load$19, Gamma_$load$19 := memory_load32_le(mem, bvadd64(R1, 4bv64)), (gamma_load32(Gamma_mem, bvadd64(R1, 4bv64)) || L(mem, bvadd64(R1, 4bv64)));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
-    goto l000001bc;
-  l000001bc:
-    assume {:captureState "l000001bc"} true;
+    goto $000001bc;
+  $000001bc:
+    assume {:captureState "$000001bc"} true;
     goto main_basil_return;
-  lmain_goto_l000001bc:
-    assume {:captureState "lmain_goto_l000001bc"} true;
+  $main_goto_$000001bc:
+    assume {:captureState "$main_goto_$000001bc"} true;
     assume (bvcomp32(R0[32:0], 0bv32) != 0bv1);
-    goto l000001bc;
-  lmain_goto_l00000398:
-    assume {:captureState "lmain_goto_l00000398"} true;
+    goto $000001bc;
+  $main_goto_$00000398:
+    assume {:captureState "$main_goto_$00000398"} true;
     assume (bvcomp32(R0[32:0], 0bv32) == 0bv1);
-    goto l00000398;
+    goto $00000398;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
@@ -132,8 +132,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
@@ -157,28 +157,28 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000334, lmain_goto_l0000034b;
-  l00000334:
-    assume {:captureState "l00000334"} true;
+    goto $main_goto_$00000334, $main_goto_$0000034b;
+  $00000334:
+    assume {:captureState "$00000334"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
-    goto l00000340;
-  l0000034b:
-    assume {:captureState "l0000034b"} true;
+    goto $00000340;
+  $0000034b:
+    assume {:captureState "$0000034b"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000340;
-  l00000340:
-    assume {:captureState "l00000340"} true;
+    goto $00000340;
+  $00000340:
+    assume {:captureState "$00000340"} true;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000334:
-    assume {:captureState "lmain_goto_l00000334"} true;
+  $main_goto_$00000334:
+    assume {:captureState "$main_goto_$00000334"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000334;
-  lmain_goto_l0000034b:
-    assume {:captureState "lmain_goto_l0000034b"} true;
+    goto $00000334;
+  $main_goto_$0000034b:
+    assume {:captureState "$main_goto_$0000034b"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000034b;
+    goto $0000034b;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/clang/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang/basic_lock_read.expected
@@ -118,8 +118,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f9"} true;
@@ -136,24 +136,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000032d, lmain_goto_l00000330;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $main_goto_$0000032d, $main_goto_$00000330;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000333;
-  l0000032d:
-    assume {:captureState "l0000032d"} true;
+    goto $00000333;
+  $0000032d:
+    assume {:captureState "$0000032d"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000333;
-  l00000333:
-    assume {:captureState "l00000333"} true;
+    goto $00000333;
+  $00000333:
+    assume {:captureState "$00000333"} true;
     assert Gamma_R8;
-    goto l00000333_goto_l0000033b, l00000333_goto_l00000352;
-  l00000352:
-    assume {:captureState "l00000352"} true;
-    goto l00000353;
-  l00000353:
-    assume {:captureState "l00000353"} true;
+    goto $00000333_goto_$0000033b, $00000333_goto_$00000352;
+  $00000352:
+    assume {:captureState "$00000352"} true;
+    goto $00000353;
+  $00000353:
+    assume {:captureState "$00000353"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 56bv64)) ==> true);
@@ -166,29 +166,29 @@ implementation main()
     R8, Gamma_R8 := zero_extend32_32($load$19), Gamma_$load$19;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%0000036f"} true;
-    goto l0000033b;
-  l0000033b:
-    assume {:captureState "l0000033b"} true;
+    goto $0000033b;
+  $0000033b:
+    assume {:captureState "$0000033b"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000032d:
-    assume {:captureState "lmain_goto_l0000032d"} true;
+  $main_goto_$0000032d:
+    assume {:captureState "$main_goto_$0000032d"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000032d;
-  lmain_goto_l00000330:
-    assume {:captureState "lmain_goto_l00000330"} true;
+    goto $0000032d;
+  $main_goto_$00000330:
+    assume {:captureState "$main_goto_$00000330"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000330;
-  l00000333_goto_l0000033b:
-    assume {:captureState "l00000333_goto_l0000033b"} true;
+    goto $00000330;
+  $00000333_goto_$0000033b:
+    assume {:captureState "$00000333_goto_$0000033b"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000033b;
-  l00000333_goto_l00000352:
-    assume {:captureState "l00000333_goto_l00000352"} true;
+    goto $0000033b;
+  $00000333_goto_$00000352:
+    assume {:captureState "$00000333_goto_$00000352"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000352;
+    goto $00000352;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/clang_O2/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_O2/basic_lock_read.expected
@@ -91,16 +91,16 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R8, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 52bv64)) || L(mem, bvadd64(R8, 52bv64)));
     R8, Gamma_R8 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R8;
-    goto lmain_goto_l000002dc, lmain_goto_l000002f7;
-  l000002dc:
-    assume {:captureState "l000002dc"} true;
+    goto $main_goto_$000002dc, $main_goto_$000002f7;
+  $000002dc:
+    assume {:captureState "$000002dc"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 56bv64)) ==> true);
@@ -110,18 +110,18 @@ implementation main()
     assume {:captureState "%000002eb"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  l000002f7:
-    assume {:captureState "l000002f7"} true;
+  $000002f7:
+    assume {:captureState "$000002f7"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l000002dc:
-    assume {:captureState "lmain_goto_l000002dc"} true;
+  $main_goto_$000002dc:
+    assume {:captureState "$main_goto_$000002dc"} true;
     assume (bvcomp32(R8[32:0], 0bv32) != 0bv1);
-    goto l000002dc;
-  lmain_goto_l000002f7:
-    assume {:captureState "lmain_goto_l000002f7"} true;
+    goto $000002dc;
+  $main_goto_$000002f7:
+    assume {:captureState "$main_goto_$000002f7"} true;
     assume (bvcomp32(R8[32:0], 0bv32) == 0bv1);
-    goto l000002f7;
+    goto $000002f7;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
@@ -132,8 +132,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000301"} true;
@@ -153,24 +153,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000033c, lmain_goto_l0000033f;
-  l0000033f:
-    assume {:captureState "l0000033f"} true;
+    goto $main_goto_$0000033c, $main_goto_$0000033f;
+  $0000033f:
+    assume {:captureState "$0000033f"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000342;
-  l0000033c:
-    assume {:captureState "l0000033c"} true;
+    goto $00000342;
+  $0000033c:
+    assume {:captureState "$0000033c"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000342;
-  l00000342:
-    assume {:captureState "l00000342"} true;
+    goto $00000342;
+  $00000342:
+    assume {:captureState "$00000342"} true;
     assert Gamma_R8;
-    goto l00000342_goto_l0000034a, l00000342_goto_l00000361;
-  l00000361:
-    assume {:captureState "l00000361"} true;
-    goto l00000362;
-  l00000362:
-    assume {:captureState "l00000362"} true;
+    goto $00000342_goto_$0000034a, $00000342_goto_$00000361;
+  $00000361:
+    assume {:captureState "$00000361"} true;
+    goto $00000362;
+  $00000362:
+    assume {:captureState "$00000362"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
@@ -186,29 +186,29 @@ implementation main()
     R8, Gamma_R8 := zero_extend32_32($load$21), Gamma_$load$21;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%00000385"} true;
-    goto l0000034a;
-  l0000034a:
-    assume {:captureState "l0000034a"} true;
+    goto $0000034a;
+  $0000034a:
+    assume {:captureState "$0000034a"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000033c:
-    assume {:captureState "lmain_goto_l0000033c"} true;
+  $main_goto_$0000033c:
+    assume {:captureState "$main_goto_$0000033c"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000033c;
-  lmain_goto_l0000033f:
-    assume {:captureState "lmain_goto_l0000033f"} true;
+    goto $0000033c;
+  $main_goto_$0000033f:
+    assume {:captureState "$main_goto_$0000033f"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000033f;
-  l00000342_goto_l0000034a:
-    assume {:captureState "l00000342_goto_l0000034a"} true;
+    goto $0000033f;
+  $00000342_goto_$0000034a:
+    assume {:captureState "$00000342_goto_$0000034a"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000034a;
-  l00000342_goto_l00000361:
-    assume {:captureState "l00000342_goto_l00000361"} true;
+    goto $0000034a;
+  $00000342_goto_$00000361:
+    assume {:captureState "$00000342_goto_$00000361"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000361;
+    goto $00000361;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/gcc/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc/basic_lock_read.expected
@@ -116,8 +116,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f9"} true;
@@ -132,9 +132,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000327, lmain_goto_l0000033e;
-  l0000033e:
-    assume {:captureState "l0000033e"} true;
+    goto $main_goto_$00000327, $main_goto_$0000033e;
+  $0000033e:
+    assume {:captureState "$0000033e"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
@@ -150,21 +150,21 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000368"} true;
-    goto l00000327;
-  l00000327:
-    assume {:captureState "l00000327"} true;
+    goto $00000327;
+  $00000327:
+    assume {:captureState "$00000327"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000327:
-    assume {:captureState "lmain_goto_l00000327"} true;
+  $main_goto_$00000327:
+    assume {:captureState "$main_goto_$00000327"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000327;
-  lmain_goto_l0000033e:
-    assume {:captureState "lmain_goto_l0000033e"} true;
+    goto $00000327;
+  $main_goto_$0000033e:
+    assume {:captureState "$main_goto_$0000033e"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000033e;
+    goto $0000033e;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/gcc_O2/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc_O2/basic_lock_read.expected
@@ -92,36 +92,36 @@ implementation main()
   var $load$18: bv32;
   var Gamma_$load$18: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R1, Gamma_R1 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R0, 20bv64)), (gamma_load32(Gamma_mem, bvadd64(R0, 20bv64)) || L(mem, bvadd64(R0, 20bv64)));
     R0, Gamma_R0 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R0;
-    goto lmain_goto_l000001bd, lmain_goto_l0000039c;
-  l0000039c:
-    assume {:captureState "l0000039c"} true;
+    goto $main_goto_$000001bd, $main_goto_$0000039c;
+  $0000039c:
+    assume {:captureState "$0000039c"} true;
     call rely();
     assert (L(mem, bvadd64(R1, 4bv64)) ==> true);
     z_old := memory_load32_le(mem, $z_addr);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R1, 4bv64), 0bv32), gamma_store32(Gamma_mem, bvadd64(R1, 4bv64), true);
     assert (memory_load32_le(mem, $z_addr) == z_old);
     assume {:captureState "%000003a1"} true;
-    goto l000001bd;
-  l000001bd:
-    assume {:captureState "l000001bd"} true;
+    goto $000001bd;
+  $000001bd:
+    assume {:captureState "$000001bd"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l000001bd:
-    assume {:captureState "lmain_goto_l000001bd"} true;
+  $main_goto_$000001bd:
+    assume {:captureState "$main_goto_$000001bd"} true;
     assume (bvnot1(bvcomp32(R0[32:0], 0bv32)) != 0bv1);
-    goto l000001bd;
-  lmain_goto_l0000039c:
-    assume {:captureState "lmain_goto_l0000039c"} true;
+    goto $000001bd;
+  $main_goto_$0000039c:
+    assume {:captureState "$main_goto_$0000039c"} true;
     assume (bvnot1(bvcomp32(R0[32:0], 0bv32)) == 0bv1);
-    goto l0000039c;
+    goto $0000039c;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_read/gcc_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc_pic/basic_lock_read.expected
@@ -132,8 +132,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f9"} true;
@@ -150,9 +150,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000328, lmain_goto_l0000033f;
-  l0000033f:
-    assume {:captureState "l0000033f"} true;
+    goto $main_goto_$00000328, $main_goto_$0000033f;
+  $0000033f:
+    assume {:captureState "$0000033f"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -172,21 +172,21 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000036b"} true;
-    goto l00000328;
-  l00000328:
-    assume {:captureState "l00000328"} true;
+    goto $00000328;
+  $00000328:
+    assume {:captureState "$00000328"} true;
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$23), Gamma_$load$23;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000328:
-    assume {:captureState "lmain_goto_l00000328"} true;
+  $main_goto_$00000328:
+    assume {:captureState "$main_goto_$00000328"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000328;
-  lmain_goto_l0000033f:
-    assume {:captureState "lmain_goto_l0000033f"} true;
+    goto $00000328;
+  $main_goto_$0000033f:
+    assume {:captureState "$main_goto_$0000033f"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000033f;
+    goto $0000033f;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
@@ -116,8 +116,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f5"} true;
@@ -134,53 +134,53 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000329, lmain_goto_l0000032c;
-  l0000032c:
-    assume {:captureState "l0000032c"} true;
+    goto $main_goto_$00000329, $main_goto_$0000032c;
+  $0000032c:
+    assume {:captureState "$0000032c"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000032f;
-  l00000329:
-    assume {:captureState "l00000329"} true;
+    goto $0000032f;
+  $00000329:
+    assume {:captureState "$00000329"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000032f;
-  l0000032f:
-    assume {:captureState "l0000032f"} true;
+    goto $0000032f;
+  $0000032f:
+    assume {:captureState "$0000032f"} true;
     assert Gamma_R8;
-    goto l0000032f_goto_l00000337, l0000032f_goto_l0000034e;
-  l0000034e:
-    assume {:captureState "l0000034e"} true;
-    goto l0000034f;
-  l0000034f:
-    assume {:captureState "l0000034f"} true;
+    goto $0000032f_goto_$00000337, $0000032f_goto_$0000034e;
+  $0000034e:
+    assume {:captureState "$0000034e"} true;
+    goto $0000034f;
+  $0000034f:
+    assume {:captureState "$0000034f"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$19, Gamma_$load$19 := memory_load32_le(mem, bvadd64(R8, 56bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 56bv64)) || L(mem, bvadd64(R8, 56bv64)));
     R8, Gamma_R8 := zero_extend32_32($load$19), Gamma_$load$19;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%00000364"} true;
-    goto l00000337;
-  l00000337:
-    assume {:captureState "l00000337"} true;
+    goto $00000337;
+  $00000337:
+    assume {:captureState "$00000337"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000329:
-    assume {:captureState "lmain_goto_l00000329"} true;
+  $main_goto_$00000329:
+    assume {:captureState "$main_goto_$00000329"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000329;
-  lmain_goto_l0000032c:
-    assume {:captureState "lmain_goto_l0000032c"} true;
+    goto $00000329;
+  $main_goto_$0000032c:
+    assume {:captureState "$main_goto_$0000032c"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000032c;
-  l0000032f_goto_l00000337:
-    assume {:captureState "l0000032f_goto_l00000337"} true;
+    goto $0000032c;
+  $0000032f_goto_$00000337:
+    assume {:captureState "$0000032f_goto_$00000337"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000337;
-  l0000032f_goto_l0000034e:
-    assume {:captureState "l0000032f_goto_l0000034e"} true;
+    goto $00000337;
+  $0000032f_goto_$0000034e:
+    assume {:captureState "$0000032f_goto_$0000034e"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000034e;
+    goto $0000034e;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
@@ -102,8 +102,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
@@ -118,26 +118,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002fa, lmain_goto_l000002fd;
-  l000002fd:
-    assume {:captureState "l000002fd"} true;
+    goto $main_goto_$000002fa, $main_goto_$000002fd;
+  $000002fd:
+    assume {:captureState "$000002fd"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000300;
-  l000002fa:
-    assume {:captureState "l000002fa"} true;
+    goto $00000300;
+  $000002fa:
+    assume {:captureState "$000002fa"} true;
     R0, Gamma_R0 := zero_extend32_32(R9[32:0]), Gamma_R9;
-    goto l00000300;
-  l00000300:
-    assume {:captureState "l00000300"} true;
+    goto $00000300;
+  $00000300:
+    assume {:captureState "$00000300"} true;
     goto main_basil_return;
-  lmain_goto_l000002fa:
-    assume {:captureState "lmain_goto_l000002fa"} true;
+  $main_goto_$000002fa:
+    assume {:captureState "$main_goto_$000002fa"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002fa;
-  lmain_goto_l000002fd:
-    assume {:captureState "lmain_goto_l000002fd"} true;
+    goto $000002fa;
+  $main_goto_$000002fd:
+    assume {:captureState "$main_goto_$000002fd"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000002fd;
+    goto $000002fd;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
@@ -130,8 +130,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002fd"} true;
@@ -151,24 +151,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000338, lmain_goto_l0000033b;
-  l0000033b:
-    assume {:captureState "l0000033b"} true;
+    goto $main_goto_$00000338, $main_goto_$0000033b;
+  $0000033b:
+    assume {:captureState "$0000033b"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000033e;
-  l00000338:
-    assume {:captureState "l00000338"} true;
+    goto $0000033e;
+  $00000338:
+    assume {:captureState "$00000338"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000033e;
-  l0000033e:
-    assume {:captureState "l0000033e"} true;
+    goto $0000033e;
+  $0000033e:
+    assume {:captureState "$0000033e"} true;
     assert Gamma_R8;
-    goto l0000033e_goto_l00000346, l0000033e_goto_l0000035d;
-  l0000035d:
-    assume {:captureState "l0000035d"} true;
-    goto l0000035e;
-  l0000035e:
-    assume {:captureState "l0000035e"} true;
+    goto $0000033e_goto_$00000346, $0000033e_goto_$0000035d;
+  $0000035d:
+    assume {:captureState "$0000035d"} true;
+    goto $0000035e;
+  $0000035e:
+    assume {:captureState "$0000035e"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
@@ -178,29 +178,29 @@ implementation main()
     R8, Gamma_R8 := zero_extend32_32($load$21), Gamma_$load$21;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%0000037a"} true;
-    goto l00000346;
-  l00000346:
-    assume {:captureState "l00000346"} true;
+    goto $00000346;
+  $00000346:
+    assume {:captureState "$00000346"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000338:
-    assume {:captureState "lmain_goto_l00000338"} true;
+  $main_goto_$00000338:
+    assume {:captureState "$main_goto_$00000338"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000338;
-  lmain_goto_l0000033b:
-    assume {:captureState "lmain_goto_l0000033b"} true;
+    goto $00000338;
+  $main_goto_$0000033b:
+    assume {:captureState "$main_goto_$0000033b"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000033b;
-  l0000033e_goto_l00000346:
-    assume {:captureState "l0000033e_goto_l00000346"} true;
+    goto $0000033b;
+  $0000033e_goto_$00000346:
+    assume {:captureState "$0000033e_goto_$00000346"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000346;
-  l0000033e_goto_l0000035d:
-    assume {:captureState "l0000033e_goto_l0000035d"} true;
+    goto $00000346;
+  $0000033e_goto_$0000035d:
+    assume {:captureState "$0000033e_goto_$0000035d"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000035d;
+    goto $0000035d;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
@@ -114,8 +114,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002ed"} true;
@@ -130,9 +130,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000031b, lmain_goto_l00000332;
-  l00000332:
-    assume {:captureState "l00000332"} true;
+    goto $main_goto_$0000031b, $main_goto_$00000332;
+  $00000332:
+    assume {:captureState "$00000332"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
@@ -140,21 +140,21 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000034a"} true;
-    goto l0000031b;
-  l0000031b:
-    assume {:captureState "l0000031b"} true;
+    goto $0000031b;
+  $0000031b:
+    assume {:captureState "$0000031b"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000031b:
-    assume {:captureState "lmain_goto_l0000031b"} true;
+  $main_goto_$0000031b:
+    assume {:captureState "$main_goto_$0000031b"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000031b;
-  lmain_goto_l00000332:
-    assume {:captureState "lmain_goto_l00000332"} true;
+    goto $0000031b;
+  $main_goto_$00000332:
+    assume {:captureState "$main_goto_$00000332"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000332;
+    goto $00000332;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
@@ -86,8 +86,8 @@ implementation main()
   var $load$19: bv32;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;
@@ -95,24 +95,24 @@ implementation main()
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R1, 20bv64)), (gamma_load32(Gamma_mem, bvadd64(R1, 20bv64)) || L(mem, bvadd64(R1, 20bv64)));
     R1, Gamma_R1 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R1;
-    goto lmain_goto_l000001c2, lmain_goto_l0000039c;
-  l0000039c:
-    assume {:captureState "l0000039c"} true;
+    goto $main_goto_$000001c2, $main_goto_$0000039c;
+  $0000039c:
+    assume {:captureState "$0000039c"} true;
     call rely();
     $load$19, Gamma_$load$19 := memory_load32_le(mem, bvadd64(R2, 4bv64)), (gamma_load32(Gamma_mem, bvadd64(R2, 4bv64)) || L(mem, bvadd64(R2, 4bv64)));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
-    goto l000001c2;
-  l000001c2:
-    assume {:captureState "l000001c2"} true;
+    goto $000001c2;
+  $000001c2:
+    assume {:captureState "$000001c2"} true;
     goto main_basil_return;
-  lmain_goto_l000001c2:
-    assume {:captureState "lmain_goto_l000001c2"} true;
+  $main_goto_$000001c2:
+    assume {:captureState "$main_goto_$000001c2"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) != 0bv1);
-    goto l000001c2;
-  lmain_goto_l0000039c:
-    assume {:captureState "lmain_goto_l0000039c"} true;
+    goto $000001c2;
+  $main_goto_$0000039c:
+    assume {:captureState "$main_goto_$0000039c"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) == 0bv1);
-    goto l0000039c;
+    goto $0000039c;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
@@ -128,8 +128,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002ed"} true;
@@ -146,9 +146,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000031c, lmain_goto_l00000333;
-  l00000333:
-    assume {:captureState "l00000333"} true;
+    goto $main_goto_$0000031c, $main_goto_$00000333;
+  $00000333:
+    assume {:captureState "$00000333"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -158,21 +158,21 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$21), Gamma_$load$21;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000034c"} true;
-    goto l0000031c;
-  l0000031c:
-    assume {:captureState "l0000031c"} true;
+    goto $0000031c;
+  $0000031c:
+    assume {:captureState "$0000031c"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000031c:
-    assume {:captureState "lmain_goto_l0000031c"} true;
+  $main_goto_$0000031c:
+    assume {:captureState "$main_goto_$0000031c"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000031c;
-  lmain_goto_l00000333:
-    assume {:captureState "lmain_goto_l00000333"} true;
+    goto $0000031c;
+  $main_goto_$00000333:
+    assume {:captureState "$main_goto_$00000333"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000333;
+    goto $00000333;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_lock_security_write/clang/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang/basic_lock_security_write.expected
@@ -103,8 +103,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002ea"} true;

--- a/src/test/correct/basic_lock_security_write/clang_O2/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang_O2/basic_lock_security_write.expected
@@ -92,8 +92,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 0bv64, true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;

--- a/src/test/correct/basic_lock_security_write/clang_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang_pic/basic_lock_security_write.expected
@@ -117,8 +117,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002f2"} true;

--- a/src/test/correct/basic_lock_security_write/gcc/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc/basic_lock_security_write.expected
@@ -99,8 +99,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000302"} true;

--- a/src/test/correct/basic_lock_security_write/gcc_O2/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc_O2/basic_lock_security_write.expected
@@ -92,8 +92,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basic_lock_security_write/gcc_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc_pic/basic_lock_security_write.expected
@@ -117,8 +117,8 @@ implementation main()
   var Gamma_x_old: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000302"} true;

--- a/src/test/correct/basic_lock_unlock/clang/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang/basic_lock_unlock.expected
@@ -86,8 +86,8 @@ implementation main()
 {
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 1bv64, true;
     call rely();

--- a/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
@@ -100,8 +100,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/basic_lock_unlock/gcc/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc/basic_lock_unlock.expected
@@ -84,8 +84,8 @@ implementation main()
 {
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;

--- a/src/test/correct/basic_lock_unlock/gcc_O2/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_O2/basic_lock_unlock.expected
@@ -88,8 +88,8 @@ implementation main()
 {
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R3, Gamma_R3 := 1bv64, true;

--- a/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
@@ -98,8 +98,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var x_old: bv32;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/correct/basic_loop_assign/clang/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang/basic_loop_assign.expected
@@ -86,8 +86,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 20bv64, true;
     call rely();

--- a/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
@@ -95,8 +95,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/basic_loop_assign/gcc/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc/basic_loop_assign.expected
@@ -84,8 +84,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 20bv64, true;

--- a/src/test/correct/basic_loop_assign/gcc_O2/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_O2/basic_loop_assign.expected
@@ -86,8 +86,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := 20bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
@@ -93,8 +93,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
@@ -127,8 +127,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     R8, Gamma_R8 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -169,17 +169,17 @@ implementation main()
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R10, Gamma_R10 := zero_extend32_32($load$23), Gamma_$load$23;
     assert Gamma_R10;
-    goto lmain_goto_l000003c9, lmain_goto_l000003ce;
-  l000003ce:
-    assume {:captureState "l000003ce"} true;
+    goto $main_goto_$000003c9, $main_goto_$000003ce;
+  $000003ce:
+    assume {:captureState "$000003ce"} true;
     R9, Gamma_R9 := zero_extend32_32(bvsdiv33(sign_extend1_32(R8[32:0]), sign_extend1_32(R10[32:0]))[32:0]), (Gamma_R10 && Gamma_R8);
-    goto l000003d1;
-  l000003c9:
-    assume {:captureState "l000003c9"} true;
+    goto $000003d1;
+  $000003c9:
+    assume {:captureState "$000003c9"} true;
     R9, Gamma_R9 := 0bv64, true;
-    goto l000003d1;
-  l000003d1:
-    assume {:captureState "l000003d1"} true;
+    goto $000003d1;
+  $000003d1:
+    assume {:captureState "$000003d1"} true;
     R9, Gamma_R9 := zero_extend32_32(bvmul64(zero_extend32_32(R9[32:0]), zero_extend32_32(R10[32:0]))[32:0]), (Gamma_R10 && Gamma_R9);
     #4, Gamma_#4 := bvnot32(R9[32:0]), Gamma_R9;
     #5, Gamma_#5 := bvadd32(R8[32:0], bvnot32(R9[32:0])), (Gamma_R9 && Gamma_R8);
@@ -192,14 +192,14 @@ implementation main()
     assume {:captureState "%00000407"} true;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l000003c9:
-    assume {:captureState "lmain_goto_l000003c9"} true;
+  $main_goto_$000003c9:
+    assume {:captureState "$main_goto_$000003c9"} true;
     assume (bvcomp32(R10[32:0], 0bv32) != 0bv1);
-    goto l000003c9;
-  lmain_goto_l000003ce:
-    assume {:captureState "lmain_goto_l000003ce"} true;
+    goto $000003c9;
+  $main_goto_$000003ce:
+    assume {:captureState "$main_goto_$000003ce"} true;
     assume (bvcomp32(R10[32:0], 0bv32) == 0bv1);
-    goto l000003ce;
+    goto $000003ce;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
@@ -109,8 +109,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000032a"} true;
@@ -147,17 +147,17 @@ implementation main()
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 24bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := zero_extend32_32($load$23), Gamma_$load$23;
     assert Gamma_R1;
-    goto lmain_goto_l000003b3, lmain_goto_l000003b8;
-  l000003b8:
-    assume {:captureState "l000003b8"} true;
+    goto $main_goto_$000003b3, $main_goto_$000003b8;
+  $000003b8:
+    assume {:captureState "$000003b8"} true;
     R2, Gamma_R2 := zero_extend32_32(bvsdiv33(sign_extend1_32(R0[32:0]), sign_extend1_32(R1[32:0]))[32:0]), (Gamma_R1 && Gamma_R0);
-    goto l000003bb;
-  l000003b3:
-    assume {:captureState "l000003b3"} true;
+    goto $000003bb;
+  $000003b3:
+    assume {:captureState "$000003b3"} true;
     R2, Gamma_R2 := 0bv64, true;
-    goto l000003bb;
-  l000003bb:
-    assume {:captureState "l000003bb"} true;
+    goto $000003bb;
+  $000003bb:
+    assume {:captureState "$000003bb"} true;
     $load$24, Gamma_$load$24 := memory_load32_le(stack, bvadd64(R31, 24bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := zero_extend32_32($load$24), Gamma_$load$24;
     R1, Gamma_R1 := zero_extend32_32(bvmul64(zero_extend32_32(R2[32:0]), zero_extend32_32(R1[32:0]))[32:0]), (Gamma_R1 && Gamma_R2);
@@ -167,14 +167,14 @@ implementation main()
     R0, Gamma_R0 := 0bv64, true;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l000003b3:
-    assume {:captureState "lmain_goto_l000003b3"} true;
+  $main_goto_$000003b3:
+    assume {:captureState "$main_goto_$000003b3"} true;
     assume (bvcomp32(R1[32:0], 0bv32) != 0bv1);
-    goto l000003b3;
-  lmain_goto_l000003b8:
-    assume {:captureState "lmain_goto_l000003b8"} true;
+    goto $000003b3;
+  $main_goto_$000003b8:
+    assume {:captureState "$main_goto_$000003b8"} true;
     assume (bvcomp32(R1[32:0], 0bv32) == 0bv1);
-    goto l000003b8;
+    goto $000003b8;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
@@ -116,8 +116,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f5"} true;
@@ -138,49 +138,49 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000336, lmain_goto_l00000339;
-  l00000339:
-    assume {:captureState "l00000339"} true;
+    goto $main_goto_$00000336, $main_goto_$00000339;
+  $00000339:
+    assume {:captureState "$00000339"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000033c;
-  l00000336:
-    assume {:captureState "l00000336"} true;
+    goto $0000033c;
+  $00000336:
+    assume {:captureState "$00000336"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000033c;
-  l0000033c:
-    assume {:captureState "l0000033c"} true;
+    goto $0000033c;
+  $0000033c:
+    assume {:captureState "$0000033c"} true;
     assert Gamma_R8;
-    goto l0000033c_goto_l00000344, l0000033c_goto_l0000035b;
-  l0000035b:
-    assume {:captureState "l0000035b"} true;
-    goto l0000035c;
-  l0000035c:
-    assume {:captureState "l0000035c"} true;
+    goto $0000033c_goto_$00000344, $0000033c_goto_$0000035b;
+  $0000035b:
+    assume {:captureState "$0000035b"} true;
+    goto $0000035c;
+  $0000035c:
+    assume {:captureState "$0000035c"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), true);
     assume {:captureState "%00000364"} true;
-    goto l00000344;
-  l00000344:
-    assume {:captureState "l00000344"} true;
+    goto $00000344;
+  $00000344:
+    assume {:captureState "$00000344"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000336:
-    assume {:captureState "lmain_goto_l00000336"} true;
+  $main_goto_$00000336:
+    assume {:captureState "$main_goto_$00000336"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000336;
-  lmain_goto_l00000339:
-    assume {:captureState "lmain_goto_l00000339"} true;
+    goto $00000336;
+  $main_goto_$00000339:
+    assume {:captureState "$main_goto_$00000339"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000339;
-  l0000033c_goto_l00000344:
-    assume {:captureState "l0000033c_goto_l00000344"} true;
+    goto $00000339;
+  $0000033c_goto_$00000344:
+    assume {:captureState "$0000033c_goto_$00000344"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000344;
-  l0000033c_goto_l0000035b:
-    assume {:captureState "l0000033c_goto_l0000035b"} true;
+    goto $00000344;
+  $0000033c_goto_$0000035b:
+    assume {:captureState "$0000033c_goto_$0000035b"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000035b;
+    goto $0000035b;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
@@ -102,8 +102,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
@@ -118,26 +118,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002fa, lmain_goto_l000002fd;
-  l000002fd:
-    assume {:captureState "l000002fd"} true;
+    goto $main_goto_$000002fa, $main_goto_$000002fd;
+  $000002fd:
+    assume {:captureState "$000002fd"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000300;
-  l000002fa:
-    assume {:captureState "l000002fa"} true;
+    goto $00000300;
+  $000002fa:
+    assume {:captureState "$000002fa"} true;
     R0, Gamma_R0 := zero_extend32_32(R9[32:0]), Gamma_R9;
-    goto l00000300;
-  l00000300:
-    assume {:captureState "l00000300"} true;
+    goto $00000300;
+  $00000300:
+    assume {:captureState "$00000300"} true;
     goto main_basil_return;
-  lmain_goto_l000002fa:
-    assume {:captureState "lmain_goto_l000002fa"} true;
+  $main_goto_$000002fa:
+    assume {:captureState "$main_goto_$000002fa"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002fa;
-  lmain_goto_l000002fd:
-    assume {:captureState "lmain_goto_l000002fd"} true;
+    goto $000002fa;
+  $main_goto_$000002fd:
+    assume {:captureState "$main_goto_$000002fd"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000002fd;
+    goto $000002fd;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
@@ -130,8 +130,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002fd"} true;
@@ -158,49 +158,49 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000034c, lmain_goto_l0000034f;
-  l0000034f:
-    assume {:captureState "l0000034f"} true;
+    goto $main_goto_$0000034c, $main_goto_$0000034f;
+  $0000034f:
+    assume {:captureState "$0000034f"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000352;
-  l0000034c:
-    assume {:captureState "l0000034c"} true;
+    goto $00000352;
+  $0000034c:
+    assume {:captureState "$0000034c"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000352;
-  l00000352:
-    assume {:captureState "l00000352"} true;
+    goto $00000352;
+  $00000352:
+    assume {:captureState "$00000352"} true;
     assert Gamma_R8;
-    goto l00000352_goto_l0000035a, l00000352_goto_l00000371;
-  l00000371:
-    assume {:captureState "l00000371"} true;
-    goto l00000372;
-  l00000372:
-    assume {:captureState "l00000372"} true;
+    goto $00000352_goto_$0000035a, $00000352_goto_$00000371;
+  $00000371:
+    assume {:captureState "$00000371"} true;
+    goto $00000372;
+  $00000372:
+    assume {:captureState "$00000372"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), true);
     assume {:captureState "%0000037a"} true;
-    goto l0000035a;
-  l0000035a:
-    assume {:captureState "l0000035a"} true;
+    goto $0000035a;
+  $0000035a:
+    assume {:captureState "$0000035a"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000034c:
-    assume {:captureState "lmain_goto_l0000034c"} true;
+  $main_goto_$0000034c:
+    assume {:captureState "$main_goto_$0000034c"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000034c;
-  lmain_goto_l0000034f:
-    assume {:captureState "lmain_goto_l0000034f"} true;
+    goto $0000034c;
+  $main_goto_$0000034f:
+    assume {:captureState "$main_goto_$0000034f"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000034f;
-  l00000352_goto_l0000035a:
-    assume {:captureState "l00000352_goto_l0000035a"} true;
+    goto $0000034f;
+  $00000352_goto_$0000035a:
+    assume {:captureState "$00000352_goto_$0000035a"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000035a;
-  l00000352_goto_l00000371:
-    assume {:captureState "l00000352_goto_l00000371"} true;
+    goto $0000035a;
+  $00000352_goto_$00000371:
+    assume {:captureState "$00000352_goto_$00000371"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000371;
+    goto $00000371;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
@@ -114,8 +114,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
@@ -135,26 +135,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000032e, lmain_goto_l00000345;
-  l00000345:
-    assume {:captureState "l00000345"} true;
+    goto $main_goto_$0000032e, $main_goto_$00000345;
+  $00000345:
+    assume {:captureState "$00000345"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%0000034a"} true;
-    goto l0000032e;
-  l0000032e:
-    assume {:captureState "l0000032e"} true;
+    goto $0000032e;
+  $0000032e:
+    assume {:captureState "$0000032e"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000032e:
-    assume {:captureState "lmain_goto_l0000032e"} true;
+  $main_goto_$0000032e:
+    assume {:captureState "$main_goto_$0000032e"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000032e;
-  lmain_goto_l00000345:
-    assume {:captureState "lmain_goto_l00000345"} true;
+    goto $0000032e;
+  $main_goto_$00000345:
+    assume {:captureState "$main_goto_$00000345"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000345;
+    goto $00000345;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
@@ -86,8 +86,8 @@ implementation main()
   var $load$19: bv32;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;
@@ -95,24 +95,24 @@ implementation main()
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R1, 20bv64)), (gamma_load32(Gamma_mem, bvadd64(R1, 20bv64)) || L(mem, bvadd64(R1, 20bv64)));
     R1, Gamma_R1 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R1;
-    goto lmain_goto_l000001c2, lmain_goto_l0000039c;
-  l0000039c:
-    assume {:captureState "l0000039c"} true;
+    goto $main_goto_$000001c2, $main_goto_$0000039c;
+  $0000039c:
+    assume {:captureState "$0000039c"} true;
     call rely();
     $load$19, Gamma_$load$19 := memory_load32_le(mem, bvadd64(R2, 4bv64)), (gamma_load32(Gamma_mem, bvadd64(R2, 4bv64)) || L(mem, bvadd64(R2, 4bv64)));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
-    goto l000001c2;
-  l000001c2:
-    assume {:captureState "l000001c2"} true;
+    goto $000001c2;
+  $000001c2:
+    assume {:captureState "$000001c2"} true;
     goto main_basil_return;
-  lmain_goto_l000001c2:
-    assume {:captureState "lmain_goto_l000001c2"} true;
+  $main_goto_$000001c2:
+    assume {:captureState "$main_goto_$000001c2"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) != 0bv1);
-    goto l000001c2;
-  lmain_goto_l0000039c:
-    assume {:captureState "lmain_goto_l0000039c"} true;
+    goto $000001c2;
+  $main_goto_$0000039c:
+    assume {:captureState "$main_goto_$0000039c"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) == 0bv1);
-    goto l0000039c;
+    goto $0000039c;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
@@ -128,8 +128,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
@@ -153,26 +153,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000330, lmain_goto_l00000347;
-  l00000347:
-    assume {:captureState "l00000347"} true;
+    goto $main_goto_$00000330, $main_goto_$00000347;
+  $00000347:
+    assume {:captureState "$00000347"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%0000034c"} true;
-    goto l00000330;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $00000330;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000330:
-    assume {:captureState "lmain_goto_l00000330"} true;
+  $main_goto_$00000330:
+    assume {:captureState "$main_goto_$00000330"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000330;
-  lmain_goto_l00000347:
-    assume {:captureState "lmain_goto_l00000347"} true;
+    goto $00000330;
+  $main_goto_$00000347:
+    assume {:captureState "$main_goto_$00000347"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000347;
+    goto $00000347;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/basic_sec_policy_write/clang/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang/basic_sec_policy_write.expected
@@ -101,8 +101,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002ee"} true;

--- a/src/test/correct/basic_sec_policy_write/clang_O2/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang_O2/basic_sec_policy_write.expected
@@ -92,8 +92,8 @@ implementation main()
 {
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 0bv64, true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;

--- a/src/test/correct/basic_sec_policy_write/clang_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang_pic/basic_sec_policy_write.expected
@@ -115,8 +115,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002f6"} true;

--- a/src/test/correct/basic_sec_policy_write/gcc/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc/basic_sec_policy_write.expected
@@ -97,8 +97,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000306"} true;

--- a/src/test/correct/basic_sec_policy_write/gcc_O2/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc_O2/basic_sec_policy_write.expected
@@ -92,8 +92,8 @@ implementation main()
 {
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R3, Gamma_R3 := 2bv64, true;

--- a/src/test/correct/basic_sec_policy_write/gcc_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc_pic/basic_sec_policy_write.expected
@@ -115,8 +115,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000306"} true;

--- a/src/test/correct/basicassign_gamma0/clang/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang/basicassign_gamma0.expected
@@ -86,8 +86,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R8, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 52bv64)) || L(mem, bvadd64(R8, 52bv64)));

--- a/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
@@ -100,8 +100,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R8, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4048bv64)) || L(mem, bvadd64(R8, 4048bv64)));

--- a/src/test/correct/basicassign_gamma0/gcc/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc/basicassign_gamma0.expected
@@ -84,8 +84,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     call rely();

--- a/src/test/correct/basicassign_gamma0/gcc_O2/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_O2/basicassign_gamma0.expected
@@ -86,8 +86,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
@@ -98,8 +98,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));

--- a/src/test/correct/basicfree/clang/basicfree.expected
+++ b/src/test/correct/basicfree/clang/basicfree.expected
@@ -125,8 +125,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -137,9 +137,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2024bv64, true;
     call malloc();
-    goto l0000030d;
-  l0000030d:
-    assume {:captureState "l0000030d"} true;
+    goto $0000030d;
+  $0000030d:
+    assume {:captureState "$0000030d"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     assume {:captureState "%00000313"} true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
@@ -153,9 +153,9 @@ implementation main()
     R0, Gamma_R0 := $load$20, Gamma_$load$20;
     R30, Gamma_R30 := 2048bv64, true;
     call #free();
-    goto l00000338;
-  l00000338:
-    assume {:captureState "l00000338"} true;
+    goto $00000338;
+  $00000338:
+    assume {:captureState "$00000338"} true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
     $load$21, Gamma_$load$21 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
     R29, Gamma_R29 := $load$21, Gamma_$load$21;

--- a/src/test/correct/basicfree/gcc/basicfree.expected
+++ b/src/test/correct/basicfree/gcc/basicfree.expected
@@ -121,8 +121,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002e8"} true;
@@ -133,9 +133,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2020bv64, true;
     call malloc();
-    goto l00000307;
-  l00000307:
-    assume {:captureState "l00000307"} true;
+    goto $00000307;
+  $00000307:
+    assume {:captureState "$00000307"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     assume {:captureState "%0000030d"} true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
@@ -149,9 +149,9 @@ implementation main()
     R0, Gamma_R0 := $load$20, Gamma_$load$20;
     R30, Gamma_R30 := 2044bv64, true;
     call #free();
-    goto l00000332;
-  l00000332:
-    assume {:captureState "l00000332"} true;
+    goto $00000332;
+  $00000332:
+    assume {:captureState "$00000332"} true;
     $load$21, Gamma_$load$21 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$21, Gamma_$load$21;
     $load$22, Gamma_$load$22 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));

--- a/src/test/correct/cjump/clang/cjump.expected
+++ b/src/test/correct/cjump/clang/cjump.expected
@@ -109,8 +109,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000309"} true;
@@ -130,62 +130,62 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000343, lmain_goto_l00000346;
-  l00000346:
-    assume {:captureState "l00000346"} true;
+    goto $main_goto_$00000343, $main_goto_$00000346;
+  $00000346:
+    assume {:captureState "$00000346"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000349;
-  l00000343:
-    assume {:captureState "l00000343"} true;
+    goto $00000349;
+  $00000343:
+    assume {:captureState "$00000343"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000349;
-  l00000349:
-    assume {:captureState "l00000349"} true;
+    goto $00000349;
+  $00000349:
+    assume {:captureState "$00000349"} true;
     assert Gamma_R8;
-    goto l00000349_goto_l00000351, l00000349_goto_l0000037e;
-  l00000351:
-    assume {:captureState "l00000351"} true;
+    goto $00000349_goto_$00000351, $00000349_goto_$0000037e;
+  $00000351:
+    assume {:captureState "$00000351"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 2bv64, true;
     call rely();
     assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 56bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 56bv64), Gamma_R8);
     assume {:captureState "%00000366"} true;
-    goto l00000369;
-  l0000037e:
-    assume {:captureState "l0000037e"} true;
-    goto l0000037f;
-  l0000037f:
-    assume {:captureState "l0000037f"} true;
+    goto $00000369;
+  $0000037e:
+    assume {:captureState "$0000037e"} true;
+    goto $0000037f;
+  $0000037f:
+    assume {:captureState "$0000037f"} true;
     R8, Gamma_R8 := 3bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 56bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 56bv64), Gamma_R8);
     assume {:captureState "%00000392"} true;
-    goto l00000369;
-  l00000369:
-    assume {:captureState "l00000369"} true;
+    goto $00000369;
+  $00000369:
+    assume {:captureState "$00000369"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000343:
-    assume {:captureState "lmain_goto_l00000343"} true;
+  $main_goto_$00000343:
+    assume {:captureState "$main_goto_$00000343"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000343;
-  lmain_goto_l00000346:
-    assume {:captureState "lmain_goto_l00000346"} true;
+    goto $00000343;
+  $main_goto_$00000346:
+    assume {:captureState "$main_goto_$00000346"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000346;
-  l00000349_goto_l00000351:
-    assume {:captureState "l00000349_goto_l00000351"} true;
+    goto $00000346;
+  $00000349_goto_$00000351:
+    assume {:captureState "$00000349_goto_$00000351"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000351;
-  l00000349_goto_l0000037e:
-    assume {:captureState "l00000349_goto_l0000037e"} true;
+    goto $00000351;
+  $00000349_goto_$0000037e:
+    assume {:captureState "$00000349_goto_$0000037e"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000037e;
+    goto $0000037e;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/cjump/clang_pic/cjump.expected
+++ b/src/test/correct/cjump/clang_pic/cjump.expected
@@ -125,8 +125,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000315"} true;
@@ -149,21 +149,21 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000356, lmain_goto_l00000359;
-  l00000359:
-    assume {:captureState "l00000359"} true;
+    goto $main_goto_$00000356, $main_goto_$00000359;
+  $00000359:
+    assume {:captureState "$00000359"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000035c;
-  l00000356:
-    assume {:captureState "l00000356"} true;
+    goto $0000035c;
+  $00000356:
+    assume {:captureState "$00000356"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000035c;
-  l0000035c:
-    assume {:captureState "l0000035c"} true;
+    goto $0000035c;
+  $0000035c:
+    assume {:captureState "$0000035c"} true;
     assert Gamma_R8;
-    goto l0000035c_goto_l00000364, l0000035c_goto_l00000398;
-  l00000364:
-    assume {:captureState "l00000364"} true;
+    goto $0000035c_goto_$00000364, $0000035c_goto_$00000398;
+  $00000364:
+    assume {:captureState "$00000364"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R9, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4048bv64)) || L(mem, bvadd64(R9, 4048bv64)));
@@ -173,12 +173,12 @@ implementation main()
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
     assume {:captureState "%00000380"} true;
-    goto l00000383;
-  l00000398:
-    assume {:captureState "l00000398"} true;
-    goto l00000399;
-  l00000399:
-    assume {:captureState "l00000399"} true;
+    goto $00000383;
+  $00000398:
+    assume {:captureState "$00000398"} true;
+    goto $00000399;
+  $00000399:
+    assume {:captureState "$00000399"} true;
     R8, Gamma_R8 := 3bv64, true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
@@ -188,29 +188,29 @@ implementation main()
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
     assume {:captureState "%000003b3"} true;
-    goto l00000383;
-  l00000383:
-    assume {:captureState "l00000383"} true;
+    goto $00000383;
+  $00000383:
+    assume {:captureState "$00000383"} true;
     $load$22, Gamma_$load$22 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000356:
-    assume {:captureState "lmain_goto_l00000356"} true;
+  $main_goto_$00000356:
+    assume {:captureState "$main_goto_$00000356"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000356;
-  lmain_goto_l00000359:
-    assume {:captureState "lmain_goto_l00000359"} true;
+    goto $00000356;
+  $main_goto_$00000359:
+    assume {:captureState "$main_goto_$00000359"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000359;
-  l0000035c_goto_l00000364:
-    assume {:captureState "l0000035c_goto_l00000364"} true;
+    goto $00000359;
+  $0000035c_goto_$00000364:
+    assume {:captureState "$0000035c_goto_$00000364"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000364;
-  l0000035c_goto_l00000398:
-    assume {:captureState "l0000035c_goto_l00000398"} true;
+    goto $00000364;
+  $0000035c_goto_$00000398:
+    assume {:captureState "$0000035c_goto_$00000398"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000398;
+    goto $00000398;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/cjump/gcc/cjump.expected
+++ b/src/test/correct/cjump/gcc/cjump.expected
@@ -99,8 +99,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;
@@ -119,9 +119,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000033e, lmain_goto_l00000365;
-  l0000033e:
-    assume {:captureState "l0000033e"} true;
+    goto $main_goto_$0000033e, $main_goto_$00000365;
+  $0000033e:
+    assume {:captureState "$0000033e"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     R1, Gamma_R1 := 2bv64, true;
@@ -129,9 +129,9 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%00000359"} true;
-    goto l0000035b;
-  l00000365:
-    assume {:captureState "l00000365"} true;
+    goto $0000035b;
+  $00000365:
+    assume {:captureState "$00000365"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     R1, Gamma_R1 := 3bv64, true;
@@ -139,19 +139,19 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%0000037b"} true;
-    goto l0000035b;
-  l0000035b:
-    assume {:captureState "l0000035b"} true;
+    goto $0000035b;
+  $0000035b:
+    assume {:captureState "$0000035b"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l0000033e:
-    assume {:captureState "lmain_goto_l0000033e"} true;
+  $main_goto_$0000033e:
+    assume {:captureState "$main_goto_$0000033e"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000033e;
-  lmain_goto_l00000365:
-    assume {:captureState "lmain_goto_l00000365"} true;
+    goto $0000033e;
+  $main_goto_$00000365:
+    assume {:captureState "$main_goto_$00000365"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000365;
+    goto $00000365;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/cjump/gcc_pic/cjump.expected
+++ b/src/test/correct/cjump/gcc_pic/cjump.expected
@@ -117,8 +117,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
@@ -141,9 +141,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000340, lmain_goto_l00000368;
-  l00000340:
-    assume {:captureState "l00000340"} true;
+    goto $main_goto_$00000340, $main_goto_$00000368;
+  $00000340:
+    assume {:captureState "$00000340"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$21, Gamma_$load$21 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
@@ -153,9 +153,9 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%0000035c"} true;
-    goto l0000035e;
-  l00000368:
-    assume {:captureState "l00000368"} true;
+    goto $0000035e;
+  $00000368:
+    assume {:captureState "$00000368"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$22, Gamma_$load$22 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
@@ -165,19 +165,19 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%0000037f"} true;
-    goto l0000035e;
-  l0000035e:
-    assume {:captureState "l0000035e"} true;
+    goto $0000035e;
+  $0000035e:
+    assume {:captureState "$0000035e"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l00000340:
-    assume {:captureState "lmain_goto_l00000340"} true;
+  $main_goto_$00000340:
+    assume {:captureState "$main_goto_$00000340"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000340;
-  lmain_goto_l00000368:
-    assume {:captureState "lmain_goto_l00000368"} true;
+    goto $00000340;
+  $main_goto_$00000368:
+    assume {:captureState "$main_goto_$00000368"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000368;
+    goto $00000368;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/function/clang/function.expected
+++ b/src/test/correct/function/clang/function.expected
@@ -97,8 +97,8 @@ procedure get_two();
 
 implementation get_two()
 {
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R0, Gamma_R0 := 2bv64, true;
     goto get_two_basil_return;
   get_two_basil_return:
@@ -135,8 +135,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000008db"} true;
@@ -152,9 +152,9 @@ implementation main()
     assume {:captureState "%000008fd"} true;
     R30, Gamma_R30 := 1836bv64, true;
     call get_two();
-    goto l00000910;
-  l00000910:
-    assume {:captureState "l00000910"} true;
+    goto $00000910;
+  $00000910:
+    assume {:captureState "$00000910"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 56bv64)) ==> Gamma_R0);

--- a/src/test/correct/function/clang_pic/function.expected
+++ b/src/test/correct/function/clang_pic/function.expected
@@ -103,8 +103,8 @@ procedure get_two();
 
 implementation get_two()
 {
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R0, Gamma_R0 := 2bv64, true;
     goto get_two_basil_return;
   get_two_basil_return:
@@ -149,8 +149,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002f0"} true;
@@ -169,9 +169,9 @@ implementation main()
     assume {:captureState "%00000319"} true;
     R30, Gamma_R30 := 1904bv64, true;
     call get_two();
-    goto l0000032c;
-  l0000032c:
-    assume {:captureState "l0000032c"} true;
+    goto $0000032c;
+  $0000032c:
+    assume {:captureState "$0000032c"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$19, Gamma_$load$19 := memory_load64_le(mem, bvadd64(R8, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4048bv64)) || L(mem, bvadd64(R8, 4048bv64)));

--- a/src/test/correct/function/gcc/function.expected
+++ b/src/test/correct/function/gcc/function.expected
@@ -96,8 +96,8 @@ procedure get_two();
 
 implementation get_two()
 {
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R0, Gamma_R0 := 2bv64, true;
     goto get_two_basil_return;
   get_two_basil_return:
@@ -134,8 +134,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%0000090b"} true;
@@ -152,9 +152,9 @@ implementation main()
     assume {:captureState "%00000933"} true;
     R30, Gamma_R30 := 1840bv64, true;
     call get_two();
-    goto l00000946;
-  l00000946:
-    assume {:captureState "l00000946"} true;
+    goto $00000946;
+  $00000946:
+    assume {:captureState "$00000946"} true;
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;

--- a/src/test/correct/function/gcc_pic/function.expected
+++ b/src/test/correct/function/gcc_pic/function.expected
@@ -102,8 +102,8 @@ procedure get_two();
 
 implementation get_two()
 {
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R0, Gamma_R0 := 2bv64, true;
     goto get_two_basil_return;
   get_two_basil_return:
@@ -148,8 +148,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002f4"} true;
@@ -168,9 +168,9 @@ implementation main()
     assume {:captureState "%0000031d"} true;
     R30, Gamma_R30 := 1904bv64, true;
     call get_two();
-    goto l00000330;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $00000330;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();

--- a/src/test/correct/function1/clang/function1.expected
+++ b/src/test/correct/function1/clang/function1.expected
@@ -134,8 +134,8 @@ implementation get_two()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store8_le(stack, bvadd64(R31, 15bv64), R0[8:0]), gamma_store8(Gamma_stack, bvadd64(R31, 15bv64), Gamma_R0);
     assume {:captureState "%00000336"} true;
@@ -188,8 +188,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000386"} true;
@@ -210,9 +210,9 @@ implementation main()
     R2, Gamma_R2 := (R2[64:48] ++ (2bv16 ++ R2[32:0])), Gamma_R2;
     R30, Gamma_R30 := 1968bv64, true;
     call get_two();
-    goto l000003ce;
-  l000003ce:
-    assume {:captureState "l000003ce"} true;
+    goto $000003ce;
+  $000003ce:
+    assume {:captureState "$000003ce"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 64bv64)) ==> Gamma_R0);
@@ -225,9 +225,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2028bv64), Gamma_R0;
     R30, Gamma_R30 := 1992bv64, true;
     call printf();
-    goto l000003f5;
-  l000003f5:
-    assume {:captureState "l000003f5"} true;
+    goto $000003f5;
+  $000003f5:
+    assume {:captureState "$000003f5"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$22, Gamma_$load$22 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$22, Gamma_$load$22;

--- a/src/test/correct/function1/clang_O2/function1.expected
+++ b/src/test/correct/function1/clang_O2/function1.expected
@@ -113,8 +113,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000317"} true;
@@ -141,9 +141,9 @@ implementation main()
     assume {:captureState "%00000367"} true;
     R30, Gamma_R30 := 1944bv64, true;
     call printf();
-    goto l00000371;
-  l00000371:
-    assume {:captureState "l00000371"} true;
+    goto $00000371;
+  $00000371:
+    assume {:captureState "$00000371"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$18, Gamma_$load$18 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$18, Gamma_$load$18;

--- a/src/test/correct/function1/gcc/function1.expected
+++ b/src/test/correct/function1/gcc/function1.expected
@@ -141,8 +141,8 @@ implementation get_two()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lget_two:
-    assume {:captureState "lget_two"} true;
+  $get_two:
+    assume {:captureState "$get_two"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store8_le(stack, bvadd64(R31, 15bv64), R0[8:0]), gamma_store8(Gamma_stack, bvadd64(R31, 15bv64), Gamma_R0);
     assume {:captureState "%0000034e"} true;
@@ -203,8 +203,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%0000039e"} true;
@@ -226,9 +226,9 @@ implementation main()
     R0, Gamma_R0 := 97bv64, true;
     R30, Gamma_R30 := 1972bv64, true;
     call get_two();
-    goto l000003ec;
-  l000003ec:
-    assume {:captureState "l000003ec"} true;
+    goto $000003ec;
+  $000003ec:
+    assume {:captureState "$000003ec"} true;
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
@@ -246,9 +246,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2056bv64), Gamma_R0;
     R30, Gamma_R30 := 2016bv64, true;
     call printf();
-    goto l00000430;
-  l00000430:
-    assume {:captureState "l00000430"} true;
+    goto $00000430;
+  $00000430:
+    assume {:captureState "$00000430"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$22, Gamma_$load$22 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$22, Gamma_$load$22;

--- a/src/test/correct/function1/gcc_O2/function1.expected
+++ b/src/test/correct/function1/gcc_O2/function1.expected
@@ -146,8 +146,8 @@ implementation main()
   var Gamma_#1: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #1, Gamma_#1 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #1, R29), gamma_store64(Gamma_stack, #1, Gamma_R29);
     assume {:captureState "%000001ca"} true;
@@ -172,9 +172,9 @@ implementation main()
     assume {:captureState "%00000210"} true;
     R30, Gamma_R30 := 1712bv64, true;
     call __printf_chk();
-    goto l0000021a;
-  l0000021a:
-    assume {:captureState "l0000021a"} true;
+    goto $0000021a;
+  $0000021a:
+    assume {:captureState "$0000021a"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$19, Gamma_$load$19;

--- a/src/test/correct/functions_with_params/clang/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang/functions_with_params.expected
@@ -106,8 +106,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -125,9 +125,9 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$18), Gamma_$load$18;
     R30, Gamma_R30 := 1848bv64, true;
     call plus_one();
-    goto l00000366;
-  l00000366:
-    assume {:captureState "l00000366"} true;
+    goto $00000366;
+  $00000366:
+    assume {:captureState "$00000366"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
     assume {:captureState "%0000036c"} true;
     R0, Gamma_R0 := 0bv64, true;
@@ -162,8 +162,8 @@ implementation plus_one()
 {
   var $load$21: bv32;
   var Gamma_$load$21: bool;
-  lplus_one:
-    assume {:captureState "lplus_one"} true;
+  $plus_one:
+    assume {:captureState "$plus_one"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000034c"} true;

--- a/src/test/correct/functions_with_params/gcc/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc/functions_with_params.expected
@@ -102,8 +102,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002fc"} true;
@@ -121,9 +121,9 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$18), Gamma_$load$18;
     R30, Gamma_R30 := 1844bv64, true;
     call plus_one();
-    goto l0000035c;
-  l0000035c:
-    assume {:captureState "l0000035c"} true;
+    goto $0000035c;
+  $0000035c:
+    assume {:captureState "$0000035c"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     assume {:captureState "%00000362"} true;
     R0, Gamma_R0 := 0bv64, true;
@@ -157,8 +157,8 @@ implementation plus_one()
 {
   var $load$21: bv32;
   var Gamma_$load$21: bool;
-  lplus_one:
-    assume {:captureState "lplus_one"} true;
+  $plus_one:
+    assume {:captureState "$plus_one"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000342"} true;

--- a/src/test/correct/ifbranches/clang/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang/ifbranches.expected
@@ -110,8 +110,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), true);
     assume {:captureState "%0000030d"} true;
@@ -130,36 +130,36 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000034c, lmain_goto_l0000034f;
-  l0000034f:
-    assume {:captureState "l0000034f"} true;
+    goto $main_goto_$0000034c, $main_goto_$0000034f;
+  $0000034f:
+    assume {:captureState "$0000034f"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000352;
-  l0000034c:
-    assume {:captureState "l0000034c"} true;
+    goto $00000352;
+  $0000034c:
+    assume {:captureState "$0000034c"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000352;
-  l00000352:
-    assume {:captureState "l00000352"} true;
+    goto $00000352;
+  $00000352:
+    assume {:captureState "$00000352"} true;
     assert Gamma_R8;
-    goto l00000352_goto_l0000035a, l00000352_goto_l00000397;
-  l0000035a:
-    assume {:captureState "l0000035a"} true;
+    goto $00000352_goto_$0000035a, $00000352_goto_$00000397;
+  $0000035a:
+    assume {:captureState "$0000035a"} true;
     R8, Gamma_R8 := 2bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%0000036a"} true;
-    goto l0000036d;
-  l00000397:
-    assume {:captureState "l00000397"} true;
-    goto l00000398;
-  l00000398:
-    assume {:captureState "l00000398"} true;
+    goto $0000036d;
+  $00000397:
+    assume {:captureState "$00000397"} true;
+    goto $00000398;
+  $00000398:
+    assume {:captureState "$00000398"} true;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%000003a6"} true;
-    goto l0000036d;
-  l0000036d:
-    assume {:captureState "l0000036d"} true;
+    goto $0000036d;
+  $0000036d:
+    assume {:captureState "$0000036d"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R8, Gamma_R8 := zero_extend32_32($load$19), Gamma_$load$19;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
@@ -169,22 +169,22 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000034c:
-    assume {:captureState "lmain_goto_l0000034c"} true;
+  $main_goto_$0000034c:
+    assume {:captureState "$main_goto_$0000034c"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000034c;
-  lmain_goto_l0000034f:
-    assume {:captureState "lmain_goto_l0000034f"} true;
+    goto $0000034c;
+  $main_goto_$0000034f:
+    assume {:captureState "$main_goto_$0000034f"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000034f;
-  l00000352_goto_l0000035a:
-    assume {:captureState "l00000352_goto_l0000035a"} true;
+    goto $0000034f;
+  $00000352_goto_$0000035a:
+    assume {:captureState "$00000352_goto_$0000035a"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000035a;
-  l00000352_goto_l00000397:
-    assume {:captureState "l00000352_goto_l00000397"} true;
+    goto $0000035a;
+  $00000352_goto_$00000397:
+    assume {:captureState "$00000352_goto_$00000397"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000397;
+    goto $00000397;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifbranches/clang_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_O2/ifbranches.expected
@@ -76,8 +76,8 @@ implementation main()
 {
   var #4: bv32;
   var Gamma_#4: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 2bv64, true;
     #4, Gamma_#4 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
     VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#4);
@@ -85,26 +85,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002db, lmain_goto_l000002df;
-  l000002df:
-    assume {:captureState "l000002df"} true;
+    goto $main_goto_$000002db, $main_goto_$000002df;
+  $000002df:
+    assume {:captureState "$000002df"} true;
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
-    goto l000002e2;
-  l000002db:
-    assume {:captureState "l000002db"} true;
+    goto $000002e2;
+  $000002db:
+    assume {:captureState "$000002db"} true;
     R0, Gamma_R0 := zero_extend32_32(R8[32:0]), Gamma_R8;
-    goto l000002e2;
-  l000002e2:
-    assume {:captureState "l000002e2"} true;
+    goto $000002e2;
+  $000002e2:
+    assume {:captureState "$000002e2"} true;
     goto main_basil_return;
-  lmain_goto_l000002db:
-    assume {:captureState "lmain_goto_l000002db"} true;
+  $main_goto_$000002db:
+    assume {:captureState "$main_goto_$000002db"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002db;
-  lmain_goto_l000002df:
-    assume {:captureState "lmain_goto_l000002df"} true;
+    goto $000002db;
+  $main_goto_$000002df:
+    assume {:captureState "$main_goto_$000002df"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000002df;
+    goto $000002df;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifbranches/gcc/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc/ifbranches.expected
@@ -108,8 +108,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002fe"} true;
@@ -125,21 +125,21 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000330, lmain_goto_l00000369;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $main_goto_$00000330, $main_goto_$00000369;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R0, Gamma_R0 := 2bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     assume {:captureState "%00000340"} true;
-    goto l00000342;
-  l00000369:
-    assume {:captureState "l00000369"} true;
+    goto $00000342;
+  $00000369:
+    assume {:captureState "$00000369"} true;
     R0, Gamma_R0 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     assume {:captureState "%00000374"} true;
-    goto l00000342;
-  l00000342:
-    assume {:captureState "l00000342"} true;
+    goto $00000342;
+  $00000342:
+    assume {:captureState "$00000342"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 24bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R0[32:0], 1bv32)), Gamma_R0;
@@ -149,14 +149,14 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000330:
-    assume {:captureState "lmain_goto_l00000330"} true;
+  $main_goto_$00000330:
+    assume {:captureState "$main_goto_$00000330"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000330;
-  lmain_goto_l00000369:
-    assume {:captureState "lmain_goto_l00000369"} true;
+    goto $00000330;
+  $main_goto_$00000369:
+    assume {:captureState "$main_goto_$00000369"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000369;
+    goto $00000369;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
@@ -74,35 +74,35 @@ implementation main()
 {
   var #1: bv32;
   var Gamma_#1: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #1, Gamma_#1 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
     VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#1, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#1);
     CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#1, 1bv32)), bvadd33(zero_extend1_32(R0[32:0]), 4294967296bv33))), (Gamma_R0 && Gamma_#1);
     ZF, Gamma_ZF := bvcomp32(bvadd32(#1, 1bv32), 0bv32), Gamma_#1;
     NF, Gamma_NF := bvadd32(#1, 1bv32)[32:31], Gamma_#1;
     assert Gamma_ZF;
-    goto lmain_goto_l000001c3, lmain_goto_l000001c6;
-  l000001c6:
-    assume {:captureState "l000001c6"} true;
+    goto $main_goto_$000001c3, $main_goto_$000001c6;
+  $000001c6:
+    assume {:captureState "$000001c6"} true;
     R0, Gamma_R0 := 1bv64, true;
-    goto l000001c9;
-  l000001c3:
-    assume {:captureState "l000001c3"} true;
+    goto $000001c9;
+  $000001c3:
+    assume {:captureState "$000001c3"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l000001c9;
-  l000001c9:
-    assume {:captureState "l000001c9"} true;
+    goto $000001c9;
+  $000001c9:
+    assume {:captureState "$000001c9"} true;
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R0[32:0], 2bv32)), Gamma_R0;
     goto main_basil_return;
-  lmain_goto_l000001c3:
-    assume {:captureState "lmain_goto_l000001c3"} true;
+  $main_goto_$000001c3:
+    assume {:captureState "$main_goto_$000001c3"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000001c3;
-  lmain_goto_l000001c6:
-    assume {:captureState "lmain_goto_l000001c6"} true;
+    goto $000001c3;
+  $main_goto_$000001c6:
+    assume {:captureState "$main_goto_$000001c6"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000001c6;
+    goto $000001c6;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/clang/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang/ifglobal.expected
@@ -105,8 +105,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f1"} true;
@@ -121,53 +121,53 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000031e, lmain_goto_l00000321;
-  l00000321:
-    assume {:captureState "l00000321"} true;
+    goto $main_goto_$0000031e, $main_goto_$00000321;
+  $00000321:
+    assume {:captureState "$00000321"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000324;
-  l0000031e:
-    assume {:captureState "l0000031e"} true;
+    goto $00000324;
+  $0000031e:
+    assume {:captureState "$0000031e"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000324;
-  l00000324:
-    assume {:captureState "l00000324"} true;
+    goto $00000324;
+  $00000324:
+    assume {:captureState "$00000324"} true;
     assert Gamma_R8;
-    goto l00000324_goto_l0000032c, l00000324_goto_l00000343;
-  l00000343:
-    assume {:captureState "l00000343"} true;
-    goto l00000344;
-  l00000344:
-    assume {:captureState "l00000344"} true;
+    goto $00000324_goto_$0000032c, $00000324_goto_$00000343;
+  $00000343:
+    assume {:captureState "$00000343"} true;
+    goto $00000344;
+  $00000344:
+    assume {:captureState "$00000344"} true;
     R8, Gamma_R8 := 1bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R9, 52bv64)) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 52bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 52bv64), Gamma_R8);
     assume {:captureState "%00000357"} true;
-    goto l0000032c;
-  l0000032c:
-    assume {:captureState "l0000032c"} true;
+    goto $0000032c;
+  $0000032c:
+    assume {:captureState "$0000032c"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000031e:
-    assume {:captureState "lmain_goto_l0000031e"} true;
+  $main_goto_$0000031e:
+    assume {:captureState "$main_goto_$0000031e"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000031e;
-  lmain_goto_l00000321:
-    assume {:captureState "lmain_goto_l00000321"} true;
+    goto $0000031e;
+  $main_goto_$00000321:
+    assume {:captureState "$main_goto_$00000321"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000321;
-  l00000324_goto_l0000032c:
-    assume {:captureState "l00000324_goto_l0000032c"} true;
+    goto $00000321;
+  $00000324_goto_$0000032c:
+    assume {:captureState "$00000324_goto_$0000032c"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000032c;
-  l00000324_goto_l00000343:
-    assume {:captureState "l00000324_goto_l00000343"} true;
+    goto $0000032c;
+  $00000324_goto_$00000343:
+    assume {:captureState "$00000324_goto_$00000343"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000343;
+    goto $00000343;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/clang_O2/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang_O2/ifglobal.expected
@@ -80,16 +80,16 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R8, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 52bv64)) || L(mem, bvadd64(R8, 52bv64)));
     R9, Gamma_R9 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R9;
-    goto lmain_goto_l000002dc, lmain_goto_l000002f8;
-  l000002dc:
-    assume {:captureState "l000002dc"} true;
+    goto $main_goto_$000002dc, $main_goto_$000002f8;
+  $000002dc:
+    assume {:captureState "$000002dc"} true;
     R9, Gamma_R9 := 1bv64, true;
     call rely();
     assert (L(mem, bvadd64(R8, 52bv64)) ==> Gamma_R9);
@@ -97,18 +97,18 @@ implementation main()
     assume {:captureState "%000002ec"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  l000002f8:
-    assume {:captureState "l000002f8"} true;
+  $000002f8:
+    assume {:captureState "$000002f8"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l000002dc:
-    assume {:captureState "lmain_goto_l000002dc"} true;
+  $main_goto_$000002dc:
+    assume {:captureState "$main_goto_$000002dc"} true;
     assume (bvcomp32(R9[32:0], 0bv32) != 0bv1);
-    goto l000002dc;
-  lmain_goto_l000002f8:
-    assume {:captureState "lmain_goto_l000002f8"} true;
+    goto $000002dc;
+  $main_goto_$000002f8:
+    assume {:captureState "$main_goto_$000002f8"} true;
     assume (bvcomp32(R9[32:0], 0bv32) == 0bv1);
-    goto l000002f8;
+    goto $000002f8;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/clang_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang_pic/ifglobal.expected
@@ -116,8 +116,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f9"} true;
@@ -135,24 +135,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000032d, lmain_goto_l00000330;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $main_goto_$0000032d, $main_goto_$00000330;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000333;
-  l0000032d:
-    assume {:captureState "l0000032d"} true;
+    goto $00000333;
+  $0000032d:
+    assume {:captureState "$0000032d"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000333;
-  l00000333:
-    assume {:captureState "l00000333"} true;
+    goto $00000333;
+  $00000333:
+    assume {:captureState "$00000333"} true;
     assert Gamma_R8;
-    goto l00000333_goto_l0000033b, l00000333_goto_l00000352;
-  l00000352:
-    assume {:captureState "l00000352"} true;
-    goto l00000353;
-  l00000353:
-    assume {:captureState "l00000353"} true;
+    goto $00000333_goto_$0000033b, $00000333_goto_$00000352;
+  $00000352:
+    assume {:captureState "$00000352"} true;
+    goto $00000353;
+  $00000353:
+    assume {:captureState "$00000353"} true;
     R8, Gamma_R8 := 1bv64, true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
@@ -162,29 +162,29 @@ implementation main()
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
     assume {:captureState "%0000036d"} true;
-    goto l0000033b;
-  l0000033b:
-    assume {:captureState "l0000033b"} true;
+    goto $0000033b;
+  $0000033b:
+    assume {:captureState "$0000033b"} true;
     $load$21, Gamma_$load$21 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$21), Gamma_$load$21;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000032d:
-    assume {:captureState "lmain_goto_l0000032d"} true;
+  $main_goto_$0000032d:
+    assume {:captureState "$main_goto_$0000032d"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l0000032d;
-  lmain_goto_l00000330:
-    assume {:captureState "lmain_goto_l00000330"} true;
+    goto $0000032d;
+  $main_goto_$00000330:
+    assume {:captureState "$main_goto_$00000330"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000330;
-  l00000333_goto_l0000033b:
-    assume {:captureState "l00000333_goto_l0000033b"} true;
+    goto $00000330;
+  $00000333_goto_$0000033b:
+    assume {:captureState "$00000333_goto_$0000033b"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000033b;
-  l00000333_goto_l00000352:
-    assume {:captureState "l00000333_goto_l00000352"} true;
+    goto $0000033b;
+  $00000333_goto_$00000352:
+    assume {:captureState "$00000333_goto_$00000352"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000352;
+    goto $00000352;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/gcc/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc/ifglobal.expected
@@ -95,8 +95,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
@@ -108,9 +108,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000302, lmain_goto_l00000311;
-  l00000311:
-    assume {:captureState "l00000311"} true;
+    goto $main_goto_$00000302, $main_goto_$00000311;
+  $00000311:
+    assume {:captureState "$00000311"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;
@@ -118,19 +118,19 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%00000327"} true;
-    goto l00000302;
-  l00000302:
-    assume {:captureState "l00000302"} true;
+    goto $00000302;
+  $00000302:
+    assume {:captureState "$00000302"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l00000302:
-    assume {:captureState "lmain_goto_l00000302"} true;
+  $main_goto_$00000302:
+    assume {:captureState "$main_goto_$00000302"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000302;
-  lmain_goto_l00000311:
-    assume {:captureState "lmain_goto_l00000311"} true;
+    goto $00000302;
+  $main_goto_$00000311:
+    assume {:captureState "$main_goto_$00000311"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000311;
+    goto $00000311;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/gcc_O2/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc_O2/ifglobal.expected
@@ -79,34 +79,34 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R0, 20bv64)), (gamma_load32(Gamma_mem, bvadd64(R0, 20bv64)) || L(mem, bvadd64(R0, 20bv64)));
     R1, Gamma_R1 := zero_extend32_32($load$18), Gamma_$load$18;
     assert Gamma_R1;
-    goto lmain_goto_l000001b7, lmain_goto_l00000396;
-  l00000396:
-    assume {:captureState "l00000396"} true;
+    goto $main_goto_$000001b7, $main_goto_$00000396;
+  $00000396:
+    assume {:captureState "$00000396"} true;
     R1, Gamma_R1 := 1bv64, true;
     call rely();
     assert (L(mem, bvadd64(R0, 20bv64)) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R0, 20bv64), R1[32:0]), gamma_store32(Gamma_mem, bvadd64(R0, 20bv64), Gamma_R1);
     assume {:captureState "%000003a1"} true;
-    goto l000001b7;
-  l000001b7:
-    assume {:captureState "l000001b7"} true;
+    goto $000001b7;
+  $000001b7:
+    assume {:captureState "$000001b7"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l000001b7:
-    assume {:captureState "lmain_goto_l000001b7"} true;
+  $main_goto_$000001b7:
+    assume {:captureState "$main_goto_$000001b7"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) != 0bv1);
-    goto l000001b7;
-  lmain_goto_l00000396:
-    assume {:captureState "lmain_goto_l00000396"} true;
+    goto $000001b7;
+  $main_goto_$00000396:
+    assume {:captureState "$main_goto_$00000396"} true;
     assume (bvnot1(bvcomp32(R1[32:0], 0bv32)) == 0bv1);
-    goto l00000396;
+    goto $00000396;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/ifglobal/gcc_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc_pic/ifglobal.expected
@@ -106,8 +106,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -121,9 +121,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000303, lmain_goto_l00000312;
-  l00000312:
-    assume {:captureState "l00000312"} true;
+    goto $main_goto_$00000303, $main_goto_$00000312;
+  $00000312:
+    assume {:captureState "$00000312"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -133,19 +133,19 @@ implementation main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     assume {:captureState "%00000329"} true;
-    goto l00000303;
-  l00000303:
-    assume {:captureState "l00000303"} true;
+    goto $00000303;
+  $00000303:
+    assume {:captureState "$00000303"} true;
     R0, Gamma_R0 := 0bv64, true;
     goto main_basil_return;
-  lmain_goto_l00000303:
-    assume {:captureState "lmain_goto_l00000303"} true;
+  $main_goto_$00000303:
+    assume {:captureState "$main_goto_$00000303"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000303;
-  lmain_goto_l00000312:
-    assume {:captureState "lmain_goto_l00000312"} true;
+    goto $00000303;
+  $main_goto_$00000312:
+    assume {:captureState "$main_goto_$00000312"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000312;
+    goto $00000312;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/initialisation/clang/initialisation.expected
+++ b/src/test/correct/initialisation/clang/initialisation.expected
@@ -147,8 +147,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     R9, Gamma_R9 := bvadd64(R9, 64bv64), Gamma_R9;

--- a/src/test/correct/initialisation/clang_O2/initialisation.expected
+++ b/src/test/correct/initialisation/clang_O2/initialisation.expected
@@ -139,8 +139,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R10, Gamma_R10 := 69632bv64, true;
     R10, Gamma_R10 := bvadd64(R10, 64bv64), Gamma_R10;
     R8, Gamma_R8 := 69632bv64, true;

--- a/src/test/correct/initialisation/clang_pic/initialisation.expected
+++ b/src/test/correct/initialisation/clang_pic/initialisation.expected
@@ -165,8 +165,8 @@ implementation main()
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/initialisation/gcc/initialisation.expected
+++ b/src/test/correct/initialisation/gcc/initialisation.expected
@@ -125,8 +125,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 16bv64), Gamma_R0;
     call rely();

--- a/src/test/correct/initialisation/gcc_O2/initialisation.expected
+++ b/src/test/correct/initialisation/gcc_O2/initialisation.expected
@@ -136,8 +136,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R5, Gamma_R5 := 69632bv64, true;
     R1, Gamma_R1 := bvadd64(R5, 16bv64), Gamma_R5;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/initialisation/gcc_pic/initialisation.expected
+++ b/src/test/correct/initialisation/gcc_pic/initialisation.expected
@@ -153,8 +153,8 @@ implementation main()
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4048bv64)) || L(mem, bvadd64(R0, 4048bv64)));

--- a/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
@@ -200,8 +200,8 @@ implementation main()
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
   var Gamma_$load$30: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551568bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 32bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -217,17 +217,17 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2100bv64, true;
     call malloc();
-    goto l00000391;
-  l00000391:
-    assume {:captureState "l00000391"} true;
+    goto $00000391;
+  $00000391:
+    assume {:captureState "$00000391"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     assume {:captureState "%00000397"} true;
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
-    goto l000003a5;
-  l000003a5:
-    assume {:captureState "l000003a5"} true;
+    goto $000003a5;
+  $000003a5:
+    assume {:captureState "$000003a5"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     assume {:captureState "%000003ab"} true;
     R8, Gamma_R8 := 10bv64, true;
@@ -256,9 +256,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2260bv64), Gamma_R0;
     R30, Gamma_R30 := 2168bv64, true;
     call printf();
-    goto l00000403;
-  l00000403:
-    assume {:captureState "l00000403"} true;
+    goto $00000403;
+  $00000403:
+    assume {:captureState "$00000403"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := $load$23, Gamma_$load$23;
     call rely();
@@ -268,32 +268,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2277bv64), Gamma_R0;
     R30, Gamma_R30 := 2188bv64, true;
     call printf();
-    goto l00000423;
-  l00000423:
-    assume {:captureState "l00000423"} true;
+    goto $00000423;
+  $00000423:
+    assume {:captureState "$00000423"} true;
     $load$25, Gamma_$load$25 := memory_load32_le(stack, bvadd64(R31, 4bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R1, Gamma_R1 := zero_extend32_32($load$25), Gamma_$load$25;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2293bv64), Gamma_R0;
     R30, Gamma_R30 := 2204bv64, true;
     call printf();
-    goto l0000043c;
-  l0000043c:
-    assume {:captureState "l0000043c"} true;
+    goto $0000043c;
+  $0000043c:
+    assume {:captureState "$0000043c"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
-    goto l0000044b;
-  l0000044b:
-    assume {:captureState "l0000044b"} true;
+    goto $0000044b;
+  $0000044b:
+    assume {:captureState "$0000044b"} true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := $load$27, Gamma_$load$27;
     R30, Gamma_R30 := 2220bv64, true;
     call #free();
-    goto l00000459;
-  l00000459:
-    assume {:captureState "l00000459"} true;
+    goto $00000459;
+  $00000459:
+    assume {:captureState "$00000459"} true;
     $load$28, Gamma_$load$28 := memory_load32_le(stack, R31), gamma_load32(Gamma_stack, R31);
     R0, Gamma_R0 := zero_extend32_32($load$28), Gamma_$load$28;
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;

--- a/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
@@ -134,8 +134,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002f8"} true;
@@ -148,25 +148,25 @@ implementation main()
     R1, Gamma_R1 := 65bv64, true;
     R30, Gamma_R30 := 1900bv64, true;
     call printf();
-    goto l00000322;
-  l00000322:
-    assume {:captureState "l00000322"} true;
+    goto $00000322;
+  $00000322:
+    assume {:captureState "$00000322"} true;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 1985bv64), Gamma_R0;
     R1, Gamma_R1 := 42bv64, true;
     R30, Gamma_R30 := 1916bv64, true;
     call printf();
-    goto l00000339;
-  l00000339:
-    assume {:captureState "l00000339"} true;
+    goto $00000339;
+  $00000339:
+    assume {:captureState "$00000339"} true;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2001bv64), Gamma_R0;
     R1, Gamma_R1 := 10bv64, true;
     R30, Gamma_R30 := 1932bv64, true;
     call printf();
-    goto l00000350;
-  l00000350:
-    assume {:captureState "l00000350"} true;
+    goto $00000350;
+  $00000350:
+    assume {:captureState "$00000350"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$18, Gamma_$load$18 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$18, Gamma_$load$18;

--- a/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
@@ -212,8 +212,8 @@ implementation main()
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551568bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000350"} true;
@@ -224,17 +224,17 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2084bv64, true;
     call malloc();
-    goto l0000036f;
-  l0000036f:
-    assume {:captureState "l0000036f"} true;
+    goto $0000036f;
+  $0000036f:
+    assume {:captureState "$0000036f"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     assume {:captureState "%00000375"} true;
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
-    goto l00000383;
-  l00000383:
-    assume {:captureState "l00000383"} true;
+    goto $00000383;
+  $00000383:
+    assume {:captureState "$00000383"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     assume {:captureState "%00000389"} true;
     R0, Gamma_R0 := 10bv64, true;
@@ -264,9 +264,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2256bv64), Gamma_R0;
     R30, Gamma_R30 := 2156bv64, true;
     call printf();
-    goto l000003e7;
-  l000003e7:
-    assume {:captureState "l000003e7"} true;
+    goto $000003e7;
+  $000003e7:
+    assume {:captureState "$000003e7"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := $load$23, Gamma_$load$23;
     call rely();
@@ -277,32 +277,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2280bv64), Gamma_R0;
     R30, Gamma_R30 := 2180bv64, true;
     call printf();
-    goto l0000040d;
-  l0000040d:
-    assume {:captureState "l0000040d"} true;
+    goto $0000040d;
+  $0000040d:
+    assume {:captureState "$0000040d"} true;
     $load$25, Gamma_$load$25 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R1, Gamma_R1 := zero_extend32_32($load$25), Gamma_$load$25;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
     R30, Gamma_R30 := 2196bv64, true;
     call printf();
-    goto l00000426;
-  l00000426:
-    assume {:captureState "l00000426"} true;
+    goto $00000426;
+  $00000426:
+    assume {:captureState "$00000426"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2204bv64, true;
     call #free();
-    goto l00000435;
-  l00000435:
-    assume {:captureState "l00000435"} true;
+    goto $00000435;
+  $00000435:
+    assume {:captureState "$00000435"} true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := $load$27, Gamma_$load$27;
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
-    goto l00000443;
-  l00000443:
-    assume {:captureState "l00000443"} true;
+    goto $00000443;
+  $00000443:
+    assume {:captureState "$00000443"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$28, Gamma_$load$28 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$28, Gamma_$load$28;

--- a/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
@@ -162,8 +162,8 @@ implementation main()
   var Gamma_#1: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #1, Gamma_#1 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #1, R29), gamma_store64(Gamma_stack, #1, Gamma_R29);
     assume {:captureState "%000001f2"} true;
@@ -177,27 +177,27 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 1692bv64, true;
     call __printf_chk();
-    goto l00000221;
-  l00000221:
-    assume {:captureState "l00000221"} true;
+    goto $00000221;
+  $00000221:
+    assume {:captureState "$00000221"} true;
     R2, Gamma_R2 := 42bv64, true;
     R1, Gamma_R1 := 0bv64, true;
     R0, Gamma_R0 := 1bv64, true;
     R1, Gamma_R1 := bvadd64(R1, 2120bv64), Gamma_R1;
     R30, Gamma_R30 := 1712bv64, true;
     call __printf_chk();
-    goto l0000023d;
-  l0000023d:
-    assume {:captureState "l0000023d"} true;
+    goto $0000023d;
+  $0000023d:
+    assume {:captureState "$0000023d"} true;
     R2, Gamma_R2 := 10bv64, true;
     R1, Gamma_R1 := 0bv64, true;
     R0, Gamma_R0 := 1bv64, true;
     R1, Gamma_R1 := bvadd64(R1, 2136bv64), Gamma_R1;
     R30, Gamma_R30 := 1732bv64, true;
     call __printf_chk();
-    goto l00000259;
-  l00000259:
-    assume {:captureState "l00000259"} true;
+    goto $00000259;
+  $00000259:
+    assume {:captureState "$00000259"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$19, Gamma_$load$19;

--- a/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
@@ -237,8 +237,8 @@ implementation main()
   var Gamma_$load$29: bool;
   var Gamma_$load$30: bool;
   var Gamma_$load$31: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551536bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 64bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -254,9 +254,9 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2100bv64, true;
     call malloc();
-    goto l000003b5;
-  l000003b5:
-    assume {:captureState "l000003b5"} true;
+    goto $000003b5;
+  $000003b5:
+    assume {:captureState "$000003b5"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     assume {:captureState "%000003bb"} true;
     R8, Gamma_R8 := 11bv64, true;
@@ -267,9 +267,9 @@ implementation main()
     assume {:captureState "%000003d5"} true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
-    goto l000003de;
-  l000003de:
-    assume {:captureState "l000003de"} true;
+    goto $000003de;
+  $000003de:
+    assume {:captureState "$000003de"} true;
     R8, Gamma_R8 := R0, Gamma_R0;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R0, Gamma_R0 := $load$19, Gamma_$load$19;
@@ -280,9 +280,9 @@ implementation main()
     assume {:captureState "%000003fe"} true;
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
-    goto l00000407;
-  l00000407:
-    assume {:captureState "l00000407"} true;
+    goto $00000407;
+  $00000407:
+    assume {:captureState "$00000407"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     assume {:captureState "%0000040d"} true;
     R8, Gamma_R8 := 9bv64, true;
@@ -311,9 +311,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
     R30, Gamma_R30 := 2204bv64, true;
     call printf();
-    goto l00000465;
-  l00000465:
-    assume {:captureState "l00000465"} true;
+    goto $00000465;
+  $00000465:
+    assume {:captureState "$00000465"} true;
     $load$24, Gamma_$load$24 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := $load$24, Gamma_$load$24;
     call rely();
@@ -323,32 +323,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2313bv64), Gamma_R0;
     R30, Gamma_R30 := 2224bv64, true;
     call printf();
-    goto l00000485;
-  l00000485:
-    assume {:captureState "l00000485"} true;
+    goto $00000485;
+  $00000485:
+    assume {:captureState "$00000485"} true;
     $load$26, Gamma_$load$26 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R1, Gamma_R1 := zero_extend32_32($load$26), Gamma_$load$26;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2329bv64), Gamma_R0;
     R30, Gamma_R30 := 2240bv64, true;
     call printf();
-    goto l0000049e;
-  l0000049e:
-    assume {:captureState "l0000049e"} true;
+    goto $0000049e;
+  $0000049e:
+    assume {:captureState "$0000049e"} true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R0, Gamma_R0 := $load$27, Gamma_$load$27;
     R30, Gamma_R30 := 2248bv64, true;
     call #free();
-    goto l000004ad;
-  l000004ad:
-    assume {:captureState "l000004ad"} true;
+    goto $000004ad;
+  $000004ad:
+    assume {:captureState "$000004ad"} true;
     $load$28, Gamma_$load$28 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := $load$28, Gamma_$load$28;
     R30, Gamma_R30 := 2256bv64, true;
     call #free();
-    goto l000004bb;
-  l000004bb:
-    assume {:captureState "l000004bb"} true;
+    goto $000004bb;
+  $000004bb:
+    assume {:captureState "$000004bb"} true;
     $load$29, Gamma_$load$29 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$29), Gamma_$load$29;
     #5, Gamma_#5 := bvadd64(R31, 64bv64), Gamma_R31;

--- a/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
@@ -212,8 +212,8 @@ implementation main()
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551552bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%0000036c"} true;
@@ -224,9 +224,9 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2084bv64, true;
     call malloc();
-    goto l0000038b;
-  l0000038b:
-    assume {:captureState "l0000038b"} true;
+    goto $0000038b;
+  $0000038b:
+    assume {:captureState "$0000038b"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     assume {:captureState "%00000391"} true;
     R0, Gamma_R0 := 11bv64, true;
@@ -235,9 +235,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
-    goto l000003ac;
-  l000003ac:
-    assume {:captureState "l000003ac"} true;
+    goto $000003ac;
+  $000003ac:
+    assume {:captureState "$000003ac"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     assume {:captureState "%000003b2"} true;
     R0, Gamma_R0 := 10bv64, true;
@@ -246,9 +246,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
-    goto l000003cd;
-  l000003cd:
-    assume {:captureState "l000003cd"} true;
+    goto $000003cd;
+  $000003cd:
+    assume {:captureState "$000003cd"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     assume {:captureState "%000003d3"} true;
     R0, Gamma_R0 := 9bv64, true;
@@ -278,9 +278,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2280bv64), Gamma_R0;
     R30, Gamma_R30 := 2184bv64, true;
     call printf();
-    goto l00000431;
-  l00000431:
-    assume {:captureState "l00000431"} true;
+    goto $00000431;
+  $00000431:
+    assume {:captureState "$00000431"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := $load$23, Gamma_$load$23;
     call rely();
@@ -291,32 +291,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2304bv64), Gamma_R0;
     R30, Gamma_R30 := 2208bv64, true;
     call printf();
-    goto l00000457;
-  l00000457:
-    assume {:captureState "l00000457"} true;
+    goto $00000457;
+  $00000457:
+    assume {:captureState "$00000457"} true;
     $load$25, Gamma_$load$25 := memory_load32_le(stack, bvadd64(R31, 32bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32($load$25), Gamma_$load$25;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2320bv64), Gamma_R0;
     R30, Gamma_R30 := 2224bv64, true;
     call printf();
-    goto l00000470;
-  l00000470:
-    assume {:captureState "l00000470"} true;
+    goto $00000470;
+  $00000470:
+    assume {:captureState "$00000470"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2232bv64, true;
     call #free();
-    goto l0000047f;
-  l0000047f:
-    assume {:captureState "l0000047f"} true;
+    goto $0000047f;
+  $0000047f:
+    assume {:captureState "$0000047f"} true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := $load$27, Gamma_$load$27;
     R30, Gamma_R30 := 2240bv64, true;
     call #free();
-    goto l0000048d;
-  l0000048d:
-    assume {:captureState "l0000048d"} true;
+    goto $0000048d;
+  $0000048d:
+    assume {:captureState "$0000048d"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$28, Gamma_$load$28 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$28, Gamma_$load$28;

--- a/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
@@ -231,8 +231,8 @@ implementation main()
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
   var Gamma_$load$30: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551536bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 64bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -248,9 +248,9 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2100bv64, true;
     call malloc();
-    goto l000003e9;
-  l000003e9:
-    assume {:captureState "l000003e9"} true;
+    goto $000003e9;
+  $000003e9:
+    assume {:captureState "$000003e9"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     assume {:captureState "%000003ef"} true;
     R8, Gamma_R8 := 11bv64, true;
@@ -261,9 +261,9 @@ implementation main()
     assume {:captureState "%00000409"} true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
-    goto l00000412;
-  l00000412:
-    assume {:captureState "l00000412"} true;
+    goto $00000412;
+  $00000412:
+    assume {:captureState "$00000412"} true;
     R8, Gamma_R8 := R0, Gamma_R0;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R0, Gamma_R0 := $load$19, Gamma_$load$19;
@@ -274,9 +274,9 @@ implementation main()
     assume {:captureState "%00000432"} true;
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
-    goto l0000043b;
-  l0000043b:
-    assume {:captureState "l0000043b"} true;
+    goto $0000043b;
+  $0000043b:
+    assume {:captureState "$0000043b"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     assume {:captureState "%00000441"} true;
     R8, Gamma_R8 := 9bv64, true;
@@ -300,9 +300,9 @@ implementation main()
     R0, Gamma_R0 := $load$22, Gamma_$load$22;
     R30, Gamma_R30 := 2192bv64, true;
     call printCharValue();
-    goto l00000504;
-  l00000504:
-    assume {:captureState "l00000504"} true;
+    goto $00000504;
+  $00000504:
+    assume {:captureState "$00000504"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := $load$23, Gamma_$load$23;
     call rely();
@@ -312,32 +312,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2348bv64), Gamma_R0;
     R30, Gamma_R30 := 2212bv64, true;
     call printf();
-    goto l00000524;
-  l00000524:
-    assume {:captureState "l00000524"} true;
+    goto $00000524;
+  $00000524:
+    assume {:captureState "$00000524"} true;
     $load$25, Gamma_$load$25 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R1, Gamma_R1 := zero_extend32_32($load$25), Gamma_$load$25;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2364bv64), Gamma_R0;
     R30, Gamma_R30 := 2228bv64, true;
     call printf();
-    goto l0000053d;
-  l0000053d:
-    assume {:captureState "l0000053d"} true;
+    goto $0000053d;
+  $0000053d:
+    assume {:captureState "$0000053d"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2236bv64, true;
     call #free();
-    goto l0000054c;
-  l0000054c:
-    assume {:captureState "l0000054c"} true;
+    goto $0000054c;
+  $0000054c:
+    assume {:captureState "$0000054c"} true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := $load$27, Gamma_$load$27;
     R30, Gamma_R30 := 2244bv64, true;
     call #free();
-    goto l0000055a;
-  l0000055a:
-    assume {:captureState "l0000055a"} true;
+    goto $0000055a;
+  $0000055a:
+    assume {:captureState "$0000055a"} true;
     $load$28, Gamma_$load$28 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$28), Gamma_$load$28;
     #7, Gamma_#7 := bvadd64(R31, 64bv64), Gamma_R31;
@@ -452,8 +452,8 @@ implementation printCharValue()
   var Gamma_$load$35: bool;
   var Gamma_$load$36: bool;
   var Gamma_$load$37: bool;
-  lprintCharValue:
-    assume {:captureState "lprintCharValue"} true;
+  $printCharValue:
+    assume {:captureState "$printCharValue"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #5, R29), gamma_store64(Gamma_stack, #5, Gamma_R29);
@@ -482,9 +482,9 @@ implementation printCharValue()
     R0, Gamma_R0 := bvadd64(R0, 2391bv64), Gamma_R0;
     R30, Gamma_R30 := 2312bv64, true;
     call printf();
-    goto l000004e9;
-  l000004e9:
-    assume {:captureState "l000004e9"} true;
+    goto $000004e9;
+  $000004e9:
+    assume {:captureState "$000004e9"} true;
     #6, Gamma_#6 := bvadd64(R31, 16bv64), Gamma_R31;
     $load$36, Gamma_$load$36 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
     R29, Gamma_R29 := $load$36, Gamma_$load$36;

--- a/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
@@ -231,8 +231,8 @@ implementation main()
   var Gamma_$load$26: bool;
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551552bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000003a4"} true;
@@ -243,9 +243,9 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2084bv64, true;
     call malloc();
-    goto l000003c3;
-  l000003c3:
-    assume {:captureState "l000003c3"} true;
+    goto $000003c3;
+  $000003c3:
+    assume {:captureState "$000003c3"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     assume {:captureState "%000003c9"} true;
     R0, Gamma_R0 := 11bv64, true;
@@ -254,9 +254,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
-    goto l000003e4;
-  l000003e4:
-    assume {:captureState "l000003e4"} true;
+    goto $000003e4;
+  $000003e4:
+    assume {:captureState "$000003e4"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     assume {:captureState "%000003ea"} true;
     R0, Gamma_R0 := 10bv64, true;
@@ -265,9 +265,9 @@ implementation main()
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
-    goto l00000405;
-  l00000405:
-    assume {:captureState "l00000405"} true;
+    goto $00000405;
+  $00000405:
+    assume {:captureState "$00000405"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     assume {:captureState "%0000040b"} true;
     R0, Gamma_R0 := 9bv64, true;
@@ -291,9 +291,9 @@ implementation main()
     R0, Gamma_R0 := $load$21, Gamma_$load$21;
     R30, Gamma_R30 := 2168bv64, true;
     call printCharValue();
-    goto l000004db;
-  l000004db:
-    assume {:captureState "l000004db"} true;
+    goto $000004db;
+  $000004db:
+    assume {:captureState "$000004db"} true;
     $load$22, Gamma_$load$22 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := $load$22, Gamma_$load$22;
     call rely();
@@ -304,32 +304,32 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2336bv64), Gamma_R0;
     R30, Gamma_R30 := 2192bv64, true;
     call printf();
-    goto l00000501;
-  l00000501:
-    assume {:captureState "l00000501"} true;
+    goto $00000501;
+  $00000501:
+    assume {:captureState "$00000501"} true;
     $load$24, Gamma_$load$24 := memory_load32_le(stack, bvadd64(R31, 32bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32($load$24), Gamma_$load$24;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2352bv64), Gamma_R0;
     R30, Gamma_R30 := 2208bv64, true;
     call printf();
-    goto l0000051a;
-  l0000051a:
-    assume {:captureState "l0000051a"} true;
+    goto $0000051a;
+  $0000051a:
+    assume {:captureState "$0000051a"} true;
     $load$25, Gamma_$load$25 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := $load$25, Gamma_$load$25;
     R30, Gamma_R30 := 2216bv64, true;
     call #free();
-    goto l00000529;
-  l00000529:
-    assume {:captureState "l00000529"} true;
+    goto $00000529;
+  $00000529:
+    assume {:captureState "$00000529"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2224bv64, true;
     call #free();
-    goto l00000537;
-  l00000537:
-    assume {:captureState "l00000537"} true;
+    goto $00000537;
+  $00000537:
+    assume {:captureState "$00000537"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$27, Gamma_$load$27;
@@ -450,8 +450,8 @@ implementation printCharValue()
   var Gamma_$load$34: bool;
   var Gamma_$load$35: bool;
   var Gamma_$load$36: bool;
-  lprintCharValue:
-    assume {:captureState "lprintCharValue"} true;
+  $printCharValue:
+    assume {:captureState "$printCharValue"} true;
     #5, Gamma_#5 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #5, R29), gamma_store64(Gamma_stack, #5, Gamma_R29);
     assume {:captureState "%0000045a"} true;
@@ -484,9 +484,9 @@ implementation printCharValue()
     R0, Gamma_R0 := bvadd64(R0, 2384bv64), Gamma_R0;
     R30, Gamma_R30 := 2296bv64, true;
     call printf();
-    goto l000004c4;
-  l000004c4:
-    assume {:captureState "l000004c4"} true;
+    goto $000004c4;
+  $000004c4:
+    assume {:captureState "$000004c4"} true;
     $load$35, Gamma_$load$35 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$35, Gamma_$load$35;
     $load$36, Gamma_$load$36 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));

--- a/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
@@ -224,8 +224,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #1, Gamma_#1 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #1, R29), gamma_store64(Gamma_stack, #1, Gamma_R29);
     assume {:captureState "%00000222"} true;
@@ -238,9 +238,9 @@ implementation main()
     assume {:captureState "%0000023f"} true;
     R30, Gamma_R30 := 1812bv64, true;
     call malloc();
-    goto l00000249;
-  l00000249:
-    assume {:captureState "l00000249"} true;
+    goto $00000249;
+  $00000249:
+    assume {:captureState "$00000249"} true;
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
@@ -249,33 +249,33 @@ implementation main()
     R19, Gamma_R19 := R0, Gamma_R0;
     R30, Gamma_R30 := 1828bv64, true;
     call printCharValue();
-    goto l0000029a;
-  l0000029a:
-    assume {:captureState "l0000029a"} true;
+    goto $0000029a;
+  $0000029a:
+    assume {:captureState "$0000029a"} true;
     R2, Gamma_R2 := 42bv64, true;
     R1, Gamma_R1 := 0bv64, true;
     R0, Gamma_R0 := 1bv64, true;
     R1, Gamma_R1 := bvadd64(R1, 2296bv64), Gamma_R1;
     R30, Gamma_R30 := 1848bv64, true;
     call __printf_chk();
-    goto l000002b6;
-  l000002b6:
-    assume {:captureState "l000002b6"} true;
+    goto $000002b6;
+  $000002b6:
+    assume {:captureState "$000002b6"} true;
     R1, Gamma_R1 := 0bv64, true;
     R1, Gamma_R1 := bvadd64(R1, 2312bv64), Gamma_R1;
     R2, Gamma_R2 := 10bv64, true;
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 1868bv64, true;
     call __printf_chk();
-    goto l000002d2;
-  l000002d2:
-    assume {:captureState "l000002d2"} true;
+    goto $000002d2;
+  $000002d2:
+    assume {:captureState "$000002d2"} true;
     R0, Gamma_R0 := R19, Gamma_R19;
     R30, Gamma_R30 := 1876bv64, true;
     call #free();
-    goto l000002e0;
-  l000002e0:
-    assume {:captureState "l000002e0"} true;
+    goto $000002e0;
+  $000002e0:
+    assume {:captureState "$000002e0"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$20, Gamma_$load$20 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R19, Gamma_R19 := $load$20, Gamma_$load$20;
@@ -364,8 +364,8 @@ implementation printCharValue()
 {
   var $load$24: bv8;
   var Gamma_$load$24: bool;
-  lprintCharValue:
-    assume {:captureState "lprintCharValue"} true;
+  $printCharValue:
+    assume {:captureState "$printCharValue"} true;
     R3, Gamma_R3 := R0, Gamma_R0;
     R0, Gamma_R0 := 1bv64, true;
     R1, Gamma_R1 := 0bv64, true;

--- a/src/test/correct/multi_malloc/clang/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang/multi_malloc.expected
@@ -203,8 +203,8 @@ implementation main()
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551568bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 32bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -220,17 +220,17 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2100bv64, true;
     call malloc();
-    goto l00000379;
-  l00000379:
-    assume {:captureState "l00000379"} true;
+    goto $00000379;
+  $00000379:
+    assume {:captureState "$00000379"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     assume {:captureState "%0000037f"} true;
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
-    goto l0000038d;
-  l0000038d:
-    assume {:captureState "l0000038d"} true;
+    goto $0000038d;
+  $0000038d:
+    assume {:captureState "$0000038d"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     assume {:captureState "%00000393"} true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
@@ -256,9 +256,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2236bv64), Gamma_R0;
     R30, Gamma_R30 := 2160bv64, true;
     call printf();
-    goto l000003de;
-  l000003de:
-    assume {:captureState "l000003de"} true;
+    goto $000003de;
+  $000003de:
+    assume {:captureState "$000003de"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := $load$23, Gamma_$load$23;
     call rely();
@@ -268,23 +268,23 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2253bv64), Gamma_R0;
     R30, Gamma_R30 := 2180bv64, true;
     call printf();
-    goto l000003fe;
-  l000003fe:
-    assume {:captureState "l000003fe"} true;
+    goto $000003fe;
+  $000003fe:
+    assume {:captureState "$000003fe"} true;
     $load$25, Gamma_$load$25 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := $load$25, Gamma_$load$25;
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
-    goto l0000040d;
-  l0000040d:
-    assume {:captureState "l0000040d"} true;
+    goto $0000040d;
+  $0000040d:
+    assume {:captureState "$0000040d"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2196bv64, true;
     call #free();
-    goto l0000041b;
-  l0000041b:
-    assume {:captureState "l0000041b"} true;
+    goto $0000041b;
+  $0000041b:
+    assume {:captureState "$0000041b"} true;
     $load$27, Gamma_$load$27 := memory_load32_le(stack, bvadd64(R31, 4bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R0, Gamma_R0 := zero_extend32_32($load$27), Gamma_$load$27;
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;

--- a/src/test/correct/multi_malloc/gcc/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc/multi_malloc.expected
@@ -180,8 +180,8 @@ implementation main()
   var Gamma_$load$26: bool;
   var Gamma_$load$27: bool;
   var Gamma_$load$28: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%00000338"} true;
@@ -192,17 +192,17 @@ implementation main()
     R0, Gamma_R0 := 1bv64, true;
     R30, Gamma_R30 := 2084bv64, true;
     call malloc();
-    goto l00000357;
-  l00000357:
-    assume {:captureState "l00000357"} true;
+    goto $00000357;
+  $00000357:
+    assume {:captureState "$00000357"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     assume {:captureState "%0000035d"} true;
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
-    goto l0000036b;
-  l0000036b:
-    assume {:captureState "l0000036b"} true;
+    goto $0000036b;
+  $0000036b:
+    assume {:captureState "$0000036b"} true;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     assume {:captureState "%00000371"} true;
     $load$19, Gamma_$load$19 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
@@ -229,9 +229,9 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2232bv64), Gamma_R0;
     R30, Gamma_R30 := 2148bv64, true;
     call printf();
-    goto l000003c2;
-  l000003c2:
-    assume {:captureState "l000003c2"} true;
+    goto $000003c2;
+  $000003c2:
+    assume {:captureState "$000003c2"} true;
     $load$23, Gamma_$load$23 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := $load$23, Gamma_$load$23;
     call rely();
@@ -242,23 +242,23 @@ implementation main()
     R0, Gamma_R0 := bvadd64(R0, 2256bv64), Gamma_R0;
     R30, Gamma_R30 := 2172bv64, true;
     call printf();
-    goto l000003e8;
-  l000003e8:
-    assume {:captureState "l000003e8"} true;
+    goto $000003e8;
+  $000003e8:
+    assume {:captureState "$000003e8"} true;
     $load$25, Gamma_$load$25 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := $load$25, Gamma_$load$25;
     R30, Gamma_R30 := 2180bv64, true;
     call #free();
-    goto l000003f7;
-  l000003f7:
-    assume {:captureState "l000003f7"} true;
+    goto $000003f7;
+  $000003f7:
+    assume {:captureState "$000003f7"} true;
     $load$26, Gamma_$load$26 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := $load$26, Gamma_$load$26;
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
-    goto l00000405;
-  l00000405:
-    assume {:captureState "l00000405"} true;
+    goto $00000405;
+  $00000405:
+    assume {:captureState "$00000405"} true;
     R0, Gamma_R0 := 0bv64, true;
     $load$27, Gamma_$load$27 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R29, Gamma_R29 := $load$27, Gamma_$load$27;

--- a/src/test/correct/no_interference_update_x/clang/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang/no_interference_update_x.expected
@@ -85,8 +85,8 @@ procedure main();
 implementation main()
 {
   var y_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 1bv64, true;
     call rely();

--- a/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
@@ -94,8 +94,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var y_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/no_interference_update_x/gcc/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc/no_interference_update_x.expected
@@ -83,8 +83,8 @@ procedure main();
 implementation main()
 {
   var y_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;

--- a/src/test/correct/no_interference_update_x/gcc_O2/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_O2/no_interference_update_x.expected
@@ -85,8 +85,8 @@ procedure main();
 implementation main()
 {
   var y_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := 1bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
@@ -92,8 +92,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var y_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/correct/no_interference_update_y/clang/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang/no_interference_update_y.expected
@@ -85,8 +85,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 1bv64, true;
     call rely();

--- a/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
@@ -94,8 +94,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4048bv64)) || L(mem, bvadd64(R9, 4048bv64)));

--- a/src/test/correct/no_interference_update_y/gcc/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc/no_interference_update_y.expected
@@ -83,8 +83,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;

--- a/src/test/correct/no_interference_update_y/gcc_O2/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_O2/no_interference_update_y.expected
@@ -85,8 +85,8 @@ procedure main();
 implementation main()
 {
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := 1bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
@@ -92,8 +92,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var x_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));

--- a/src/test/correct/secret_write/clang/secret_write.expected
+++ b/src/test/correct/secret_write/clang/secret_write.expected
@@ -110,8 +110,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;
     call rely();

--- a/src/test/correct/secret_write/clang_O2/secret_write.expected
+++ b/src/test/correct/secret_write/clang_O2/secret_write.expected
@@ -102,8 +102,8 @@ implementation main()
 {
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 0bv64, true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;

--- a/src/test/correct/secret_write/clang_pic/secret_write.expected
+++ b/src/test/correct/secret_write/clang_pic/secret_write.expected
@@ -129,8 +129,8 @@ implementation main()
   var Gamma_$load$23: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4024bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4024bv64)) || L(mem, bvadd64(R9, 4024bv64)));

--- a/src/test/correct/secret_write/gcc/secret_write.expected
+++ b/src/test/correct/secret_write/gcc/secret_write.expected
@@ -106,8 +106,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();

--- a/src/test/correct/secret_write/gcc_O2/secret_write.expected
+++ b/src/test/correct/secret_write/gcc_O2/secret_write.expected
@@ -102,8 +102,8 @@ implementation main()
 {
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R3, Gamma_R3 := 2bv64, true;

--- a/src/test/correct/secret_write/gcc_pic/secret_write.expected
+++ b/src/test/correct/secret_write/gcc_pic/secret_write.expected
@@ -135,8 +135,8 @@ implementation main()
   var Gamma_$load$28: bool;
   var Gamma_x_old: bool;
   var z_old: bv32;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4048bv64)) || L(mem, bvadd64(R0, 4048bv64)));

--- a/src/test/correct/switch/clang/switch.expected
+++ b/src/test/correct/switch/clang/switch.expected
@@ -99,8 +99,8 @@ implementation main()
   var Gamma_#5: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
@@ -118,24 +118,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000035a, lmain_goto_l0000035d;
-  l0000035d:
-    assume {:captureState "l0000035d"} true;
+    goto $main_goto_$0000035a, $main_goto_$0000035d;
+  $0000035d:
+    assume {:captureState "$0000035d"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000360;
-  l0000035a:
-    assume {:captureState "l0000035a"} true;
+    goto $00000360;
+  $0000035a:
+    assume {:captureState "$0000035a"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000360;
-  l00000360:
-    assume {:captureState "l00000360"} true;
+    goto $00000360;
+  $00000360:
+    assume {:captureState "$00000360"} true;
     assert Gamma_R8;
-    goto l00000360_goto_l00000368, l00000360_goto_l0000039a;
-  l0000039a:
-    assume {:captureState "l0000039a"} true;
-    goto l0000039b;
-  l0000039b:
-    assume {:captureState "l0000039b"} true;
+    goto $00000360_goto_$00000368, $00000360_goto_$0000039a;
+  $0000039a:
+    assume {:captureState "$0000039a"} true;
+    goto $0000039b;
+  $0000039b:
+    assume {:captureState "$0000039b"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 4bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R8, Gamma_R8 := zero_extend32_32($load$19), Gamma_$load$19;
     #5, Gamma_#5 := bvadd32(R8[32:0], 4294967292bv32), Gamma_R8;
@@ -145,76 +145,76 @@ implementation main()
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#5, 1bv32)), Gamma_#5;
     assert Gamma_ZF;
-    goto l0000039b_goto_l000003c4, l0000039b_goto_l000003c7;
-  l000003c7:
-    assume {:captureState "l000003c7"} true;
+    goto $0000039b_goto_$000003c4, $0000039b_goto_$000003c7;
+  $000003c7:
+    assume {:captureState "$000003c7"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l000003ca;
-  l000003c4:
-    assume {:captureState "l000003c4"} true;
+    goto $000003ca;
+  $000003c4:
+    assume {:captureState "$000003c4"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l000003ca;
-  l000003ca:
-    assume {:captureState "l000003ca"} true;
+    goto $000003ca;
+  $000003ca:
+    assume {:captureState "$000003ca"} true;
     assert Gamma_R8;
-    goto l000003ca_goto_l00000389, l000003ca_goto_l000003d7;
-  l00000389:
-    assume {:captureState "l00000389"} true;
+    goto $000003ca_goto_$00000389, $000003ca_goto_$000003d7;
+  $00000389:
+    assume {:captureState "$00000389"} true;
     R8, Gamma_R8 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%00000394"} true;
-    goto l0000037b;
-  l000003d7:
-    assume {:captureState "l000003d7"} true;
-    goto l000003d8;
-  l000003d8:
-    assume {:captureState "l000003d8"} true;
+    goto $0000037b;
+  $000003d7:
+    assume {:captureState "$000003d7"} true;
+    goto $000003d8;
+  $000003d8:
+    assume {:captureState "$000003d8"} true;
     R8, Gamma_R8 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%000003e6"} true;
-    goto l00000368;
-  l00000368:
-    assume {:captureState "l00000368"} true;
+    goto $00000368;
+  $00000368:
+    assume {:captureState "$00000368"} true;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
     assume {:captureState "%00000378"} true;
-    goto l0000037b;
-  l0000037b:
-    assume {:captureState "l0000037b"} true;
+    goto $0000037b;
+  $0000037b:
+    assume {:captureState "$0000037b"} true;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000035a:
-    assume {:captureState "lmain_goto_l0000035a"} true;
+  $main_goto_$0000035a:
+    assume {:captureState "$main_goto_$0000035a"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000035a;
-  lmain_goto_l0000035d:
-    assume {:captureState "lmain_goto_l0000035d"} true;
+    goto $0000035a;
+  $main_goto_$0000035d:
+    assume {:captureState "$main_goto_$0000035d"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000035d;
-  l00000360_goto_l00000368:
-    assume {:captureState "l00000360_goto_l00000368"} true;
+    goto $0000035d;
+  $00000360_goto_$00000368:
+    assume {:captureState "$00000360_goto_$00000368"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000368;
-  l00000360_goto_l0000039a:
-    assume {:captureState "l00000360_goto_l0000039a"} true;
+    goto $00000368;
+  $00000360_goto_$0000039a:
+    assume {:captureState "$00000360_goto_$0000039a"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000039a;
-  l0000039b_goto_l000003c4:
-    assume {:captureState "l0000039b_goto_l000003c4"} true;
+    goto $0000039a;
+  $0000039b_goto_$000003c4:
+    assume {:captureState "$0000039b_goto_$000003c4"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000003c4;
-  l0000039b_goto_l000003c7:
-    assume {:captureState "l0000039b_goto_l000003c7"} true;
+    goto $000003c4;
+  $0000039b_goto_$000003c7:
+    assume {:captureState "$0000039b_goto_$000003c7"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000003c7;
-  l000003ca_goto_l00000389:
-    assume {:captureState "l000003ca_goto_l00000389"} true;
+    goto $000003c7;
+  $000003ca_goto_$00000389:
+    assume {:captureState "$000003ca_goto_$00000389"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000389;
-  l000003ca_goto_l000003d7:
-    assume {:captureState "l000003ca_goto_l000003d7"} true;
+    goto $00000389;
+  $000003ca_goto_$000003d7:
+    assume {:captureState "$000003ca_goto_$000003d7"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l000003d7;
+    goto $000003d7;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/switch/clang_O2/switch.expected
+++ b/src/test/correct/switch/clang_O2/switch.expected
@@ -53,8 +53,8 @@ procedure main();
 
 implementation main()
 {
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     goto main_basil_return;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;

--- a/src/test/correct/switch/gcc/switch.expected
+++ b/src/test/correct/switch/gcc/switch.expected
@@ -99,8 +99,8 @@ implementation main()
   var Gamma_#5: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
@@ -115,9 +115,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000339, lmain_goto_l0000036b;
-  l0000036b:
-    assume {:captureState "l0000036b"} true;
+    goto $main_goto_$00000339, $main_goto_$0000036b;
+  $0000036b:
+    assume {:captureState "$0000036b"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 8bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     #5, Gamma_#5 := bvadd32(R0[32:0], 4294967292bv32), Gamma_R0;
@@ -126,45 +126,45 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#5, 1bv32), 0bv32), Gamma_#5;
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     assert Gamma_ZF;
-    goto l0000036b_goto_l0000035c, l0000036b_goto_l00000391;
-  l0000035c:
-    assume {:captureState "l0000035c"} true;
+    goto $0000036b_goto_$0000035c, $0000036b_goto_$00000391;
+  $0000035c:
+    assume {:captureState "$0000035c"} true;
     R0, Gamma_R0 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000367"} true;
-    goto l0000034c;
-  l00000391:
-    assume {:captureState "l00000391"} true;
+    goto $0000034c;
+  $00000391:
+    assume {:captureState "$00000391"} true;
     R0, Gamma_R0 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000039c"} true;
-    goto l00000339;
-  l00000339:
-    assume {:captureState "l00000339"} true;
+    goto $00000339;
+  $00000339:
+    assume {:captureState "$00000339"} true;
     R0, Gamma_R0 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000349"} true;
-    goto l0000034c;
-  l0000034c:
-    assume {:captureState "l0000034c"} true;
+    goto $0000034c;
+  $0000034c:
+    assume {:captureState "$0000034c"} true;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000339:
-    assume {:captureState "lmain_goto_l00000339"} true;
+  $main_goto_$00000339:
+    assume {:captureState "$main_goto_$00000339"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000339;
-  lmain_goto_l0000036b:
-    assume {:captureState "lmain_goto_l0000036b"} true;
+    goto $00000339;
+  $main_goto_$0000036b:
+    assume {:captureState "$main_goto_$0000036b"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000036b;
-  l0000036b_goto_l0000035c:
-    assume {:captureState "l0000036b_goto_l0000035c"} true;
+    goto $0000036b;
+  $0000036b_goto_$0000035c:
+    assume {:captureState "$0000036b_goto_$0000035c"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000035c;
-  l0000036b_goto_l00000391:
-    assume {:captureState "l0000036b_goto_l00000391"} true;
+    goto $0000035c;
+  $0000036b_goto_$00000391:
+    assume {:captureState "$0000036b_goto_$00000391"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000391;
+    goto $00000391;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/switch/gcc_O2/switch.expected
+++ b/src/test/correct/switch/gcc_O2/switch.expected
@@ -53,8 +53,8 @@ procedure main();
 
 implementation main()
 {
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     goto main_basil_return;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;

--- a/src/test/correct/syscall/clang/syscall.expected
+++ b/src/test/correct/syscall/clang/syscall.expected
@@ -122,8 +122,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551568bv64), Gamma_R31;
     #4, Gamma_#4 := bvadd64(R31, 32bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
@@ -139,9 +139,9 @@ implementation main()
     assume {:captureState "%0000030d"} true;
     R30, Gamma_R30 := 1904bv64, true;
     call fork();
-    goto l00000317;
-  l00000317:
-    assume {:captureState "l00000317"} true;
+    goto $00000317;
+  $00000317:
+    assume {:captureState "$00000317"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%0000031d"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));

--- a/src/test/correct/syscall/gcc/syscall.expected
+++ b/src/test/correct/syscall/gcc/syscall.expected
@@ -120,8 +120,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     #4, Gamma_#4 := bvadd64(R31, 18446744073709551568bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
     assume {:captureState "%000002d8"} true;
@@ -135,9 +135,9 @@ implementation main()
     assume {:captureState "%000002f8"} true;
     R30, Gamma_R30 := 1896bv64, true;
     call fork();
-    goto l00000302;
-  l00000302:
-    assume {:captureState "l00000302"} true;
+    goto $00000302;
+  $00000302:
+    assume {:captureState "$00000302"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 44bv64), Gamma_R0);
     assume {:captureState "%00000308"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 44bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 44bv64));

--- a/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
@@ -115,8 +115,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f5"} true;
@@ -131,55 +131,55 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000322, lmain_goto_l00000325;
-  l00000325:
-    assume {:captureState "l00000325"} true;
+    goto $main_goto_$00000322, $main_goto_$00000325;
+  $00000325:
+    assume {:captureState "$00000325"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000328;
-  l00000322:
-    assume {:captureState "l00000322"} true;
+    goto $00000328;
+  $00000322:
+    assume {:captureState "$00000322"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000328;
-  l00000328:
-    assume {:captureState "l00000328"} true;
+    goto $00000328;
+  $00000328:
+    assume {:captureState "$00000328"} true;
     assert Gamma_R8;
-    goto l00000328_goto_l00000330, l00000328_goto_l00000358;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $00000328_goto_$00000330, $00000328_goto_$00000358;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%00000340"} true;
-    goto l00000343;
-  l00000358:
-    assume {:captureState "l00000358"} true;
-    goto l00000359;
-  l00000359:
-    assume {:captureState "l00000359"} true;
+    goto $00000343;
+  $00000358:
+    assume {:captureState "$00000358"} true;
+    goto $00000359;
+  $00000359:
+    assume {:captureState "$00000359"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000361"} true;
-    goto l00000343;
-  l00000343:
-    assume {:captureState "l00000343"} true;
+    goto $00000343;
+  $00000343:
+    assume {:captureState "$00000343"} true;
     $load$19, Gamma_$load$19 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$19), Gamma_$load$19;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000322:
-    assume {:captureState "lmain_goto_l00000322"} true;
+  $main_goto_$00000322:
+    assume {:captureState "$main_goto_$00000322"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000322;
-  lmain_goto_l00000325:
-    assume {:captureState "lmain_goto_l00000325"} true;
+    goto $00000322;
+  $main_goto_$00000325:
+    assume {:captureState "$main_goto_$00000325"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000325;
-  l00000328_goto_l00000330:
-    assume {:captureState "l00000328_goto_l00000330"} true;
+    goto $00000325;
+  $00000328_goto_$00000330:
+    assume {:captureState "$00000328_goto_$00000330"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000330;
-  l00000328_goto_l00000358:
-    assume {:captureState "l00000328_goto_l00000358"} true;
+    goto $00000330;
+  $00000328_goto_$00000358:
+    assume {:captureState "$00000328_goto_$00000358"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000358;
+    goto $00000358;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
@@ -99,8 +99,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R8, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 52bv64)) || L(mem, bvadd64(R8, 52bv64)));
@@ -111,26 +111,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002e5, lmain_goto_l000002e8;
-  l000002e8:
-    assume {:captureState "l000002e8"} true;
+    goto $main_goto_$000002e5, $main_goto_$000002e8;
+  $000002e8:
+    assume {:captureState "$000002e8"} true;
     R0, Gamma_R0 := 1bv64, true;
-    goto l000002eb;
-  l000002e5:
-    assume {:captureState "l000002e5"} true;
+    goto $000002eb;
+  $000002e5:
+    assume {:captureState "$000002e5"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l000002eb;
-  l000002eb:
-    assume {:captureState "l000002eb"} true;
+    goto $000002eb;
+  $000002eb:
+    assume {:captureState "$000002eb"} true;
     goto main_basil_return;
-  lmain_goto_l000002e5:
-    assume {:captureState "lmain_goto_l000002e5"} true;
+  $main_goto_$000002e5:
+    assume {:captureState "$main_goto_$000002e5"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l000002e5;
-  lmain_goto_l000002e8:
-    assume {:captureState "lmain_goto_l000002e8"} true;
+    goto $000002e5;
+  $main_goto_$000002e8:
+    assume {:captureState "$main_goto_$000002e8"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l000002e8;
+    goto $000002e8;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
@@ -124,8 +124,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f9"} true;
@@ -143,55 +143,55 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l0000032d, lmain_goto_l00000330;
-  l00000330:
-    assume {:captureState "l00000330"} true;
+    goto $main_goto_$0000032d, $main_goto_$00000330;
+  $00000330:
+    assume {:captureState "$00000330"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000333;
-  l0000032d:
-    assume {:captureState "l0000032d"} true;
+    goto $00000333;
+  $0000032d:
+    assume {:captureState "$0000032d"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000333;
-  l00000333:
-    assume {:captureState "l00000333"} true;
+    goto $00000333;
+  $00000333:
+    assume {:captureState "$00000333"} true;
     assert Gamma_R8;
-    goto l00000333_goto_l0000033b, l00000333_goto_l00000363;
-  l0000033b:
-    assume {:captureState "l0000033b"} true;
+    goto $00000333_goto_$0000033b, $00000333_goto_$00000363;
+  $0000033b:
+    assume {:captureState "$0000033b"} true;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
     assume {:captureState "%0000034b"} true;
-    goto l0000034e;
-  l00000363:
-    assume {:captureState "l00000363"} true;
-    goto l00000364;
-  l00000364:
-    assume {:captureState "l00000364"} true;
+    goto $0000034e;
+  $00000363:
+    assume {:captureState "$00000363"} true;
+    goto $00000364;
+  $00000364:
+    assume {:captureState "$00000364"} true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%0000036c"} true;
-    goto l0000034e;
-  l0000034e:
-    assume {:captureState "l0000034e"} true;
+    goto $0000034e;
+  $0000034e:
+    assume {:captureState "$0000034e"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l0000032d:
-    assume {:captureState "lmain_goto_l0000032d"} true;
+  $main_goto_$0000032d:
+    assume {:captureState "$main_goto_$0000032d"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l0000032d;
-  lmain_goto_l00000330:
-    assume {:captureState "lmain_goto_l00000330"} true;
+    goto $0000032d;
+  $main_goto_$00000330:
+    assume {:captureState "$main_goto_$00000330"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000330;
-  l00000333_goto_l0000033b:
-    assume {:captureState "l00000333_goto_l0000033b"} true;
+    goto $00000330;
+  $00000333_goto_$0000033b:
+    assume {:captureState "$00000333_goto_$0000033b"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000033b;
-  l00000333_goto_l00000363:
-    assume {:captureState "l00000333_goto_l00000363"} true;
+    goto $0000033b;
+  $00000333_goto_$00000363:
+    assume {:captureState "$00000333_goto_$00000363"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000363;
+    goto $00000363;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
@@ -97,8 +97,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
@@ -110,26 +110,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002fa, lmain_goto_l00000309;
-  l000002fa:
-    assume {:captureState "l000002fa"} true;
+    goto $main_goto_$000002fa, $main_goto_$00000309;
+  $000002fa:
+    assume {:captureState "$000002fa"} true;
     R0, Gamma_R0 := 1bv64, true;
-    goto l00000304;
-  l00000309:
-    assume {:captureState "l00000309"} true;
+    goto $00000304;
+  $00000309:
+    assume {:captureState "$00000309"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000304;
-  l00000304:
-    assume {:captureState "l00000304"} true;
+    goto $00000304;
+  $00000304:
+    assume {:captureState "$00000304"} true;
     goto main_basil_return;
-  lmain_goto_l000002fa:
-    assume {:captureState "lmain_goto_l000002fa"} true;
+  $main_goto_$000002fa:
+    assume {:captureState "$main_goto_$000002fa"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002fa;
-  lmain_goto_l00000309:
-    assume {:captureState "lmain_goto_l00000309"} true;
+    goto $000002fa;
+  $main_goto_$00000309:
+    assume {:captureState "$main_goto_$00000309"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000309;
+    goto $00000309;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
@@ -106,8 +106,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -121,26 +121,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000002fb, lmain_goto_l0000030a;
-  l000002fb:
-    assume {:captureState "l000002fb"} true;
+    goto $main_goto_$000002fb, $main_goto_$0000030a;
+  $000002fb:
+    assume {:captureState "$000002fb"} true;
     R0, Gamma_R0 := 1bv64, true;
-    goto l00000305;
-  l0000030a:
-    assume {:captureState "l0000030a"} true;
+    goto $00000305;
+  $0000030a:
+    assume {:captureState "$0000030a"} true;
     R0, Gamma_R0 := 0bv64, true;
-    goto l00000305;
-  l00000305:
-    assume {:captureState "l00000305"} true;
+    goto $00000305;
+  $00000305:
+    assume {:captureState "$00000305"} true;
     goto main_basil_return;
-  lmain_goto_l000002fb:
-    assume {:captureState "lmain_goto_l000002fb"} true;
+  $main_goto_$000002fb:
+    assume {:captureState "$main_goto_$000002fb"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000002fb;
-  lmain_goto_l0000030a:
-    assume {:captureState "lmain_goto_l0000030a"} true;
+    goto $000002fb;
+  $main_goto_$0000030a:
+    assume {:captureState "$main_goto_$0000030a"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000030a;
+    goto $0000030a;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/correct/using_gamma_write_z/clang/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang/using_gamma_write_z.expected
@@ -89,8 +89,8 @@ procedure main();
 implementation main()
 {
   var Gamma_x_old: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 69632bv64, true;
     R8, Gamma_R8 := 1bv64, true;
     call rely();

--- a/src/test/correct/using_gamma_write_z/clang_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang_pic/using_gamma_write_z.expected
@@ -98,8 +98,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var Gamma_x_old: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R9, Gamma_R9 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));

--- a/src/test/correct/using_gamma_write_z/gcc/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc/using_gamma_write_z.expected
@@ -87,8 +87,8 @@ procedure main();
 implementation main()
 {
   var Gamma_x_old: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     R1, Gamma_R1 := 1bv64, true;

--- a/src/test/correct/using_gamma_write_z/gcc_O2/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc_O2/using_gamma_write_z.expected
@@ -89,8 +89,8 @@ procedure main();
 implementation main()
 {
   var Gamma_x_old: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := 1bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/correct/using_gamma_write_z/gcc_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc_pic/using_gamma_write_z.expected
@@ -96,8 +96,8 @@ implementation main()
   var $load$18: bv64;
   var Gamma_$load$18: bool;
   var Gamma_x_old: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));

--- a/src/test/incorrect/basicassign/clang/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang/basicassign.expected
@@ -97,8 +97,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R10, Gamma_R10 := 69632bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load32_le(mem, bvadd64(R10, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R10, 52bv64)) || L(mem, bvadd64(R10, 52bv64)));

--- a/src/test/incorrect/basicassign/clang_O2/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang_O2/basicassign.expected
@@ -89,8 +89,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;
     R9, Gamma_R9 := 69632bv64, true;

--- a/src/test/incorrect/basicassign/clang_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang_pic/basicassign.expected
@@ -116,8 +116,8 @@ implementation main()
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));

--- a/src/test/incorrect/basicassign/gcc/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc/basicassign.expected
@@ -91,8 +91,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 28bv64), Gamma_R0;
     call rely();

--- a/src/test/incorrect/basicassign/gcc_O2/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc_O2/basicassign.expected
@@ -89,8 +89,8 @@ implementation main()
   var $load$18: bv32;
   var Gamma_#1: bool;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R2, Gamma_R2 := 69632bv64, true;
     R1, Gamma_R1 := bvadd64(R2, 20bv64), Gamma_R2;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign/gcc_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc_pic/basicassign.expected
@@ -122,8 +122,8 @@ implementation main()
   var Gamma_$load$28: bool;
   var Gamma_$load$29: bool;
   var Gamma_$load$30: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$18, Gamma_$load$18 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));

--- a/src/test/incorrect/basicassign1/clang/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang/basicassign1.expected
@@ -93,8 +93,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign1/clang_O2/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang_O2/basicassign1.expected
@@ -79,8 +79,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign1/clang_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang_pic/basicassign1.expected
@@ -107,8 +107,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign1/gcc/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc/basicassign1.expected
@@ -89,8 +89,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;

--- a/src/test/incorrect/basicassign1/gcc_O2/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc_O2/basicassign1.expected
@@ -79,8 +79,8 @@ implementation main()
 {
   var $load$18: bv32;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 20bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign1/gcc_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc_pic/basicassign1.expected
@@ -107,8 +107,8 @@ implementation main()
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign2/clang/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang/basicassign2.expected
@@ -94,8 +94,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign2/clang_O2/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang_O2/basicassign2.expected
@@ -80,8 +80,8 @@ implementation main()
 {
   var $load$18: bv64;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign2/clang_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang_pic/basicassign2.expected
@@ -104,8 +104,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign2/gcc/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc/basicassign2.expected
@@ -90,8 +90,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 32bv64), Gamma_R0;

--- a/src/test/incorrect/basicassign2/gcc_O2/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc_O2/basicassign2.expected
@@ -80,8 +80,8 @@ implementation main()
 {
   var $load$18: bv64;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 24bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign2/gcc_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc_pic/basicassign2.expected
@@ -104,8 +104,8 @@ implementation main()
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign3/clang/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang/basicassign3.expected
@@ -99,8 +99,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign3/clang_O2/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang_O2/basicassign3.expected
@@ -85,8 +85,8 @@ implementation main()
 {
   var $load$18: bv8;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R8, Gamma_R8 := 69632bv64, true;
     R9, Gamma_R9 := 69632bv64, true;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign3/clang_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang_pic/basicassign3.expected
@@ -113,8 +113,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/basicassign3/gcc/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc/basicassign3.expected
@@ -95,8 +95,8 @@ implementation main()
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 18bv64), Gamma_R0;

--- a/src/test/incorrect/basicassign3/gcc_O2/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc_O2/basicassign3.expected
@@ -85,8 +85,8 @@ implementation main()
 {
   var $load$18: bv8;
   var Gamma_$load$18: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R1, Gamma_R1 := 69632bv64, true;
     R2, Gamma_R2 := bvadd64(R1, 17bv64), Gamma_R1;
     R0, Gamma_R0 := 0bv64, true;

--- a/src/test/incorrect/basicassign3/gcc_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc_pic/basicassign3.expected
@@ -113,8 +113,8 @@ implementation main()
   var Gamma_$load$23: bool;
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();

--- a/src/test/incorrect/iflocal/clang/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang/iflocal.expected
@@ -99,8 +99,8 @@ implementation main()
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
   var Gamma_$load$20: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%000002f5"} true;
@@ -119,50 +119,50 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000334, lmain_goto_l00000337;
-  l00000337:
-    assume {:captureState "l00000337"} true;
+    goto $main_goto_$00000334, $main_goto_$00000337;
+  $00000337:
+    assume {:captureState "$00000337"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000033a;
-  l00000334:
-    assume {:captureState "l00000334"} true;
+    goto $0000033a;
+  $00000334:
+    assume {:captureState "$00000334"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000033a;
-  l0000033a:
-    assume {:captureState "l0000033a"} true;
+    goto $0000033a;
+  $0000033a:
+    assume {:captureState "$0000033a"} true;
     assert Gamma_R8;
-    goto l0000033a_goto_l00000342, l0000033a_goto_l00000359;
-  l00000359:
-    assume {:captureState "l00000359"} true;
-    goto l0000035a;
-  l0000035a:
-    assume {:captureState "l0000035a"} true;
+    goto $0000033a_goto_$00000342, $0000033a_goto_$00000359;
+  $00000359:
+    assume {:captureState "$00000359"} true;
+    goto $0000035a;
+  $0000035a:
+    assume {:captureState "$0000035a"} true;
     R8, Gamma_R8 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
     assume {:captureState "%00000368"} true;
-    goto l00000342;
-  l00000342:
-    assume {:captureState "l00000342"} true;
+    goto $00000342;
+  $00000342:
+    assume {:captureState "$00000342"} true;
     $load$20, Gamma_$load$20 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$20), Gamma_$load$20;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000334:
-    assume {:captureState "lmain_goto_l00000334"} true;
+  $main_goto_$00000334:
+    assume {:captureState "$main_goto_$00000334"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000334;
-  lmain_goto_l00000337:
-    assume {:captureState "lmain_goto_l00000337"} true;
+    goto $00000334;
+  $main_goto_$00000337:
+    assume {:captureState "$main_goto_$00000337"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000337;
-  l0000033a_goto_l00000342:
-    assume {:captureState "l0000033a_goto_l00000342"} true;
+    goto $00000337;
+  $0000033a_goto_$00000342:
+    assume {:captureState "$0000033a_goto_$00000342"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000342;
-  l0000033a_goto_l00000359:
-    assume {:captureState "l0000033a_goto_l00000359"} true;
+    goto $00000342;
+  $0000033a_goto_$00000359:
+    assume {:captureState "$0000033a_goto_$00000359"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000359;
+    goto $00000359;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/incorrect/iflocal/gcc/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc/iflocal.expected
@@ -95,8 +95,8 @@ implementation main()
   var Gamma_#4: bool;
   var Gamma_$load$18: bool;
   var Gamma_$load$19: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%000002e6"} true;
@@ -112,26 +112,26 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000318, lmain_goto_l0000032d;
-  l0000032d:
-    assume {:captureState "l0000032d"} true;
+    goto $main_goto_$00000318, $main_goto_$0000032d;
+  $0000032d:
+    assume {:captureState "$0000032d"} true;
     R0, Gamma_R0 := 1bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000338"} true;
-    goto l00000318;
-  l00000318:
-    assume {:captureState "l00000318"} true;
+    goto $00000318;
+  $00000318:
+    assume {:captureState "$00000318"} true;
     R0, Gamma_R0 := 0bv64, true;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000318:
-    assume {:captureState "lmain_goto_l00000318"} true;
+  $main_goto_$00000318:
+    assume {:captureState "$main_goto_$00000318"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000318;
-  lmain_goto_l0000032d:
-    assume {:captureState "lmain_goto_l0000032d"} true;
+    goto $00000318;
+  $main_goto_$0000032d:
+    assume {:captureState "$main_goto_$0000032d"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000032d;
+    goto $0000032d;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/incorrect/nestedifglobal/clang/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang/nestedifglobal.expected
@@ -115,8 +115,8 @@ implementation main()
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
   var Gamma_$load$23: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
     assume {:captureState "%00000345"} true;
@@ -141,30 +141,30 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000390, lmain_goto_l00000393;
-  l00000393:
-    assume {:captureState "l00000393"} true;
+    goto $main_goto_$00000390, $main_goto_$00000393;
+  $00000393:
+    assume {:captureState "$00000393"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l00000396;
-  l00000390:
-    assume {:captureState "l00000390"} true;
+    goto $00000396;
+  $00000390:
+    assume {:captureState "$00000390"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l00000396;
-  l00000396:
-    assume {:captureState "l00000396"} true;
+    goto $00000396;
+  $00000396:
+    assume {:captureState "$00000396"} true;
     assert Gamma_R8;
-    goto l00000396_goto_l0000039e, l00000396_goto_l0000045d;
-  l0000045d:
-    assume {:captureState "l0000045d"} true;
-    goto l0000045e;
-  l0000045e:
-    assume {:captureState "l0000045e"} true;
+    goto $00000396_goto_$0000039e, $00000396_goto_$0000045d;
+  $0000045d:
+    assume {:captureState "$0000045d"} true;
+    goto $0000045e;
+  $0000045e:
+    assume {:captureState "$0000045e"} true;
     R8, Gamma_R8 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
     assume {:captureState "%0000046c"} true;
-    goto l0000039e;
-  l0000039e:
-    assume {:captureState "l0000039e"} true;
+    goto $0000039e;
+  $0000039e:
+    assume {:captureState "$0000039e"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$20, Gamma_$load$20 := memory_load32_le(mem, bvadd64(R8, 52bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 52bv64)) || L(mem, bvadd64(R8, 52bv64)));
@@ -176,30 +176,30 @@ implementation main()
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#5, 1bv32)), Gamma_#5;
     assert Gamma_ZF;
-    goto l0000039e_goto_l000003ce, l0000039e_goto_l000003d1;
-  l000003d1:
-    assume {:captureState "l000003d1"} true;
+    goto $0000039e_goto_$000003ce, $0000039e_goto_$000003d1;
+  $000003d1:
+    assume {:captureState "$000003d1"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l000003d4;
-  l000003ce:
-    assume {:captureState "l000003ce"} true;
+    goto $000003d4;
+  $000003ce:
+    assume {:captureState "$000003ce"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l000003d4;
-  l000003d4:
-    assume {:captureState "l000003d4"} true;
+    goto $000003d4;
+  $000003d4:
+    assume {:captureState "$000003d4"} true;
     assert Gamma_R8;
-    goto l000003d4_goto_l000003dc, l000003d4_goto_l00000448;
-  l00000448:
-    assume {:captureState "l00000448"} true;
-    goto l00000449;
-  l00000449:
-    assume {:captureState "l00000449"} true;
+    goto $000003d4_goto_$000003dc, $000003d4_goto_$00000448;
+  $00000448:
+    assume {:captureState "$00000448"} true;
+    goto $00000449;
+  $00000449:
+    assume {:captureState "$00000449"} true;
     R8, Gamma_R8 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
     assume {:captureState "%00000457"} true;
-    goto l000003dc;
-  l000003dc:
-    assume {:captureState "l000003dc"} true;
+    goto $000003dc;
+  $000003dc:
+    assume {:captureState "$000003dc"} true;
     $load$21, Gamma_$load$21 := memory_load32_le(stack, bvadd64(R31, 4bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R8, Gamma_R8 := zero_extend32_32($load$21), Gamma_$load$21;
     #6, Gamma_#6 := bvadd32(R8[32:0], 4294967292bv32), Gamma_R8;
@@ -209,85 +209,85 @@ implementation main()
     NF, Gamma_NF := bvadd32(#6, 1bv32)[32:31], Gamma_#6;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#6, 1bv32)), Gamma_#6;
     assert Gamma_ZF;
-    goto l000003dc_goto_l00000407, l000003dc_goto_l0000040a;
-  l0000040a:
-    assume {:captureState "l0000040a"} true;
+    goto $000003dc_goto_$00000407, $000003dc_goto_$0000040a;
+  $0000040a:
+    assume {:captureState "$0000040a"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000040d;
-  l00000407:
-    assume {:captureState "l00000407"} true;
+    goto $0000040d;
+  $00000407:
+    assume {:captureState "$00000407"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000040d;
-  l0000040d:
-    assume {:captureState "l0000040d"} true;
+    goto $0000040d;
+  $0000040d:
+    assume {:captureState "$0000040d"} true;
     assert Gamma_R8;
-    goto l0000040d_goto_l00000415, l0000040d_goto_l0000042c;
-  l0000042c:
-    assume {:captureState "l0000042c"} true;
-    goto l0000042d;
-  l0000042d:
-    assume {:captureState "l0000042d"} true;
+    goto $0000040d_goto_$00000415, $0000040d_goto_$0000042c;
+  $0000042c:
+    assume {:captureState "$0000042c"} true;
+    goto $0000042d;
+  $0000042d:
+    assume {:captureState "$0000042d"} true;
     R8, Gamma_R8 := 69632bv64, true;
     call rely();
     $load$22, Gamma_$load$22 := memory_load32_le(mem, bvadd64(R8, 56bv64)), (gamma_load32(Gamma_mem, bvadd64(R8, 56bv64)) || L(mem, bvadd64(R8, 56bv64)));
     R8, Gamma_R8 := zero_extend32_32($load$22), Gamma_$load$22;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
     assume {:captureState "%00000442"} true;
-    goto l00000415;
-  l00000415:
-    assume {:captureState "l00000415"} true;
+    goto $00000415;
+  $00000415:
+    assume {:captureState "$00000415"} true;
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 12bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     R0, Gamma_R0 := zero_extend32_32($load$23), Gamma_$load$23;
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000390:
-    assume {:captureState "lmain_goto_l00000390"} true;
+  $main_goto_$00000390:
+    assume {:captureState "$main_goto_$00000390"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000390;
-  lmain_goto_l00000393:
-    assume {:captureState "lmain_goto_l00000393"} true;
+    goto $00000390;
+  $main_goto_$00000393:
+    assume {:captureState "$main_goto_$00000393"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000393;
-  l00000396_goto_l0000039e:
-    assume {:captureState "l00000396_goto_l0000039e"} true;
+    goto $00000393;
+  $00000396_goto_$0000039e:
+    assume {:captureState "$00000396_goto_$0000039e"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l0000039e;
-  l00000396_goto_l0000045d:
-    assume {:captureState "l00000396_goto_l0000045d"} true;
+    goto $0000039e;
+  $00000396_goto_$0000045d:
+    assume {:captureState "$00000396_goto_$0000045d"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000045d;
-  l0000039e_goto_l000003ce:
-    assume {:captureState "l0000039e_goto_l000003ce"} true;
+    goto $0000045d;
+  $0000039e_goto_$000003ce:
+    assume {:captureState "$0000039e_goto_$000003ce"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000003ce;
-  l0000039e_goto_l000003d1:
-    assume {:captureState "l0000039e_goto_l000003d1"} true;
+    goto $000003ce;
+  $0000039e_goto_$000003d1:
+    assume {:captureState "$0000039e_goto_$000003d1"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000003d1;
-  l000003d4_goto_l000003dc:
-    assume {:captureState "l000003d4_goto_l000003dc"} true;
+    goto $000003d1;
+  $000003d4_goto_$000003dc:
+    assume {:captureState "$000003d4_goto_$000003dc"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l000003dc;
-  l000003d4_goto_l00000448:
-    assume {:captureState "l000003d4_goto_l00000448"} true;
+    goto $000003dc;
+  $000003d4_goto_$00000448:
+    assume {:captureState "$000003d4_goto_$00000448"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000448;
-  l000003dc_goto_l00000407:
-    assume {:captureState "l000003dc_goto_l00000407"} true;
+    goto $00000448;
+  $000003dc_goto_$00000407:
+    assume {:captureState "$000003dc_goto_$00000407"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000407;
-  l000003dc_goto_l0000040a:
-    assume {:captureState "l000003dc_goto_l0000040a"} true;
+    goto $00000407;
+  $000003dc_goto_$0000040a:
+    assume {:captureState "$000003dc_goto_$0000040a"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l0000040a;
-  l0000040d_goto_l00000415:
-    assume {:captureState "l0000040d_goto_l00000415"} true;
+    goto $0000040a;
+  $0000040d_goto_$00000415:
+    assume {:captureState "$0000040d_goto_$00000415"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000415;
-  l0000040d_goto_l0000042c:
-    assume {:captureState "l0000040d_goto_l0000042c"} true;
+    goto $00000415;
+  $0000040d_goto_$0000042c:
+    assume {:captureState "$0000040d_goto_$0000042c"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000042c;
+    goto $0000042c;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
@@ -139,8 +139,8 @@ implementation main()
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
   var Gamma_$load$26: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
@@ -170,30 +170,30 @@ implementation main()
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l000003ab, lmain_goto_l000003ae;
-  l000003ae:
-    assume {:captureState "l000003ae"} true;
+    goto $main_goto_$000003ab, $main_goto_$000003ae;
+  $000003ae:
+    assume {:captureState "$000003ae"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l000003b1;
-  l000003ab:
-    assume {:captureState "l000003ab"} true;
+    goto $000003b1;
+  $000003ab:
+    assume {:captureState "$000003ab"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l000003b1;
-  l000003b1:
-    assume {:captureState "l000003b1"} true;
+    goto $000003b1;
+  $000003b1:
+    assume {:captureState "$000003b1"} true;
     assert Gamma_R8;
-    goto l000003b1_goto_l000003b9, l000003b1_goto_l00000481;
-  l00000481:
-    assume {:captureState "l00000481"} true;
-    goto l00000482;
-  l00000482:
-    assume {:captureState "l00000482"} true;
+    goto $000003b1_goto_$000003b9, $000003b1_goto_$00000481;
+  $00000481:
+    assume {:captureState "$00000481"} true;
+    goto $00000482;
+  $00000482:
+    assume {:captureState "$00000482"} true;
     R8, Gamma_R8 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 20bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 20bv64), Gamma_R8);
     assume {:captureState "%00000490"} true;
-    goto l000003b9;
-  l000003b9:
-    assume {:captureState "l000003b9"} true;
+    goto $000003b9;
+  $000003b9:
+    assume {:captureState "$000003b9"} true;
     $load$21, Gamma_$load$21 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := $load$21, Gamma_$load$21;
     call rely();
@@ -206,30 +206,30 @@ implementation main()
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#5, 1bv32)), Gamma_#5;
     assert Gamma_ZF;
-    goto l000003b9_goto_l000003eb, l000003b9_goto_l000003ee;
-  l000003ee:
-    assume {:captureState "l000003ee"} true;
+    goto $000003b9_goto_$000003eb, $000003b9_goto_$000003ee;
+  $000003ee:
+    assume {:captureState "$000003ee"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l000003f1;
-  l000003eb:
-    assume {:captureState "l000003eb"} true;
+    goto $000003f1;
+  $000003eb:
+    assume {:captureState "$000003eb"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l000003f1;
-  l000003f1:
-    assume {:captureState "l000003f1"} true;
+    goto $000003f1;
+  $000003f1:
+    assume {:captureState "$000003f1"} true;
     assert Gamma_R8;
-    goto l000003f1_goto_l000003f9, l000003f1_goto_l0000046c;
-  l0000046c:
-    assume {:captureState "l0000046c"} true;
-    goto l0000046d;
-  l0000046d:
-    assume {:captureState "l0000046d"} true;
+    goto $000003f1_goto_$000003f9, $000003f1_goto_$0000046c;
+  $0000046c:
+    assume {:captureState "$0000046c"} true;
+    goto $0000046d;
+  $0000046d:
+    assume {:captureState "$0000046d"} true;
     R8, Gamma_R8 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 20bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 20bv64), Gamma_R8);
     assume {:captureState "%0000047b"} true;
-    goto l000003f9;
-  l000003f9:
-    assume {:captureState "l000003f9"} true;
+    goto $000003f9;
+  $000003f9:
+    assume {:captureState "$000003f9"} true;
     $load$23, Gamma_$load$23 := memory_load32_le(stack, bvadd64(R31, 20bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 20bv64));
     R8, Gamma_R8 := zero_extend32_32($load$23), Gamma_$load$23;
     #6, Gamma_#6 := bvadd32(R8[32:0], 4294967292bv32), Gamma_R8;
@@ -239,24 +239,24 @@ implementation main()
     NF, Gamma_NF := bvadd32(#6, 1bv32)[32:31], Gamma_#6;
     R8, Gamma_R8 := zero_extend32_32(bvadd32(#6, 1bv32)), Gamma_#6;
     assert Gamma_ZF;
-    goto l000003f9_goto_l00000424, l000003f9_goto_l00000427;
-  l00000427:
-    assume {:captureState "l00000427"} true;
+    goto $000003f9_goto_$00000424, $000003f9_goto_$00000427;
+  $00000427:
+    assume {:captureState "$00000427"} true;
     R8, Gamma_R8 := 1bv64, true;
-    goto l0000042a;
-  l00000424:
-    assume {:captureState "l00000424"} true;
+    goto $0000042a;
+  $00000424:
+    assume {:captureState "$00000424"} true;
     R8, Gamma_R8 := 0bv64, true;
-    goto l0000042a;
-  l0000042a:
-    assume {:captureState "l0000042a"} true;
+    goto $0000042a;
+  $0000042a:
+    assume {:captureState "$0000042a"} true;
     assert Gamma_R8;
-    goto l0000042a_goto_l00000432, l0000042a_goto_l00000449;
-  l00000449:
-    assume {:captureState "l00000449"} true;
-    goto l0000044a;
-  l0000044a:
-    assume {:captureState "l0000044a"} true;
+    goto $0000042a_goto_$00000432, $0000042a_goto_$00000449;
+  $00000449:
+    assume {:captureState "$00000449"} true;
+    goto $0000044a;
+  $0000044a:
+    assume {:captureState "$0000044a"} true;
     R8, Gamma_R8 := 65536bv64, true;
     call rely();
     $load$24, Gamma_$load$24 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
@@ -266,61 +266,61 @@ implementation main()
     R8, Gamma_R8 := zero_extend32_32($load$25), Gamma_$load$25;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 20bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 20bv64), Gamma_R8);
     assume {:captureState "%00000466"} true;
-    goto l00000432;
-  l00000432:
-    assume {:captureState "l00000432"} true;
+    goto $00000432;
+  $00000432:
+    assume {:captureState "$00000432"} true;
     $load$26, Gamma_$load$26 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := zero_extend32_32($load$26), Gamma_$load$26;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l000003ab:
-    assume {:captureState "lmain_goto_l000003ab"} true;
+  $main_goto_$000003ab:
+    assume {:captureState "$main_goto_$000003ab"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000003ab;
-  lmain_goto_l000003ae:
-    assume {:captureState "lmain_goto_l000003ae"} true;
+    goto $000003ab;
+  $main_goto_$000003ae:
+    assume {:captureState "$main_goto_$000003ae"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000003ae;
-  l000003b1_goto_l000003b9:
-    assume {:captureState "l000003b1_goto_l000003b9"} true;
+    goto $000003ae;
+  $000003b1_goto_$000003b9:
+    assume {:captureState "$000003b1_goto_$000003b9"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l000003b9;
-  l000003b1_goto_l00000481:
-    assume {:captureState "l000003b1_goto_l00000481"} true;
+    goto $000003b9;
+  $000003b1_goto_$00000481:
+    assume {:captureState "$000003b1_goto_$00000481"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000481;
-  l000003b9_goto_l000003eb:
-    assume {:captureState "l000003b9_goto_l000003eb"} true;
+    goto $00000481;
+  $000003b9_goto_$000003eb:
+    assume {:captureState "$000003b9_goto_$000003eb"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l000003eb;
-  l000003b9_goto_l000003ee:
-    assume {:captureState "l000003b9_goto_l000003ee"} true;
+    goto $000003eb;
+  $000003b9_goto_$000003ee:
+    assume {:captureState "$000003b9_goto_$000003ee"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l000003ee;
-  l000003f1_goto_l000003f9:
-    assume {:captureState "l000003f1_goto_l000003f9"} true;
+    goto $000003ee;
+  $000003f1_goto_$000003f9:
+    assume {:captureState "$000003f1_goto_$000003f9"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l000003f9;
-  l000003f1_goto_l0000046c:
-    assume {:captureState "l000003f1_goto_l0000046c"} true;
+    goto $000003f9;
+  $000003f1_goto_$0000046c:
+    assume {:captureState "$000003f1_goto_$0000046c"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l0000046c;
-  l000003f9_goto_l00000424:
-    assume {:captureState "l000003f9_goto_l00000424"} true;
+    goto $0000046c;
+  $000003f9_goto_$00000424:
+    assume {:captureState "$000003f9_goto_$00000424"} true;
     assume (bvcomp1(ZF, 1bv1) != 0bv1);
-    goto l00000424;
-  l000003f9_goto_l00000427:
-    assume {:captureState "l000003f9_goto_l00000427"} true;
+    goto $00000424;
+  $000003f9_goto_$00000427:
+    assume {:captureState "$000003f9_goto_$00000427"} true;
     assume (bvcomp1(ZF, 1bv1) == 0bv1);
-    goto l00000427;
-  l0000042a_goto_l00000432:
-    assume {:captureState "l0000042a_goto_l00000432"} true;
+    goto $00000427;
+  $0000042a_goto_$00000432:
+    assume {:captureState "$0000042a_goto_$00000432"} true;
     assume (bvcomp1(R8[1:0], 1bv1) != 0bv1);
-    goto l00000432;
-  l0000042a_goto_l00000449:
-    assume {:captureState "l0000042a_goto_l00000449"} true;
+    goto $00000432;
+  $0000042a_goto_$00000449:
+    assume {:captureState "$0000042a_goto_$00000449"} true;
     assume (bvcomp1(R8[1:0], 1bv1) == 0bv1);
-    goto l00000449;
+    goto $00000449;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/incorrect/nestedifglobal/gcc/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/gcc/nestedifglobal.expected
@@ -111,8 +111,8 @@ implementation main()
   var Gamma_$load$20: bool;
   var Gamma_$load$21: bool;
   var Gamma_$load$22: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000332"} true;
@@ -137,15 +137,15 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000381, lmain_goto_l00000414;
-  l00000414:
-    assume {:captureState "l00000414"} true;
+    goto $main_goto_$00000381, $main_goto_$00000414;
+  $00000414:
+    assume {:captureState "$00000414"} true;
     R0, Gamma_R0 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%0000041f"} true;
-    goto l00000381;
-  l00000381:
-    assume {:captureState "l00000381"} true;
+    goto $00000381;
+  $00000381:
+    assume {:captureState "$00000381"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
     call rely();
@@ -157,15 +157,15 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#5, 1bv32), 0bv32), Gamma_#5;
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     assert Gamma_ZF;
-    goto l00000381_goto_l000003b2, l00000381_goto_l00000407;
-  l00000407:
-    assume {:captureState "l00000407"} true;
+    goto $00000381_goto_$000003b2, $00000381_goto_$00000407;
+  $00000407:
+    assume {:captureState "$00000407"} true;
     R0, Gamma_R0 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000412"} true;
-    goto l000003b2;
-  l000003b2:
-    assume {:captureState "l000003b2"} true;
+    goto $000003b2;
+  $000003b2:
+    assume {:captureState "$000003b2"} true;
     $load$21, Gamma_$load$21 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := zero_extend32_32($load$21), Gamma_$load$21;
     #6, Gamma_#6 := bvadd32(R0[32:0], 4294967292bv32), Gamma_R0;
@@ -174,9 +174,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#6, 1bv32), 0bv32), Gamma_#6;
     NF, Gamma_NF := bvadd32(#6, 1bv32)[32:31], Gamma_#6;
     assert Gamma_ZF;
-    goto l000003b2_goto_l000003d8, l000003b2_goto_l000003ed;
-  l000003ed:
-    assume {:captureState "l000003ed"} true;
+    goto $000003b2_goto_$000003d8, $000003b2_goto_$000003ed;
+  $000003ed:
+    assume {:captureState "$000003ed"} true;
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
     call rely();
@@ -184,36 +184,36 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$22), Gamma_$load$22;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000405"} true;
-    goto l000003d8;
-  l000003d8:
-    assume {:captureState "l000003d8"} true;
+    goto $000003d8;
+  $000003d8:
+    assume {:captureState "$000003d8"} true;
     R0, Gamma_R0 := 0bv64, true;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000381:
-    assume {:captureState "lmain_goto_l00000381"} true;
+  $main_goto_$00000381:
+    assume {:captureState "$main_goto_$00000381"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000381;
-  lmain_goto_l00000414:
-    assume {:captureState "lmain_goto_l00000414"} true;
+    goto $00000381;
+  $main_goto_$00000414:
+    assume {:captureState "$main_goto_$00000414"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000414;
-  l00000381_goto_l000003b2:
-    assume {:captureState "l00000381_goto_l000003b2"} true;
+    goto $00000414;
+  $00000381_goto_$000003b2:
+    assume {:captureState "$00000381_goto_$000003b2"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l000003b2;
-  l00000381_goto_l00000407:
-    assume {:captureState "l00000381_goto_l00000407"} true;
+    goto $000003b2;
+  $00000381_goto_$00000407:
+    assume {:captureState "$00000381_goto_$00000407"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000407;
-  l000003b2_goto_l000003d8:
-    assume {:captureState "l000003b2_goto_l000003d8"} true;
+    goto $00000407;
+  $000003b2_goto_$000003d8:
+    assume {:captureState "$000003b2_goto_$000003d8"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l000003d8;
-  l000003b2_goto_l000003ed:
-    assume {:captureState "l000003b2_goto_l000003ed"} true;
+    goto $000003d8;
+  $000003b2_goto_$000003ed:
+    assume {:captureState "$000003b2_goto_$000003ed"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l000003ed;
+    goto $000003ed;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;

--- a/src/test/incorrect/nestedifglobal/gcc_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/gcc_pic/nestedifglobal.expected
@@ -129,8 +129,8 @@ implementation main()
   var Gamma_$load$24: bool;
   var Gamma_$load$25: bool;
   var Gamma_$load$26: bool;
-  lmain:
-    assume {:captureState "lmain"} true;
+  $main:
+    assume {:captureState "$main"} true;
     R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
     assume {:captureState "%00000332"} true;
@@ -159,15 +159,15 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
     NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
     assert Gamma_ZF;
-    goto lmain_goto_l00000383, lmain_goto_l00000418;
-  l00000418:
-    assume {:captureState "l00000418"} true;
+    goto $main_goto_$00000383, $main_goto_$00000418;
+  $00000418:
+    assume {:captureState "$00000418"} true;
     R0, Gamma_R0 := 3bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000423"} true;
-    goto l00000383;
-  l00000383:
-    assume {:captureState "l00000383"} true;
+    goto $00000383;
+  $00000383:
+    assume {:captureState "$00000383"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$22, Gamma_$load$22 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
@@ -181,15 +181,15 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#5, 1bv32), 0bv32), Gamma_#5;
     NF, Gamma_NF := bvadd32(#5, 1bv32)[32:31], Gamma_#5;
     assert Gamma_ZF;
-    goto l00000383_goto_l000003b5, l00000383_goto_l0000040b;
-  l0000040b:
-    assume {:captureState "l0000040b"} true;
+    goto $00000383_goto_$000003b5, $00000383_goto_$0000040b;
+  $0000040b:
+    assume {:captureState "$0000040b"} true;
     R0, Gamma_R0 := 5bv64, true;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000416"} true;
-    goto l000003b5;
-  l000003b5:
-    assume {:captureState "l000003b5"} true;
+    goto $000003b5;
+  $000003b5:
+    assume {:captureState "$000003b5"} true;
     $load$24, Gamma_$load$24 := memory_load32_le(stack, bvadd64(R31, 28bv64)), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := zero_extend32_32($load$24), Gamma_$load$24;
     #6, Gamma_#6 := bvadd32(R0[32:0], 4294967292bv32), Gamma_R0;
@@ -198,9 +198,9 @@ implementation main()
     ZF, Gamma_ZF := bvcomp32(bvadd32(#6, 1bv32), 0bv32), Gamma_#6;
     NF, Gamma_NF := bvadd32(#6, 1bv32)[32:31], Gamma_#6;
     assert Gamma_ZF;
-    goto l000003b5_goto_l000003db, l000003b5_goto_l000003f0;
-  l000003f0:
-    assume {:captureState "l000003f0"} true;
+    goto $000003b5_goto_$000003db, $000003b5_goto_$000003f0;
+  $000003f0:
+    assume {:captureState "$000003f0"} true;
     R0, Gamma_R0 := 65536bv64, true;
     call rely();
     $load$25, Gamma_$load$25 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
@@ -210,36 +210,36 @@ implementation main()
     R0, Gamma_R0 := zero_extend32_32($load$26), Gamma_$load$26;
     stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     assume {:captureState "%00000409"} true;
-    goto l000003db;
-  l000003db:
-    assume {:captureState "l000003db"} true;
+    goto $000003db;
+  $000003db:
+    assume {:captureState "$000003db"} true;
     R0, Gamma_R0 := 0bv64, true;
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     goto main_basil_return;
-  lmain_goto_l00000383:
-    assume {:captureState "lmain_goto_l00000383"} true;
+  $main_goto_$00000383:
+    assume {:captureState "$main_goto_$00000383"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l00000383;
-  lmain_goto_l00000418:
-    assume {:captureState "lmain_goto_l00000418"} true;
+    goto $00000383;
+  $main_goto_$00000418:
+    assume {:captureState "$main_goto_$00000418"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l00000418;
-  l00000383_goto_l000003b5:
-    assume {:captureState "l00000383_goto_l000003b5"} true;
+    goto $00000418;
+  $00000383_goto_$000003b5:
+    assume {:captureState "$00000383_goto_$000003b5"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l000003b5;
-  l00000383_goto_l0000040b:
-    assume {:captureState "l00000383_goto_l0000040b"} true;
+    goto $000003b5;
+  $00000383_goto_$0000040b:
+    assume {:captureState "$00000383_goto_$0000040b"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l0000040b;
-  l000003b5_goto_l000003db:
-    assume {:captureState "l000003b5_goto_l000003db"} true;
+    goto $0000040b;
+  $000003b5_goto_$000003db:
+    assume {:captureState "$000003b5_goto_$000003db"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1);
-    goto l000003db;
-  l000003b5_goto_l000003f0:
-    assume {:captureState "l000003b5_goto_l000003f0"} true;
+    goto $000003db;
+  $000003b5_goto_$000003f0:
+    assume {:captureState "$000003b5_goto_$000003f0"} true;
     assume (bvnot1(bvcomp1(ZF, 1bv1)) == 0bv1);
-    goto l000003f0;
+    goto $000003f0;
   main_basil_return:
     assume {:captureState "main_basil_return"} true;
     return;


### PR DESCRIPTION
Uses BAP TIDs when parsing block names from BAP to ensure that BASIL blocks are given unique names

Fixes #238 