### PR TITLE
fixes from cntlm with offline lifter

### DIFF
--- a/src/main/scala/cfg_visualiser/DotTools.scala
+++ b/src/main/scala/cfg_visualiser/DotTools.scala
@@ -11,6 +11,13 @@ object IDGenerator {
   }
 }
 
+
+def escape(s: String) =  {
+  val n = s.replace("\"", "\\\"")
+  n
+}
+
+
 def wrap(_input: String, width: Integer = 20, first : Boolean = true): String =
   var input = _input
 
@@ -61,10 +68,12 @@ class DotNode(val id: String, val label: String) extends DotElement {
 
   def equals(other: DotNode): Boolean = toDotString.equals(other.toDotString)
 
-  override def toString: String = toDotString
 
   def toDotString: String =
-    s"\"$id\"" + "[label=\"" + wrap(label, 100) + "\", shape=\"box\", fontname=\"Mono\", fontsize=\"5\"]"
+    s"\"$id\"" + "[label=\"" + escape(wrap(label, 100)) + "\", shape=\"box\", fontname=\"Mono\", fontsize=\"5\"]"
+
+
+  override def toString: String = toDotString
 
 }
 
@@ -81,8 +90,9 @@ class DotNode(val id: String, val label: String) extends DotElement {
 
   def equals(other: DotArrow): Boolean = toDotString.equals(other.toDotString)
 
+
   def toDotString: String =
-    s"\"${fromNode.id}\" $arrow \"${toNode.id}\"[label=\"$label\", style=\"$style\", color=\"$colour\"]"
+    s"\"${fromNode.id}\" $arrow \"${toNode.id}\"[label=\"${escape(label)}\", style=\"$style\", color=\"$colour\"]"
 }
 
 /** Represents a directed edge between two regular cfg nodes in a Graphviz dot file.
@@ -161,7 +171,7 @@ class DotStruct(val id: String, val details: String, val fields: Option[Iterable
   override def toString: String = toDotString
 
   override def toDotString: String =
-    s"$id " + "[label=" + label + "]"
+    s"$id " + "[label=" + escape(label) + "]"
 }
 
 class DotStructElement(val id: String, val field: Option[String]) extends DotElement {
@@ -183,7 +193,7 @@ case class StructArrow(
   def equals(other: DotArrow): Boolean = toDotString.equals(other.toDotString)
 
   def toDotString: String =
-    s"${from.toString} $arrow ${to.toString} [label=\"$label\", style=\"$style\", color=\"$colour\"]"
+    s"${from.toString} $arrow ${to.toString} [label=\"${escape(label)}\", style=\"$style\", color=\"$colour\"]"
 }
 
 

--- a/src/main/scala/ir/cilvisitor/CILVisitor.scala
+++ b/src/main/scala/ir/cilvisitor/CILVisitor.scala
@@ -90,7 +90,7 @@ class CILVisitorImpl(val v: CILVisitor) {
       }
       case Repeat(repeats, arg) => {
         val narg = visit_expr(arg)
-        if (narg ne arg) Repeat(repeats, arg) else n
+        if (narg ne arg) Repeat(repeats, narg) else n
       }
       case ZeroExtend(bits, arg) => {
         val narg = visit_expr(arg)
@@ -132,8 +132,8 @@ class CILVisitorImpl(val v: CILVisitor) {
         i.target = visit_rvar(i.target)
         i
       case m: MemoryStore =>
-        m.value = visit_expr(m.value)
         m.index = visit_expr(m.index)
+        m.value = visit_expr(m.value)
         m.mem = visit_mem(m.mem)
         m
       case m: MemoryLoad =>

--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -53,16 +53,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
               instructionAddress.toString + "$" + i
             }
 
-            statements.appendAll(
-              try {
-                visitStmt(s, label)
-              } catch {
-                case e => {
-                  Logger.error(s"Failed to load insn: $e\n${e.getStackTrace.mkString("\n")}")
-                  Seq(Assert(FalseLiteral, Some(" Failed to load instruction")))
-                }
-              }
-            )
+            statements.appendAll(visitStmt(s, label))
           }
           instructionCount += 1
         }
@@ -330,6 +321,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
             case o => UnaryExpr(BoolToBV1, o)
           }
         (result, load)
+
 
       case "not_bool.0" => (resolveUnaryOp(BoolNOT, function, 0, typeArgs, args, ctx.getText), None)
       case "eq_enum.0" => (resolveBinaryOp(BoolEQ, function, 0, typeArgs, args, ctx.getText))

--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -229,6 +229,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
       case c: TypeConstructorContext => visitIdent(c.str).match {
         case "FPRounding" => BitVecType(3)
         case "integer" => BitVecType(64)
+        case "boolean" => BoolType
         case _ => throw Exception(s"unknown type ${ctx.getText}")
       }
       case _ => throw Exception(s"unknown type ${ctx.getText}")

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -127,7 +127,7 @@ object IRLoading {
     val mods = ir.modules
     val cfg = ir.cfg.get
 
-    def parse_asl_stmt(line: String): StmtContext = {
+    def parse_asl_stmt(line: String): Option[StmtContext] = {
       val lexer = ASLpLexer(CharStreams.fromString(line))
       val tokens = CommonTokenStream(lexer)
       val parser = ASLpParser(tokens)
@@ -135,7 +135,7 @@ object IRLoading {
       parser.setBuildParseTree(true)
 
       try {
-        parser.stmt()
+        Some(parser.stmt())
       } catch {
         case e: org.antlr.v4.runtime.misc.ParseCancellationException =>
           val extra = e.getCause match {
@@ -151,7 +151,8 @@ object IRLoading {
             case o => o.toString
           }
           Logger.error(s"""Semantics parse error:\n  line: $line\n$extra""")
-          throw e
+          Logger.error(e.getStackTrace.mkString("\n"))
+          None
       }
     }
 
@@ -165,7 +166,14 @@ object IRLoading {
           }
           InsnSemantics.Error(m("opcode").convertTo[String], m("error").convertTo[String])
         }
-        case array @ JsArray(_) => InsnSemantics.Result(array.convertTo[Array[String]].map(parse_asl_stmt))
+        case array @ JsArray(_) => {
+          val xs = array.convertTo[Array[String]].map(parse_asl_stmt)
+          if (xs.exists(_.isEmpty))  {
+            InsnSemantics.Error("?", "parseError")
+          } else {
+            InsnSemantics.Result(xs.map(_.get))
+          }
+        }
         case s => deserializationError(s"Bad sem format $s")
       }
     }

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -173,8 +173,6 @@ object IRLoading {
     val semantics = mods.map(_.auxData("ast").data.toStringUtf8.parseJson.convertTo[Map[String, List[InsnSemantics]]])
 
     val parserMap : Map[String, List[InsnSemantics]] = semantics.flatten.toMap
-
-
     val GTIRBConverter = GTIRBToIR(mods, parserMap, cfg, mainAddress)
     GTIRBConverter.createIR()
   }

--- a/src/test/scala/ir/CILVisitorTest.scala
+++ b/src/test/scala/ir/CILVisitorTest.scala
@@ -197,8 +197,32 @@ class CILVisitorTest extends AnyFunSuite {
 
     val v3 = RegReplacePost()
     visit_proc(v3, program.procedures.head)
-    assert(v3.res.toList == List("elR31", "elR6", "elR6"))
+    assert(v3.res.toList == List("elR31_0", "elR6_0", "elR6_0"))
 
   }
+
+  test ("changedochildrenposttest") {
+
+    val expr = BinaryExpr(BVADD, BitVecLiteral(BigInt(12), 32), (BinaryExpr(BVADD, BitVecLiteral(BigInt(100), 32), BitVecLiteral(BigInt(120), 32))))
+    class vis extends CILVisitor {
+
+      override def vexpr(e: Expr) = {
+        ChangeDoChildrenPost(e match {
+          case BitVecLiteral(100, 32) => BitVecLiteral(111, 32)
+          case _ => e
+          }, x => x match {
+            case BitVecLiteral(111,32) =>  LocalVar("beans", BitVecType(32))
+            case _ => x
+          })
+        }
+      }
+
+      val cexpr = BinaryExpr(BVADD, BitVecLiteral(BigInt(12), 32), (BinaryExpr(BVADD, LocalVar("beans", BitVecType(32)), BitVecLiteral(BigInt(120), 32))))
+
+      val ne = visit_expr(vis(), expr)
+      assert(ne == cexpr)
+
+    }
+
 
 }


### PR DESCRIPTION
Some fixes to get cntlm lifted with the offline lifter to go through the gtirb frontend

- relax the expectations of the gtirb loader a bit so it doesn't immediately crash on bad rASL and detached blocks
- more assertions in simplifier as I keep adding them when debugging
- fix to repeat bits in cil visitor