### PR TITLE
constraint generation

### DIFF
--- a/src/main/scala/analysis/data_structure_analysis/Constraints.scala
+++ b/src/main/scala/analysis/data_structure_analysis/Constraints.scala
@@ -1,0 +1,122 @@
+package analysis.data_structure_analysis
+
+import ir.{CFGPosition, Call, DirectCall, Expr, IndirectCall, IntraProcIRCursor, LocalVar, MemoryLoad, MemoryStore, Procedure, Statement, Variable, computeDomain}
+import util.ConstGenLogger
+
+sealed trait Constraint {
+  def source: CFGPosition
+  val label: String
+  def eval(evaluator: Expr => Any = identity): String
+}
+
+def content(value: Any): String = s"[|${value.toString}|]}"
+
+case class ConstraintArg(value: Expr, contents: Boolean = false) {
+  override def toString: String = eval()
+  def ignoreContents: ConstraintArg = ConstraintArg(value)
+  def eval(evaluator: Expr => Any = identity): String = {
+    val evaluated = evaluator(value)
+    if contents then content(evaluated) else evaluated.toString
+  }
+}
+
+sealed trait BinaryConstraint extends Constraint {
+  val arg1: ConstraintArg
+  val arg2: ConstraintArg
+
+  private def name = this.getClass.getSimpleName
+  override def toString: String = eval()
+  override def eval(evaluator: Expr => Any = identity): String = s"(${arg1.eval(evaluator)} <==> ${arg2.eval(evaluator)}"
+}
+
+case class AssignmentConstraint(pos: CFGPosition, ar1: Expr, ar2: Expr) extends BinaryConstraint {
+  override def source: CFGPosition = pos
+  override val label: String = labelToPC(Some(pos.toString))
+  override val arg1: ConstraintArg = ConstraintArg(ar1)
+  override val arg2: ConstraintArg =  ConstraintArg(ar2)
+}
+
+sealed trait MemoryAccessConstraint[T <: MemoryStore | MemoryLoad](pos: T, index: Expr, value: Expr, val size: Int)
+  extends BinaryConstraint {
+  val label: String = labelToPC(pos.label)
+  override def source: T = pos
+
+  override val arg1: ConstraintArg = ConstraintArg(index, true)
+  override val arg2: ConstraintArg = ConstraintArg(value)
+
+  override def toString: String = eval()
+
+  override def eval(evaluator: Expr => Any = identity): String =
+    s"${this.getClass.getSimpleName}($label, size: $size): " + super.eval(evaluator)
+}
+
+case class MemoryReadConstraint(pos: MemoryLoad)
+  extends MemoryAccessConstraint[MemoryLoad](pos, pos.index, pos.lhs, pos.size/8)
+
+case class MemoryWriteConstraint(pos: MemoryStore)
+  extends MemoryAccessConstraint[MemoryStore](pos, pos.index, pos.value, pos.size/8)
+
+sealed trait CallConstraint[T <: Call, V <: Procedure | Variable](call: T)
+  extends Constraint {
+  val label: String = labelToPC(call.label)
+  def caller: Procedure = call.parent.parent
+  def target: V
+  val inParams: Map[LocalVar, Expr]
+  val outParmas: Map[LocalVar, LocalVar]
+  def inConstraints: Set[AssignmentConstraint] = inParams.map(pair => AssignmentConstraint(call, pair._1, pair._2)).toSet
+  def outConstraints: Set[AssignmentConstraint] = outParmas.map(pair => AssignmentConstraint(call, pair._1, pair._2)).toSet
+  override def source: T = call
+  override def toString: String = eval()
+
+  override def eval(evaluator: Expr => Any = identity): String = {
+    s"${this.getClass.getSimpleName}($label, Proc ${caller.name} calls $target" ++ s"\nIn Param Constraints: ${inConstraints.map(_.eval(evaluator))}"
+      ++ s"\nOut Param Constraints: ${outConstraints.map(_.eval(evaluator))}"
+  }
+}
+
+case class DirectCallConstraint(call: DirectCall)
+  extends CallConstraint[DirectCall, Procedure] (call) {
+  override def target: Procedure = call.target
+
+  override val inParams: Map[LocalVar, Expr] = call.actualParams
+  override val outParmas: Map[LocalVar, LocalVar] = call.outParams.view.mapValues(_.asInstanceOf[LocalVar]).toMap
+}
+
+case class IndirectCallConstraint(call: IndirectCall)
+  extends CallConstraint[IndirectCall, Variable](call)
+{
+
+  override def target: Variable = call.target
+
+  override val inParams: Map[LocalVar, Expr] = Map.empty
+  override val outParmas: Map[LocalVar, LocalVar] = Map.empty
+}
+
+def generateConstraints(proc: Procedure): Set[Constraint]  = {
+  ConstGenLogger.info(s"Generating Constraints for ${proc.name}")
+  val domain = computeDomain(IntraProcIRCursor, Set(proc))
+  var constraints: Set[Constraint] = Set.empty
+
+  domain.foreach {
+    case load: MemoryLoad =>
+      constraints += MemoryReadConstraint(load)
+    case write: MemoryStore =>
+      constraints += MemoryWriteConstraint(write)
+    case call: DirectCall =>
+      constraints += DirectCallConstraint(call)
+    case indirectCall: IndirectCall => constraints += IndirectCallConstraint(indirectCall)
+    case _ =>
+  }
+
+  constraints
+}
+
+case class SVAConstraints(sva: SymbolicValues, constraints: Set[Constraint]) {
+  def this(proc: Procedure) = {
+    this(getSymbolicValues(proc), generateConstraints(proc))
+  }
+  def exprToSymVal(expr: Expr): SymValueSet = sva.exprToSymValSet(expr)
+}
+object SVAConstraints {
+  def apply(proc: Procedure) = new SVAConstraints(proc)
+}

--- a/src/main/scala/analysis/data_structure_analysis/SymbolicValueAnalysis.scala
+++ b/src/main/scala/analysis/data_structure_analysis/SymbolicValueAnalysis.scala
@@ -1,0 +1,365 @@
+package analysis.data_structure_analysis
+
+import ir.eval.BitVectorEval.bv2SignedInt
+import ir.{Assert, Assign, Assume, BVADD, BVAND, BVASHR, BVBinOp, BVCOMP, BVCONCAT, BVEQ, BVLSHR, BVMUL, BVNAND, BVNEQ, BVNOR, BVOR, BVSDIV, BVSGE, BVSGT, BVSHL, BVSLE, BVSLT, BVSMOD, BVSREM, BVSUB, BVUDIV, BVUGE, BVUGT, BVULE, BVULT, BVUREM, BVXNOR, BVXOR, BinOp, BinaryExpr, BitVecLiteral, BitVecType, Block, BoolBinOp, BoolLit, CFGPosition, Call, Command, DirectCall, Expr, Extract, GoTo, IndirectCall, IntBinOp, IntLiteral, Jump, Literal, LocalAssign, LocalVar, MemoryLoad, MemoryStore, NOP, Procedure, Repeat, Return, SignExtend, SingleAssign, Statement, UnaryExpr, UninterpretedFunction, Unreachable, Variable, ZeroExtend}
+import ir.transforms.{AbstractDomain, worklistSolver}
+import util.SVALogger as Logger
+
+import scala.annotation.tailrec
+import scala.collection.{SortedMap, mutable}
+
+
+def getSymbolicValues(p: Procedure): SymbolicValues = {
+  Logger.info(s"Generating Symbolic Values for ${p.name}")
+  val symValDomain = SymbolicValueDomain()
+  val symValSolver = worklistSolver[SymbolicValues, symValDomain.type](symValDomain)
+  symValSolver.solveProc(p)._2
+    .values
+    .fold(SymbolicValues.empty)(SymbolicValues.join)
+}
+
+// a symbolic base address
+sealed trait SymBase
+
+// Known heap, malloc, global address
+sealed trait Known extends SymBase
+
+case class Heap(call: DirectCall) extends Known {
+  assert(call.target.name.startsWith("malloc"), "Expected a call to malloc")
+  private val procName = call.parent.parent.name
+  private val label = labelToPC(call.label)
+  override def toString: String = s"Heap(${procName}_$label)"
+}
+
+case class Stack(proc: Procedure) extends Known {
+  override def toString: String = s"Stack(${proc.name})"
+}
+
+sealed trait Const extends Known
+case object Global extends Const
+case object NonPointer extends Const
+
+// placeholder sym bases for loaded and in/out params
+sealed trait Unknown extends SymBase
+case class Par(proc: Procedure, param: LocalVar) extends Unknown {
+  private val procName = proc.name
+  override def toString: String = s"Par(${procName}_${param.name})"
+}
+
+case class Ret(call: DirectCall, param: LocalVar) extends Unknown {
+  private val procName = call.parent.parent.name
+  private val targetName = call.target.name
+  private val label = labelToPC(call.label)
+  override def toString: String = s"Ret(${procName}_${targetName}_${param.name}_$label)"
+}
+
+case class Loaded(load: MemoryLoad) extends Unknown {
+  private val procName = load.parent.parent.name
+  private val label = labelToPC(load.label)
+  override def toString: String = s"Loaded(${procName}_$label)"
+}
+
+
+// Represents a set of offsets
+// None represents top or all offsets
+case class SymOffsets(set: Option[Set[Int]]) {
+  def this(i: Int) = this(Some(Set(i)))
+  def this(s: Set[Int]) = this(Some(s))
+
+  override def toString: String = if set.nonEmpty then set.get.mkString("offSets(", ",", ")") else "T"
+
+  def join(other: SymOffsets): SymOffsets = {
+    (this.set, other.set) match
+      case (None, _ ) => this
+      case (_, None) => other
+      case (Some(set1), Some(set2)) => SymOffsets(Some(set1.union(set2)))
+  }
+
+  def isTop: Boolean = set.isEmpty
+  def getOffsets: Set[Int] = {
+    if set.nonEmpty then set.get
+    else
+      throw new Exception("Attempted to get a set of offsets from SymOffsets with value TOP")
+  }
+  def apply(f: Int => Int): SymOffsets = if set.isEmpty then this else SymOffsets(Some(set.get.map(f)))
+  def filter(f: Int => Boolean): SymOffsets = SymOffsets(set.map(offs => offs.filter(f)))
+}
+
+object SymOffsets {
+  def empty: SymOffsets = SymOffsets(Some(Set.empty))
+  def top: SymOffsets = SymOffsets(None)
+  def join(symOffsets1: SymOffsets, symOffsets2: SymOffsets): SymOffsets = symOffsets1.join(symOffsets2)
+  def apply(i: Int) = new SymOffsets(i)
+  def apply(s: Set[Int]) = new SymOffsets(s)
+}
+
+
+// Symbolic Value Set
+// mapping from Symbolic Bases (representing regions) and the different offsets into those bases
+// represents a set of addresses/constant values
+case class SymValueSet(state: Map[SymBase, SymOffsets]) {
+
+  def this(base: SymBase, value: Int = 0) = this(Map(base -> SymOffsets(value)))
+  def this(base: SymBase, valueSet: Set[Int]) = this(Map(base -> SymOffsets(valueSet)))
+  def this(base: SymBase, symOffsets: SymOffsets) = this(Map(base -> symOffsets))
+
+  def join(other: SymValueSet): SymValueSet = {
+    val joinedMap = (this.state.toSeq ++ other.state.toSeq)
+      .groupMapReduce(_._1)(_._2)(SymOffsets.join)
+
+    SymValueSet(joinedMap)
+  }
+
+  def size = state.size
+
+  def get(base: SymBase): SymOffsets = this.state.getOrElse(base, SymOffsets.empty)
+  def contains(base: SymBase): Boolean = this.state.contains(base)
+
+  def apply(f: Int => Int): SymValueSet = {
+    SymValueSet(state.view.mapValues(_.apply(f)).toMap)
+  }
+
+  def toTop: SymValueSet =
+    SymValueSet(state.view.mapValues(_ => SymOffsets.top).toMap)
+
+  def widen(other: SymValueSet): SymValueSet = {
+    val update = state
+      .collect {
+          case (base: SymBase, offsets: SymOffsets) if other.state.contains(base) && other.state(base) != offsets =>
+            (base, SymOffsets.top)
+        }
+    join(other).join(SymValueSet(update))
+  }
+
+  def removeNonAddress(isAddress: Int => Boolean): SymValueSet = {
+    val updated = if contains(Global) then
+      val globalAddresses = get(Global).filter(isAddress)
+      remove(Global).join(SymValueSet(Global, globalAddresses))
+    else this
+
+    updated.remove(NonPointer)
+  }
+  
+  def getStack(): SymValueSet = {
+    SymValueSet(state.filter((base, offsets) => base.isInstanceOf[Stack]))
+  }
+
+  def remove(symBase: SymBase): SymValueSet = SymValueSet(state.removed(symBase))
+  override def toString: String = state.mkString("SymValSet(", ", ", ")")
+}
+
+object SymValueSet {
+  def empty: SymValueSet = SymValueSet(Map.empty)
+  def join(symValueSet1: SymValueSet, symValueSet2: SymValueSet): SymValueSet = symValueSet1.join(symValueSet2)
+  def apply(base: SymBase, value: Int = 0): SymValueSet = new SymValueSet(base, value)
+  def apply(base: SymBase, valueSet: Set[Int]): SymValueSet = new SymValueSet(base, valueSet)
+  def apply(base: SymBase, offsets: SymOffsets): SymValueSet = new SymValueSet(base, offsets)
+}
+
+def labelToPC(label: Option[String]): String = {
+//  assert(label.nonEmpty)
+  label.getOrElse("no_label").takeWhile(_ != ':')
+}
+
+def DSAVartoLast(DSAVar: LocalVar): LocalVar = {
+   if DSAVar.index > 1 then
+     LocalVar(DSAVar.varName, DSAVar.irType, DSAVar.index - 1)
+   else if DSAVar.index == 1 then
+     LocalVar(DSAVar.varName + "_in", DSAVar.irType)
+   else
+     throw Exception(s"Attempted to get previous version of DSA variable without one")
+}
+
+
+object DSAVarOrdering extends Ordering[LocalVar] {
+  def compare(a:LocalVar, b:LocalVar) = {
+    if a.name == b.name then 0
+    else if a.name.endsWith("_in") || b.name.endsWith("_out") then -1
+    else if a.name.endsWith("_out") then 1
+    else a.index - b.index
+  }
+}
+
+def toOffsetMove(op: BinOp, arg: BitVecLiteral): Int => Int = {
+  op match
+    case BVADD => (i: Int) => i + bv2SignedInt(arg).toInt
+    case BVSUB => (i: Int) => i - bv2SignedInt(arg).toInt
+    case _ =>  throw Exception(s"Usupported Binary Op $op")
+}
+
+
+// Symbolic Value Set
+// mapping from Symbolic Bases (representing regions) and the different offsets into those bases
+// represents a set of addresses/constant values
+case class SymbolicValues(state: Map[LocalVar, SymValueSet]) {
+
+  def this(proc: Procedure) = {
+    this(SymbolicValues.procInitState(proc)) 
+  }
+  
+  def pretty: String = {
+    state
+      .map {
+        case (localVar: LocalVar, symValSet: SymValueSet) =>
+          localVar.toString + ": " + symValSet.toString
+      }
+      .mkString("\n")
+  }
+
+  // get the Symbolic Values of local Vars with prefix in their names
+  def get(prefix: String): SymbolicValues = {
+    val newState = state.collect {
+      case entry@(loc: LocalVar, _) if loc.name.startsWith(prefix) => entry
+    }
+    SymbolicValues(newState)
+  }
+
+  private def sort: SortedMap[LocalVar, SymValueSet] = {
+    require(state.keys.map(f => f.name.take(3)).toSet.size <= 1, "Expected one or less Variable in state")
+    SortedMap.sortedMapFactory[LocalVar, SymValueSet](DSAVarOrdering).fromSpecific(state)
+  }
+
+  def getSorted(prefix: String) : SortedMap[LocalVar, SymValueSet] = {
+    get(prefix).sort
+  }
+  
+  def join(other: SymbolicValues): SymbolicValues = {
+    val newState = (state.toSeq ++ other.state.toSeq)
+      .groupMapReduce(_._1)(_._2)(SymValueSet.join)
+    SymbolicValues(newState)
+  }
+
+  @tailrec
+  final def exprToSymValSet(expr: Expr, transform: Int => Int = identity, replace: LocalVar => LocalVar = identity): SymValueSet = {
+    expr match
+      case literal @ BitVecLiteral(value, size) => SymValueSet(Global, bv2SignedInt(literal).toInt).apply(transform)
+      case Extract(end, start, body) if end - start >= 64 => exprToSymValSet(body, transform)
+      case Extract(32, 0, body) => exprToSymValSet(body, transform) // todo incorrectly assuming value is preserved
+      case ZeroExtend(extension, body) => exprToSymValSet(body, transform)
+      case binExp @ BinaryExpr(BVADD| BVSUB, arg1, arg2: BitVecLiteral) =>
+        val oPlus = toOffsetMove(binExp.op, arg2)
+        exprToSymValSet(arg1, oPlus)
+      case variable: LocalVar => state.getOrElse(replace(variable), SymValueSet.empty).apply(transform)
+      case Extract(end, start, body) if end - start < 64 => SymValueSet(NonPointer, SymOffsets.top)
+      case BinaryExpr(BVCOMP, _, _) => SymValueSet(NonPointer, Set(0, 1)).apply(transform)
+      case e @ (BinaryExpr(_, _, _) | SignExtend(_, _) | UnaryExpr(_, _)) =>
+        e.variables
+          .map(_.asInstanceOf[LocalVar])
+          .collect {case locVar: LocalVar if state.contains(locVar) => state(locVar)}
+          .foldLeft(SymValueSet.empty)((result, operand) => result.join(operand))
+          .toTop
+      case _ =>
+        ???
+  }
+  
+  def contains(variable: LocalVar): Boolean = state.contains(variable)
+  def apply(variable: LocalVar): SymValueSet = state(variable)
+  def isEmpty: Boolean = this == SymbolicValues.empty
+  
+  def widen(other: SymbolicValues): SymbolicValues = {
+    val update = state.collect { // widen iff localVar is in both a and b todo this could be wrong
+      case (localVar: LocalVar, symValueSet: SymValueSet) if other.contains(localVar) && symValueSet != other(localVar) =>
+        (localVar, symValueSet.widen(other(localVar)))
+    }
+    
+    join(other).join(SymbolicValues(update))
+  }
+  
+}
+
+object SymbolicValues {
+  
+  private val stackPointer = LocalVar("R31_in", BitVecType(64))
+  private val linkRegister = LocalVar("R30_in", BitVecType(64)) //Register("R30", 64)
+  private val framePointer = LocalVar("R29_in", BitVecType(64))
+  private val calleePreserved = (19 to 29).appended(31).map(i => "R"+i)
+  private val implicitFormals = Set(stackPointer, linkRegister, framePointer)
+ 
+  private def procInitState(proc: Procedure): Map[LocalVar, SymValueSet] = {
+    Map(stackPointer -> SymValueSet(Stack(proc), proc.stackSize.getOrElse(0)), linkRegister -> SymValueSet(Par(proc, linkRegister)),  framePointer -> SymValueSet(Par(proc, framePointer))) ++
+          proc.formalInParam
+            .filterNot(param=> implicitFormals.map(f => f.name.take(3)).exists(name => param.name.startsWith(name)))
+            .toSet
+            .map(param => (param, SymValueSet(Par(proc, param))))
+            .toMap
+  }
+
+  def apply(proc: Procedure) = new SymbolicValues(proc)
+  
+  def empty: SymbolicValues = SymbolicValues(Map.empty)
+  
+  def join(a: SymbolicValues, b: SymbolicValues): SymbolicValues = a.join(b)
+}
+
+class SymbolicValueDomain extends AbstractDomain[SymbolicValues]  {
+
+
+  private val count: mutable.Map[Block, Int] = mutable.Map.empty.withDefault(_ => 0)
+
+  override def widen(
+                      a: SymbolicValues,
+                      b: SymbolicValues,
+                      pos: Block): SymbolicValues = a.widen(b) 
+
+  override def init(b: Block): SymbolicValues = {
+      if b.isEntry then
+        val proc: Procedure = b.parent
+        SymbolicValues(proc)
+      else bot
+  }
+
+  override def join(a: SymbolicValues, b: SymbolicValues,
+                    pos: Block): SymbolicValues = {
+    count.update(pos, count(pos) + 1)
+//    if count(pos) >= 10 then SVALogger.debug(s"Visiting ${pos.label} for ${count(pos)}th time")
+    if count(pos) < 10 then a.join(b) else widen(a, b, pos)
+  }
+
+  override def transfer(a: SymbolicValues, b: Command): SymbolicValues = {
+    val proc = b.parent.parent
+    b match
+      case LocalAssign(lhs: LocalVar, rhs: Expr, _) =>
+        val update = SymbolicValues(Map(lhs -> a.exprToSymValSet(rhs)))
+        a.join(update)
+      case load @ MemoryLoad(lhs: LocalVar, _, rhs, _, size, label) =>
+        val update = SymbolicValues(Map(lhs -> SymValueSet(Loaded(load))))
+        a.join(update)
+      case mal @ DirectCall(target, outParams, inParams, label) if target.name.startsWith("malloc") =>
+        val (malloc, others) = outParams
+          .values
+          .map(_.asInstanceOf[LocalVar])
+          .partition(outParam => outParam.name.startsWith("R0")) // malloc ret R0
+        assert(malloc.size == 1, s"SVA expected only one R0 returned from $mal")
+        val update = SymbolicValues( // assume call to malloc only changes the value of R0
+          Map(malloc.head -> SymValueSet(Heap(mal))) ++
+            others // set every other out param to it's DSA index - 1
+            .map(DSAVartoLast)
+            .collect {case param: LocalVar if a.contains(param) => (param, a(param))})
+        a.join(update)
+      case call @ DirectCall(target, outParams, inParams, label) =>
+        val retInitSymValSet = SymbolicValues(
+          outParams
+            .values
+            .map(_.asInstanceOf[LocalVar])
+            .map(param => (param, SymValueSet(Ret(call, param))))
+            .toMap
+        )
+        a.join(retInitSymValSet)
+      case ind: IndirectCall => a // TODO possibly map every live variable to top
+      case ret: Return =>
+        val update = SymbolicValues(
+          ret.outParams.map {
+            case (outVar: LocalVar, value: Expr) => outVar -> a.exprToSymValSet(value)
+          })
+        
+        a.join(update)
+      case _ => a
+  }
+
+  override def top: SymbolicValues = ???
+
+  override def bot: SymbolicValues = SymbolicValues.empty
+}
+
+
+

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -280,6 +280,7 @@ class Procedure private (
   def makeCall(label: Option[String] = None) = DirectCall(this, label, outParamDefaultBinding, inParamDefaultBinding)
 
   var isExternal : Option[Boolean] = None
+  var stackSize : Option[Int] = None
 
   /**
    * Get an Iterator in approximate syntactic pre-order of procedures, blocks, and commands. Blocks and procedures are 

--- a/src/main/scala/util/BASILConfig.scala
+++ b/src/main/scala/util/BASILConfig.scala
@@ -32,6 +32,13 @@ case class StaticAnalysisConfig(
   irreducibleLoops: Boolean = true
 )
 
+
+enum DSAAnalysis {
+  case Norm, Set, Field
+}
+
+case class DSAConfig(analyses: Set[DSAAnalysis])
+
 enum BoogieMemoryAccessMode {
   case SuccessiveStoreSelect, LambdaStoreSelect
 }
@@ -41,10 +48,12 @@ enum MemoryRegionsMode {
 }
 
 case class BASILConfig(
+  context: Option[IRContext] = None,
   loading: ILLoadingConfig,
   runInterpret: Boolean = false,
   simplify: Boolean = false,
   validateSimp: Boolean = false,
+  dsaConfig: Option[DSAConfig] = None,
   staticAnalysis: Option[StaticAnalysisConfig] = None,
   boogieTranslation: BoogieGeneratorConfig = BoogieGeneratorConfig(),
   outputPrefix: String

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -168,3 +168,8 @@ val AnalysisResultDotLogger = Logger.deriveLogger("analysis-results-dot").setLev
 val VSALogger = StaticAnalysisLogger.deriveLogger("vsa")
 val MRALogger = StaticAnalysisLogger.deriveLogger("mra").setLevel(LogLevel.INFO)
 val SteensLogger = StaticAnalysisLogger.deriveLogger("steensgaard")
+// DSA Loggers
+val DSALogger = Logger.deriveLogger("DSA", System.out).setLevel(LogLevel.OFF)
+val ConstGenLogger = DSALogger.deriveLogger("Constraint Gen", System.out).setLevel(LogLevel.INFO)
+val SVALogger = DSALogger.deriveLogger("VSA", System.out)
+val SadDSALogger = DSALogger.deriveLogger("SadDSA", System.out)

--- a/src/test/scala/SVATest.scala
+++ b/src/test/scala/SVATest.scala
@@ -1,0 +1,381 @@
+import analysis.data_structure_analysis.*
+import boogie.SpecGlobal
+import ir.Endian.LittleEndian
+import ir.dsl.*
+import ir.*
+import org.scalatest.funsuite.AnyFunSuite
+import specification.Specification
+import util.*
+
+import scala.collection.immutable.{AbstractSeq, LinearSeq}
+
+class SVATest extends AnyFunSuite {
+
+  def runAnalysis(program: Program): StaticAnalysisContext = {
+    cilvisitor.visit_prog(transforms.ReplaceReturns(), program)
+    transforms.addReturnBlocks(program)
+    cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
+
+    val emptySpec = Specification(Set(), Set(), Map(), List(), List(), List(), Set())
+    val emptyContext = IRContext(List(), Set(), Set(), Set(), Map(), emptySpec, program)
+    RunUtils.staticAnalysis(StaticAnalysisConfig(), emptyContext)
+  }
+
+  def runTest(path: String): BASILResult = {
+    RunUtils.loadAndTranslate(
+      BASILConfig(
+        loading = ILLoadingConfig(
+          inputFile = path + ".adt",
+          relfFile = path + ".relf",
+        ),
+        simplify = true,
+        staticAnalysis = None,
+        boogieTranslation = BoogieGeneratorConfig(),
+        outputPrefix = "boogie_out",
+        dsaConfig = Some(DSAConfig(Set.empty))
+      )
+    )
+  }
+
+  def runTest(context: IRContext): BASILResult = {
+    RunUtils.loadAndTranslate(
+      BASILConfig(
+        context = Some(context),
+        loading = ILLoadingConfig(
+          inputFile = "",
+          relfFile = "",
+        ),
+        simplify = true,
+        staticAnalysis = None,
+        boogieTranslation = BoogieGeneratorConfig(),
+        outputPrefix = "boogie_out",
+        dsaConfig = Some(DSAConfig(Set.empty))
+      )
+    )
+  }
+
+  def programToContext(program: Program, globals: Set[SpecGlobal] = Set.empty, globalOffsets: Map[BigInt, BigInt] = Map.empty): IRContext = {
+    cilvisitor.visit_prog(transforms.ReplaceReturns(), program)
+    transforms.addReturnBlocks(program)
+    cilvisitor.visit_prog(transforms.ConvertSingleReturn(), program)
+
+    val spec = Specification(Set(), globals, Map(), List(), List(), List(), Set())
+    IRContext(List(), Set(), globals, Set(), globalOffsets, spec, program)
+  }
+
+  test("malloc") {
+    val mem = SharedMemory("mem", 64, 8)
+    val R0 = Register("R0", 64)
+    val R1 = Register("R1", 64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val load = MemoryLoad(R0, mem, R0, Endian.LittleEndian, 64, Some("001"))
+//    val assign = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(5, 64)), Some("assign"))
+//    val use = MemoryStore(mem, R0, R1, Endian.LittleEndian, 64, Some("use"))
+    val use = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)), Some("use"))
+    val use1 = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)), Some("use1"))
+
+    val program = prog(
+      proc("main",
+        block("call",
+          directCall("malloc"),
+          goto("block1", "block2")
+        ),
+        block("block1",
+          use,
+          goto("return")
+        ),
+        block("block2",
+          use1,
+          goto("return")
+        ),
+        block("return",
+          ret
+        )
+      ),
+
+      proc("malloc", // fake malloc
+        block("malloc_b",
+          load,
+          ret
+        )
+      ),
+    )
+
+    val context = programToContext(program, globals, globalOffsets)
+    val results = runTest(context)
+    val mainProc = results.ir.program.mainProcedure
+    val sva = results.dsa.get.sva(mainProc)
+    println(sva)
+    val r0SVA = sva.getSorted("R0")
+//    val r1SVA = sva.getSorted("R1")
+
+    val inParam = r0SVA.firstKey // TODO look into why there is an inParam
+    assert(r0SVA(inParam) == SymValueSet(Par(mainProc, inParam)), "input param not set correctly")
+
+//    val mallocCall: DirectCall = computeDomain(IntraProcIRCursor, Set(mainProc))
+//      .collectFirst {
+//        case call: DirectCall if call.target.name.startsWith("malloc") => call
+//      }.get // this doesn't work because the call is changed somewhere after the analysis
+//
+//    val mallocSB: SymBase = Heap(mallocCall)
+
+
+    val mallocValSet = r0SVA.collectFirst {
+      case (variable: LocalVar, valueSet: SymValueSet)
+        if valueSet.state.keys.exists(_.isInstanceOf[Heap]) && valueSet.size == 1 => valueSet
+    }.get // expect exactly 1 value set matching the case
+    assert(mallocValSet.state.head._2.getOffsets == Set(0), "incorrect offset for malloc symbolic value")
+
+    val outPram = r0SVA.lastKey
+    assert(r0SVA(outPram) == mallocValSet.apply(i => i + 10), "should be malloc symValueSet oplus 10")
+  }
+
+  test("call") {
+    val mem = SharedMemory("mem", 64, 8)
+    val regName = "R0"
+    val R0 = Register(regName, 64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val init = LocalAssign(R0, BitVecLiteral(20, 64))
+    val load = MemoryLoad(R0, mem, R0, Endian.LittleEndian, 64, Some("001"))
+    val assign = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)), Some("assign"))
+
+    val program = prog(
+      proc("main",
+        block("call",
+          init,
+          directCall("callee"),
+          goto("block")
+        ),
+        block("block",
+          assign,
+          ret
+        )
+      ),
+
+      proc("callee", // fake malloc
+        block("callee_b",
+          load,
+          ret
+        )
+      ),
+    )
+
+    val context = programToContext(program, globals, globalOffsets)
+    val main = program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(main)
+    val r0SVA = sva.getSorted(regName)
+
+    val returnedValSet = r0SVA.collectFirst {
+      case (variable: LocalVar, valueSet: SymValueSet)
+        if valueSet.state.keys.exists(_.isInstanceOf[Ret]) && valueSet.size == 1 => valueSet
+    }.get // expect exactly 1 value set matching the case
+    assert(returnedValSet.state.head._2.getOffsets == Set(0), "incorrect offset for returned symbolic value")
+
+    val outPram = r0SVA.lastKey
+    assert(r0SVA(outPram) == returnedValSet.apply(i => i + 10), "should be malloc symValueSet oplus 10")
+  }
+
+  test("proc entry") {
+    val R0 = Register("R0", 64)
+    val R1 = Register("R1", 64)
+    val R2 = Register("R2", 64)
+    val R3 = Register("R3", 64)
+    val bv64 = BitVecType(64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val assign1 = LocalAssign(R2, R0, Some("01"))
+    val assign2 = LocalAssign(R3, R1, Some("02"))
+//    val assign3 = LocalAssign(R0, BinaryExpr(BVADD, R2, BitVecLiteral(10, 64)), Some("assign"))
+
+    val program = prog(
+      proc("main",
+        block("block",
+          assign1,
+          assign2,
+          ret
+        )
+      ),
+    )
+
+    val context = programToContext(program, globals, globalOffsets)
+    val main = program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(main)
+
+    val R0in = LocalVar("R0_in", bv64)
+    val R1in = LocalVar("R1_in", bv64)
+
+    val R2out = LocalVar("R2_out", bv64)
+    val R3out = LocalVar("R3_out", bv64)
+
+    assert(main.formalInParam.contains(R0in), "Expected R0 as an input parameter")
+    assert(main.formalInParam.contains(R1in), "Expected R1 as an input parameter")
+
+    assert(sva(R0in) == SymValueSet(Par(main, R0in)), "Incorrect SymbolicValueSet for R0_in")
+    assert(sva(R1in) == SymValueSet(Par(main, R1in)), "Incorrect SymbolicValueSet for R1_in")
+
+    assert(sva(R0in) == sva(R2out), "Expected input param to propagate to output")
+    assert(sva(R1in) == sva(R3out), "Expected input param to propagate to output")
+
+  }
+
+  test("reassignment") {
+    val R0 = Register("R0", 64)
+    val R1 = Register("R1", 64)
+    val bv64 = BitVecType(64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val assign1 = LocalAssign(R1, R0, Some("01"))
+    val assign2 = LocalAssign(R0, BinaryExpr(BVADD, R1, BitVecLiteral(10, 64)), Some("assign"))
+
+    val program = prog(
+      proc("main",
+        block("block",
+          assign1,
+          assign2,
+          ret
+        )
+      ),
+    )
+
+    val context = programToContext(program, globals, globalOffsets)
+    val main = program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(main)
+
+    val R0in = LocalVar("R0_in", bv64)
+
+    val R0out = LocalVar("R0_out", bv64)
+    val R1out = LocalVar("R1_out", bv64)
+
+    assert(main.formalInParam.contains(R0in), "Expected R0 as an input parameter")
+
+    assert(sva(R0in) == SymValueSet(Par(main, R0in)), "Incorrect SymbolicValueSet for R0_in")
+
+    assert(sva(R0in) == sva(R1out), "Expected input param to propagate to output")
+    assert(sva(R0out) == sva(R0in).apply(i => i + 10), "Expected updated input param to propagate to output")
+  }
+
+  test("branch") {
+    val R0 = Register("R0", 64)
+    val bv64 = BitVecType(64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val assign1 = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)), Some("01"))
+    val assign2 = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(45, 64)), Some("02"))
+    val assign3 = LocalAssign(R0, R0, Some("03"))
+
+    val program = prog(
+      proc("main",
+        block("split",
+          goto(List("return", "branch1", "branch2"))
+        ),
+        block("branch1",
+          assign1,
+          goto("return")
+        ),
+        block("branch2",
+          assign2,
+          goto("return")
+        ),
+        block("return",
+          assign3, // needed so that dead code won't kill the branch assignments
+          ret
+        )
+      ),
+    )
+    val R0in = LocalVar("R0_in", bv64)
+
+    val context = programToContext(program, globals, globalOffsets)
+    val main = program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(main)
+
+    val (_, lastValSet) = sva.getSorted("R0").last
+
+    assert(sva(R0in) == SymValueSet(Par(main, R0in)), "Incorrect SymbolicValueSet for R0_in")
+    assert(lastValSet == sva(R0in).join(sva(R0in).apply(i => i + 10).join(sva(R0in).apply(i => i + 45))), "Incorrect set of offsets")
+  }
+
+  test("loop") {
+    val R0 = Register("R0", 64)
+    val bv64 = BitVecType(64)
+    val globalOffsets: Map[BigInt, BigInt] = Map.empty
+    val globals: Set[SpecGlobal] = Set.empty
+
+    val assign1 = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)), Some("01"))
+    val assign2 = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(45, 64)), Some("assign"))
+
+    val program = prog(
+      proc("main",
+        block("intro",
+          goto("head")
+        ),
+        block("head",
+          goto("body", "return")
+        ),
+        block("body",
+          assign1,
+          goto(List("head", "return"))
+        ),
+        block("return",
+          ret
+        )
+      ),
+    )
+
+    val R0in = LocalVar("R0_in", bv64)
+
+    val context = programToContext(program, globals, globalOffsets)
+    val main = context.program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(main)
+    val R0last = sva.getSorted("R0").lastKey
+
+    assert(sva(R0in) == SymValueSet(Par(main, R0in)), "Incorrect SymbolicValueSet for R0_in")
+    assert(sva(R0last) == sva(R0in).toTop, "Incorrect set of offsets")
+  }
+
+  test("load") {
+    val mem = SharedMemory("mem", 64, 8)
+    val regName = "R0"
+    val R0 = Register(regName, 64)
+    val xAddress = BitVecLiteral(2000, 64)
+    val xPointer = BitVecLiteral(1000, 64)
+    val globalOffsets = Map(xPointer.value -> xAddress.value)
+    val x = SpecGlobal("x", 64, None, xAddress.value)
+    val globals = Set(x)
+
+    val load = MemoryLoad(R0, mem, xPointer, Endian.LittleEndian, 64, Some("001"))
+    val assign = LocalAssign(R0, BinaryExpr(BVADD, R0, BitVecLiteral(10, 64)))
+
+    val program = prog(
+      proc("main",
+        block("block",
+          load,
+          assign,
+          ret
+        )
+      )
+    )
+
+    val context = programToContext(program, globals, globalOffsets)
+
+    val procedure: Procedure = program.mainProcedure
+    val sva = runTest(context).dsa.get.sva(procedure)
+
+    val r0SVA = sva.getSorted(regName)
+
+    val loadValSet = r0SVA.collectFirst {
+      case (variable: LocalVar, valueSet: SymValueSet)
+        if valueSet.contains(Loaded(load)) && valueSet.size == 1 => valueSet
+    }.get // expect exactly 1 value set matching the case
+    assert(loadValSet.get(Loaded(load)).getOffsets == Set(0), "incorrect offset for loaded symbolic value")
+
+    val outPram = r0SVA.lastKey
+    assert(r0SVA(outPram) == loadValSet.apply(i => i + 10), "should be load symValueSet oplus 10")
+  }
+}


### PR DESCRIPTION
Implements DSA pre-pass (Symbolic Value Analysis and Constraint generation)

Adds flag interface for specifying DSA type
`--dsa (none|norm|set|field|all)`
currently all options are equivalent to none which computes constraints but doesn't perform DS analysis 