### PR TITLE
Improve in-param detection completeness

### DIFF
--- a/src/main/scala/analysis/InterLiveVarsAnalysis.scala
+++ b/src/main/scala/analysis/InterLiveVarsAnalysis.scala
@@ -13,7 +13,7 @@ import ir.{Assert, LocalAssign, Assume, CFGPosition, Command, DirectCall, Indire
  * Tip SPA IDE Slides include a short and clear explanation of microfunctions
  * https://cs.au.dk/~amoeller/spa/8-distributive.pdf
  */
-trait LiveVarsAnalysisFunctions extends BackwardIDEAnalysis[Variable, TwoElement, TwoElementLattice] {
+trait LiveVarsAnalysisFunctions(inline: Boolean = false) extends BackwardIDEAnalysis[Variable, TwoElement, TwoElementLattice] {
 
   val valuelattice: TwoElementLattice = TwoElementLattice()
   val edgelattice: EdgeFunctionLattice[TwoElement, TwoElementLattice] = EdgeFunctionLattice(valuelattice)
@@ -21,9 +21,10 @@ trait LiveVarsAnalysisFunctions extends BackwardIDEAnalysis[Variable, TwoElement
 
   def edgesCallToEntry(call: Command, entry: Return)(d: DL): Map[DL, EdgeFunction[TwoElement]] = {
     d match {
-      case Left(l) => {
+      case Left(l) if inline => {
         Map(d -> IdEdge())
       }
+      case Left(l) => Map()
       case Right(_) => entry.outParams.flatMap(_._2.variables).foldLeft(Map[DL, EdgeFunction[TwoElement]](d -> IdEdge())) {
               (mp, expVar) => mp + (Left(expVar) -> ConstEdge(TwoElementTop))
       }
@@ -134,6 +135,7 @@ class InterLiveVarsAnalysis(program: Program)
   extends BackwardIDESolver[Variable, TwoElement, TwoElementLattice](program), LiveVarsAnalysisFunctions
 
 
-
+class InlineInterLiveVarsAnalysis(program: Program)
+  extends BackwardIDESolver[Variable, TwoElement, TwoElementLattice](program), LiveVarsAnalysisFunctions(true)
 
 

--- a/src/main/scala/analysis/InterLiveVarsAnalysis.scala
+++ b/src/main/scala/analysis/InterLiveVarsAnalysis.scala
@@ -13,7 +13,7 @@ import ir.{Assert, LocalAssign, Assume, CFGPosition, Command, DirectCall, Indire
  * Tip SPA IDE Slides include a short and clear explanation of microfunctions
  * https://cs.au.dk/~amoeller/spa/8-distributive.pdf
  */
-trait LiveVarsAnalysisFunctions(inline: Boolean = false) extends BackwardIDEAnalysis[Variable, TwoElement, TwoElementLattice] {
+trait LiveVarsAnalysisFunctions(inline: Boolean) extends BackwardIDEAnalysis[Variable, TwoElement, TwoElementLattice] {
 
   val valuelattice: TwoElementLattice = TwoElementLattice()
   val edgelattice: EdgeFunctionLattice[TwoElement, TwoElementLattice] = EdgeFunctionLattice(valuelattice)
@@ -132,7 +132,7 @@ trait LiveVarsAnalysisFunctions(inline: Boolean = false) extends BackwardIDEAnal
 }
 
 class InterLiveVarsAnalysis(program: Program)
-  extends BackwardIDESolver[Variable, TwoElement, TwoElementLattice](program), LiveVarsAnalysisFunctions
+  extends BackwardIDESolver[Variable, TwoElement, TwoElementLattice](program), LiveVarsAnalysisFunctions(false)
 
 
 class InlineInterLiveVarsAnalysis(program: Program)

--- a/src/main/scala/analysis/InterLiveVarsAnalysis.scala
+++ b/src/main/scala/analysis/InterLiveVarsAnalysis.scala
@@ -98,7 +98,7 @@ trait LiveVarsAnalysisFunctions extends BackwardIDEAnalysis[Variable, TwoElement
         val reads = ir.transforms.externalCallReads(c.target.procName).toSet[Variable]
         d match {
           case Left(value) =>
-            if reads.contains(value) then
+            if writes.contains(value) then
               Map()
             else
               Map(d -> IdEdge())
@@ -113,7 +113,7 @@ trait LiveVarsAnalysisFunctions extends BackwardIDEAnalysis[Variable, TwoElement
         val reads = c.actualParams.flatMap(_._2.variables).toSet
         d match {
           case Left(value) =>
-            if reads.contains(value) then
+            if writes.contains(value) then
               Map()
             else
               Map(d -> IdEdge())

--- a/src/main/scala/analysis/InterLiveVarsAnalysis.scala
+++ b/src/main/scala/analysis/InterLiveVarsAnalysis.scala
@@ -21,7 +21,9 @@ trait LiveVarsAnalysisFunctions extends BackwardIDEAnalysis[Variable, TwoElement
 
   def edgesCallToEntry(call: Command, entry: Return)(d: DL): Map[DL, EdgeFunction[TwoElement]] = {
     d match {
-      case Left(l) => Map() // maps all variables before the call to bottom
+      case Left(l) => {
+        Map(d -> IdEdge())
+      }
       case Right(_) => entry.outParams.flatMap(_._2.variables).foldLeft(Map[DL, EdgeFunction[TwoElement]](d -> IdEdge())) {
               (mp, expVar) => mp + (Left(expVar) -> ConstEdge(TwoElementTop))
       }

--- a/src/main/scala/analysis/LatticeCollections.scala
+++ b/src/main/scala/analysis/LatticeCollections.scala
@@ -151,6 +151,14 @@ enum LatticeMap[D, L] {
     case BottomMap(m) => BottomMap(m.filter(pred))
   }
 
+  def toMap: Map[D, L] = this match {
+    case Top() => Map()
+    case Bottom() => Map()
+    case TopMap(m) => m
+    case BottomMap(m) => m
+  }
+
+
   def + (kv: (D, L)): LatticeMap[D, L] = update(kv._1, kv._2)
   def ++ (kv: Map[D, L]): LatticeMap[D, L] = kv.foldLeft(this) { (m, kv) => m + kv }
 

--- a/src/main/scala/cfg_visualiser/DotTools.scala
+++ b/src/main/scala/cfg_visualiser/DotTools.scala
@@ -60,7 +60,7 @@ abstract class DotElement {
 
 /** Represents a node in a Graphviz dot file.
   */
-class DotNode(val id: String, val label: String) extends DotElement {
+class DotNode(val id: String, val label: String, highlight: Boolean = false) extends DotElement {
 
   def this(label: String) = this("n" + IDGenerator.getNewId, label)
 
@@ -69,11 +69,10 @@ class DotNode(val id: String, val label: String) extends DotElement {
   def equals(other: DotNode): Boolean = toDotString.equals(other.toDotString)
 
 
+  def hl = if (highlight) then "style=filled, fillcolor=\"orangered\", " else ""
+
   def toDotString: String =
-    s"\"$id\"" + "[label=\"" + escape(wrap(label, 100)) + "\", shape=\"box\", fontname=\"Mono\", fontsize=\"5\"]"
-
-
-  override def toString: String = toDotString
+    s"\"$id\"" + s"[${hl}label=\"" + escape(wrap(label, 100)) + "\", shape=\"box\", fontname=\"Mono\", fontsize=\"5\"]"
 
 }
 

--- a/src/main/scala/ir/IRCursor.scala
+++ b/src/main/scala/ir/IRCursor.scala
@@ -248,33 +248,54 @@ def stronglyConnectedComponents[T <: CFGPosition, O <: T](walker: IRWalk[T, O], 
 def toDot(program: Program, labels: Map[CFGPosition, String] = Map.empty, inter: Boolean = false): String = {
   if (inter) {
     val domain = computeDomain[CFGPosition, CFGPosition](InterProcIRCursor, program.procedures).toSet
-    toDot[CFGPosition](domain, InterProcIRCursor, labels)
+    toDot[CFGPosition](domain, InterProcIRCursor, labels, Set())
   } else {
     val domain = computeDomain[CFGPosition, CFGPosition](IntraProcIRCursor, program.procedures).toSet
-    toDot[CFGPosition](domain, IntraProcIRCursor, labels)
+    toDot[CFGPosition](domain, IntraProcIRCursor, labels, Set())
   }
 }
 
 
 def dotCallGraph(program: Program, labels: Map[CFGPosition, String] = Map.empty): String = {
   val domain = computeDomain[Procedure, Procedure](CallGraph, program.procedures)
-  toDot[Procedure](domain.toSet, CallGraph, labels)
+  toDot[Procedure](domain.toSet, CallGraph, labels, Set())
+}
+
+
+case class DetachedEntry(blocksEmptyPred: Set[Block], reachableFromBlockEmptyPred: Set[Block])
+
+def getDetachedBlocks(p: Procedure) = {
+  val b = p.blocks.filter(b => !p.entryBlock.contains(b) && b.prevBlocks.isEmpty )
+
+  var oldReachable = Set[Block]()
+  var reachable = b.toSet
+
+  while (oldReachable != reachable) {
+    oldReachable = reachable
+
+    reachable = reachable.flatMap(b => Set(b) ++ b.nextBlocks)
+  }
+
+  DetachedEntry(b.toSet, reachable)
 }
 
 
 def dotBlockGraph(proc: Procedure) : String = {
+  val o = getDetachedBlocks(proc)
   dotBlockGraph(proc.collect {
     case b: Block => b
-  })
+  }, o.reachableFromBlockEmptyPred)
 }
 
 def dotBlockGraph(prog: Program) : String = {
+  val e = prog.procedures.toSet.flatMap(getDetachedBlocks(_).reachableFromBlockEmptyPred)
+
   dotBlockGraph(prog.collect {
     case b: Block => b
-  })
+  }, e)
 }
 
-def dotBlockGraph(blocks: Iterable[Block]) : String = {
+def dotBlockGraph(blocks: Iterable[Block], orphaned: Set[Block]) : String = {
     val printer = translating.BasilIRPrettyPrinter()
     val labels : Map[CFGPosition, String] = (blocks.collect {
       case b : Block => b -> {
@@ -287,18 +308,19 @@ def dotBlockGraph(blocks: Iterable[Block]) : String = {
       }
     }).toMap
 
-    toDot[Block](blocks.toSet, IntraProcBlockIRCursor, labels)
+    toDot[Block](blocks.toSet, IntraProcBlockIRCursor, labels, orphaned)
 }
 
 def dotBlockGraph(program: Program, labels: Map[CFGPosition, String] = Map.empty): String = {
   val domain = computeDomain[CFGPosition, Block](IntraProcBlockIRCursor, program.procedures.flatMap(_.blocks).toSet)
-  toDot[Block](domain.toSet, IntraProcBlockIRCursor, labels)
+  toDot[Block](domain.toSet, IntraProcBlockIRCursor, labels, Set())
 }
 
 def toDot[T <: CFGPosition](
     domain: Set[T],
     iterator: IRWalk[? >: T, ?],
-    labels: Map[CFGPosition, String]
+    labels: Map[CFGPosition, String],
+    filled: Set[T],
 ): String = {
 
   val visited: mutable.Set[CFGPosition] = mutable.Set.from(domain)
@@ -329,9 +351,9 @@ def toDot[T <: CFGPosition](
 
   for (node <- domain) {
     node match
-      case s: Command => dotNodes.addOne(s -> DotNode(label(s.label), nodeText(s)))
-      case s: Block   => dotNodes.addOne(s -> DotNode(label(Some(s.label)), nodeText(s)))
-      case s          => dotNodes.addOne(s -> DotNode(label(Some(s.toString)), nodeText(s)))
+      case s: Command => dotNodes.addOne(s -> DotNode(label(s.label), nodeText(s), filled.contains(node)))
+      case s: Block   => dotNodes.addOne(s -> DotNode(label(Some(s.label)), nodeText(s), filled.contains(node)))
+      case s          => dotNodes.addOne(s -> DotNode(label(Some(s.toString)), nodeText(s), filled.contains(node)))
   }
 
   def getArrow(s: CFGPosition, n: CFGPosition) = {

--- a/src/main/scala/ir/invariant/AllVarsIndex.scala
+++ b/src/main/scala/ir/invariant/AllVarsIndex.scala
@@ -1,0 +1,48 @@
+package ir.invariant
+import ir.*
+import ir.cilvisitor.*
+import util.Logger
+import scala.collection.mutable
+
+def reachableEntry(p: Program) = {
+
+  var old = Set[Procedure]()
+  var entry = Set(p.mainProcedure)
+
+  while (old != entry) {
+    old = entry
+    entry = entry ++ entry.flatMap(_.calls)
+  }
+  
+  entry
+}
+
+
+/**
+ * The DSA local block filling should set all variables to have index > 0 if the flow is correct. Variables
+ * with index 0 will be uninitialised. 
+ */
+def allVariablesAssignedIndex(p: Program) : Boolean = {
+  val detached = p.procedures.map(getDetachedBlocks(_)).toSet
+  val badBlocks = detached.flatMap(_.reachableFromBlockEmptyPred)
+
+  val detachedHeaders = detached.flatMap(_.blocksEmptyPred)
+  if (detachedHeaders.nonEmpty) {
+    Logger.warn(s"Blocks unreachable from procedure entry: ${detachedHeaders.map(_.label)}")
+  }
+
+
+  val reachable = reachableEntry(p)
+
+  val fails = p.collect {
+    case c: Command if !(badBlocks.contains(c.parent)) && reachable.contains(c.parent.parent) => 
+      freeVarsPos(c).filterNot(v => v match {
+      case l: LocalVar if (! l.name.endsWith("_in")) => l.index > 0
+      case _ => true
+      }).map(v => (c, v)).toSet
+  }.flatten
+  for ((command, variable) <- fails) {
+    Logger.error(s"Unindexed variable $variable in ${command.parent.parent.name}::${command.parent.label}")
+  }
+  fails.isEmpty
+}

--- a/src/main/scala/ir/transforms/AbsInt.scala
+++ b/src/main/scala/ir/transforms/AbsInt.scala
@@ -217,7 +217,7 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
       savedAfter(lastBlock) = nx
       saveCount(lastBlock) = saveCount.get(lastBlock).getOrElse(0) + 1
       if (!prev.contains(nx)) then {
-        if (saveCount(lastBlock) >= 50) {
+        if (saveCount(lastBlock) >= 100) {
           Logger.warn(s"Large join count on block ${lastBlock.label}, no fix point? (-v for mor info)")
           Logger.debug(lastBlock.label + "    ==> " + x)
           Logger.debug(lastBlock.label + "    <== " + nx)

--- a/src/main/scala/ir/transforms/AbsInt.scala
+++ b/src/main/scala/ir/transforms/AbsInt.scala
@@ -217,8 +217,8 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
       savedAfter(lastBlock) = nx
       saveCount(lastBlock) = saveCount.get(lastBlock).getOrElse(0) + 1
       if (!prev.contains(nx)) then {
-        if (saveCount(lastBlock) >= 100) {
-          Logger.warn(s"Large join count on block ${lastBlock.label}, no fix point? (-v for mor info)")
+        if (saveCount(lastBlock) >= 1000) {
+          Logger.warn(s"Large join count on block ${lastBlock.label}, no fix point? (-v for more info)")
           Logger.debug(lastBlock.label + "    ==> " + x)
           Logger.debug(lastBlock.label + "    <== " + nx)
         }

--- a/src/main/scala/ir/transforms/ProcedureParameters.scala
+++ b/src/main/scala/ir/transforms/ProcedureParameters.scala
@@ -112,7 +112,6 @@ object DefinedOnAllPaths {
   }
 }
 
-
 def liftProcedureCallAbstraction(ctx: util.IRContext): util.IRContext = {
 
   val mainNonEmpty = ctx.program.mainProcedure.blocks.nonEmpty
@@ -390,6 +389,7 @@ def inOutParams(
     })
     .toMap
 
+  val alwaysReturnParams = (0 to 7).map(i => Register(s"R$i", 64))
 
   val inout = readWrites.collect {
     case (proc, rws) if p.mainProcedure == proc => {
@@ -402,7 +402,7 @@ def inOutParams(
     }
     case (proc, rws) => {
       val liveStart = lives(proc)._1
-      val liveEnd = lives(proc)._2
+      val liveEnd = lives(proc)._2 ++ alwaysReturnParams
 
       val outParams = liveEnd.intersect(rws.writes)
       val inParams = liveStart
@@ -424,6 +424,7 @@ def inOutParams(
       r <- stmts.foldLeft(init)(defUseDom.transfer).get(v)
     } yield (r.contains(Def.Entry))
     r.getOrElse(true)
+    true
   }
 
   var newParams = inout

--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -50,7 +50,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
           for ((s, i) <- instruction.zipWithIndex) {
             val label = blockAddress.map {(a: BigInt) =>
               val instructionAddress = a + (opcodeSize * instructionCount)
-              instructionAddress.toString + "$" + i
+              instructionAddress.toString + "_" + i
             }
 
             statements.appendAll(visitStmt(s, label))
@@ -171,8 +171,8 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
     val (expr, load) = visitExpr(ctx.expr)
     if (expr.isDefined) {
       if (load.isDefined) {
-        val loadWithLabel = MemoryLoad(load.get.lhs, load.get.mem, load.get.index, load.get.endian, load.get.size, label.map(_ + "$0"))
-        val assign = LocalAssign(LocalVar(name, ty), expr.get, label.map(_ + "$1"))
+        val loadWithLabel = MemoryLoad(load.get.lhs, load.get.mem, load.get.index, load.get.endian, load.get.size, label.map(_ + "_0"))
+        val assign = LocalAssign(LocalVar(name, ty), expr.get, label.map(_ + "_1"))
         Seq(loadWithLabel, assign)
       } else {
         val assign = LocalAssign(LocalVar(name, ty), expr.get, label)
@@ -188,8 +188,8 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
     val (rhs, load) = visitExpr(ctx.expr)
     if (lhs.isDefined && rhs.isDefined) {
       if (load.isDefined) {
-        val loadWithLabel = MemoryLoad(load.get.lhs, load.get.mem, load.get.index, load.get.endian, load.get.size, label.map(_ + "$0"))
-        val assign = LocalAssign(lhs.get, rhs.get, label.map(_ + "$1"))
+        val loadWithLabel = MemoryLoad(load.get.lhs, load.get.mem, load.get.index, load.get.endian, load.get.size, label.map(_ + "_0"))
+        val assign = LocalAssign(lhs.get, rhs.get, label.map(_ + "_1"))
         Seq(loadWithLabel, assign)
       } else {
         val assign = LocalAssign(lhs.get, rhs.get, label)
@@ -208,10 +208,10 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
     if (expr.isDefined) {
       if (load.isDefined) {
         val loadWithLabel = MemoryLoad(load.get.lhs, load.get.mem, load.get.index, load.get.endian, load.get.size, label.map(_ + "$0"))
-        val assign = LocalAssign(LocalVar(name + "$" + blockCount + "$" + instructionCount, ty), expr.get, label.map(_ + "$1"))
+        val assign = LocalAssign(LocalVar(name + "_" + blockCount + "_" + instructionCount, ty), expr.get, label.map(_ + "$1"))
         Seq(loadWithLabel, assign)
       } else {
-        val assign = LocalAssign(LocalVar(name + "$" + blockCount + "$" + instructionCount, ty), expr.get, label)
+        val assign = LocalAssign(LocalVar(name + "_" + blockCount + "_" + instructionCount, ty), expr.get, label)
         Seq(assign)
       }
     } else {
@@ -260,7 +260,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
   private def visitExprVar(ctx: ExprVarContext): Option[Expr] = {
     val name = visitIdent(ctx.ident)
     name match {
-      case n if constMap.contains(n) => Some(LocalVar(n + "$" + blockCount + "$" + instructionCount, constMap(n)))
+      case n if constMap.contains(n) => Some(LocalVar(n + "_" + blockCount + "_" + instructionCount, constMap(n)))
       case v if varMap.contains(v) => Some(LocalVar(v, varMap(v)))
       case "SP_EL0" => Some(Register("R31", 64))
       case "_PC" => Some(Register("_PC", 64))
@@ -401,14 +401,14 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val name = function.stripSuffix(".0")
         val size = parseInt(typeArgs(0))
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + size, argsIR, BoolType)), None)
+        (Some(UninterpretedFunction(name + "_" + size, argsIR, BoolType)), None)
 
       case "FPAdd.0" | "FPMul.0" | "FPDiv.0" | "FPMulX.0" | "FPMax.0" | "FPMin.0" | "FPMaxNum.0" | "FPMinNum.0" | "FPSub.0" =>
         checkArgs(function, 1, 3, typeArgs.size, args.size, ctx.getText)
         val name = function.stripSuffix(".0")
         val size = parseInt(typeArgs(0)).toInt
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + size, argsIR, BitVecType(size))), None)
+        (Some(UninterpretedFunction(name + "_" + size, argsIR, BitVecType(size))), None)
 
       case "FPMulAddH.0" | "FPMulAdd.0" |
            "FPRoundInt.0" |
@@ -417,7 +417,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val name = function.stripSuffix(".0")
         val size = parseInt(typeArgs(0)).toInt
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + size, argsIR, BitVecType(size))), None)
+        (Some(UninterpretedFunction(name + "_" + size, argsIR, BitVecType(size))), None)
 
       case "FPRecpX.0" | "FPSqrt.0" | "FPRecipEstimate.0" |
            "FPRSqrtStepFused.0" | "FPRecipStepFused.0" =>
@@ -425,14 +425,14 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val name = function.stripSuffix(".0")
         val size = parseInt(typeArgs(0)).toInt
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + size, argsIR, BitVecType(size))), None)
+        (Some(UninterpretedFunction(name + "_" + size, argsIR, BitVecType(size))), None)
 
       case "FPCompare.0" =>
         checkArgs(function, 1, 4, typeArgs.size, args.size, ctx.getText)
         val name = function.stripSuffix(".0")
         val size = parseInt(typeArgs(0))
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + size, argsIR, BitVecType(4))), None)
+        (Some(UninterpretedFunction(name + "_" + size, argsIR, BitVecType(4))), None)
 
       case "FPConvert.0" =>
         checkArgs(function, 2, 3, typeArgs.size, args.size, ctx.getText)
@@ -440,7 +440,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val outSize = parseInt(typeArgs(0)).toInt
         val inSize = parseInt(typeArgs(1))
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + outSize + "$" + inSize, argsIR, BitVecType(outSize))), None)
+        (Some(UninterpretedFunction(name + "_" + outSize + "_" + inSize, argsIR, BitVecType(outSize))), None)
 
       case "FPToFixed.0" =>
         checkArgs(function, 2, 5, typeArgs.size, args.size, ctx.getText)
@@ -449,7 +449,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val inSize = parseInt(typeArgs(1))
         // need to specifically handle the integer parameter
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + outSize + "$" + inSize, argsIR, BitVecType(outSize))), None)
+        (Some(UninterpretedFunction(name + "_" + outSize + "_" + inSize, argsIR, BitVecType(outSize))), None)
 
       case "FixedToFP.0" =>
         checkArgs(function, 2, 5, typeArgs.size, args.size, ctx.getText)
@@ -458,7 +458,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val outSize = parseInt(typeArgs(1)).toInt
         // need to specifically handle the integer parameter
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + outSize + "$" + inSize, argsIR, BitVecType(outSize))), None)
+        (Some(UninterpretedFunction(name + "_" + outSize + "_" + inSize, argsIR, BitVecType(outSize))), None)
 
       case "FPConvertBF.0" =>
         checkArgs(function, 0, 3, typeArgs.size, args.size, ctx.getText)
@@ -472,7 +472,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         val inSize = parseInt(typeArgs(0))
         val outSize = parseInt(typeArgs(1)).toInt
         val argsIR = args.flatMap(visitExprOnly).toSeq
-        (Some(UninterpretedFunction(name + "$" + outSize + "$" + inSize, argsIR, BitVecType(outSize))), None)
+        (Some(UninterpretedFunction(name + "_" + outSize + "_" + inSize, argsIR, BitVecType(outSize))), None)
 
       case "BFAdd.0" | "BFMul.0" =>
         checkArgs(function, 0, 2, typeArgs.size, args.size, ctx.getText)
@@ -617,7 +617,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
   private def visitLExprVar(ctx: LExprVarContext): Option[Variable] = {
     val name = visitIdent(ctx.ident)
     name match {
-      case n if constMap.contains(n) => Some(LocalVar(n + "$" + blockCount + "$" + instructionCount, constMap(n)))
+      case n if constMap.contains(n) => Some(LocalVar(n + "_" + blockCount + "_" + instructionCount, constMap(n)))
       case v if varMap.contains(v) => Some(LocalVar(v, varMap(v)))
       case "SP_EL0" => Some(Register("R31", 64))
       case "_PC" => Some(Register("_PC", 64))

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -303,7 +303,7 @@ class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, List[InsnSem
 
   // makes label boogie friendly
   private def convertLabel(procedure: Procedure, label: ByteString, blockCount: Int): String = {
-    "$" + procedure.name + "$__" + blockCount + "__$" + byteStringToString(label).replace("=", "").replace("-", "~").replace("/", "\'")
+    procedure.name + "__" + blockCount + "__" + byteStringToString(label).replace("=", "").replace("-", "__").replace("/", "__")
   }
 
   // handles stray assignments to the program counter (which are indirect calls that DDisasm failed to identify)
@@ -582,7 +582,7 @@ class GTIRBToIR(mods: Seq[Module], parserMap: immutable.Map[String, List[InsnSem
       val resolvedCall = DirectCall(target)
 
       val assume = Assume(BinaryExpr(BVEQ, targetRegister, BitVecLiteral(target.address.get, 64)))
-      val label = block.label + "$" + target.name
+      val label = block.label + "_" + target.name
       newBlocks.append(Block(label, None, ArrayBuffer(assume, resolvedCall), GoTo(returnTarget)))
     }
     removePCAssign(block)

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -260,13 +260,6 @@ object IRTransform {
     transforms.addReturnBlocks(ctx.program)
     cilvisitor.visit_prog(transforms.ConvertSingleReturn(), ctx.program)
 
-    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
-      val dir = File("./graphs/")
-      if (!dir.exists()) then dir.mkdirs()
-      for (p <- ctx.program.procedures) {
-        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
-      }
-    }
 
     val externalRemover = ExternalRemover(externalNamesLibRemoved.toSet)
     externalRemover.visitProgram(ctx.program)
@@ -646,9 +639,13 @@ object RunUtils {
 
     // transforms.DynamicSingleAssignment.applyTransform(program, liveVars)
     transforms.OnePassDSA().applyTransform(program)
-    Logger.info(s"DSA ${timer.checkPoint("DSA ")} ms ")
-    if (ir.eval.SimplifyValidation.validate) {
-      assert(invariant.allVariablesAssignedIndex(program))
+    (invariant.allVariablesAssignedIndex(program))
+    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
+      val dir = File("./graphs/")
+      if (!dir.exists()) then dir.mkdirs()
+      for (p <- ctx.program.procedures) {
+        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
+      }
     }
 
     transforms.removeEmptyBlocks(program)

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -639,14 +639,6 @@ object RunUtils {
 
     // transforms.DynamicSingleAssignment.applyTransform(program, liveVars)
     transforms.OnePassDSA().applyTransform(program)
-    (invariant.allVariablesAssignedIndex(program))
-    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
-      val dir = File("./graphs/")
-      if (!dir.exists()) then dir.mkdirs()
-      for (p <- ctx.program.procedures) {
-        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
-      }
-    }
 
     transforms.removeEmptyBlocks(program)
 
@@ -657,6 +649,8 @@ object RunUtils {
     DebugDumpIRLogger.writeToFile(File("il-after-dsa.il"), pp_prog(program))
 
     if (ir.eval.SimplifyValidation.validate) {
+      Logger.info("DSA no uninitialised")
+      assert(invariant.allVariablesAssignedIndex(program))
       // Logger.info("Live vars difftest")
       // val tipLiveVars : Map[CFGPosition, Set[Variable]] = analysis.IntraLiveVarsAnalysis(program).analyze()
       // assert(program.procedures.forall(transforms.difftestLiveVars(_, tipLiveVars)))
@@ -709,6 +703,13 @@ object RunUtils {
       val w = BufferedWriter(FileWriter("rewrites.smt2"))
       ir.eval.SimplifyValidation.makeValidation(w)
       w.close()
+    }
+    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
+      val dir = File("./graphs/")
+      if (!dir.exists()) then dir.mkdirs()
+      for (p <- ctx.program.procedures) {
+        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
+      }
     }
 
     Logger.info("[!] Simplify :: finished")


### PR DESCRIPTION
We were missing in and out parameters due to the inter-procedural effects of introducing the parameters, e.g. out-parameters that are required due to being modified in the procedure and live after, but which were not known to be live by the initial liveness analysis (i.e. a use is introduced by adding the out-parameter to the return statement).

(image below shows the before and after the DSA pass for a buggy example; R3 has not been made an inparam so `lf_goto_l00..30f` on the RHS uses the uninitialised `R3` variable.) This pr adds r3 as an in-param. Without [5e2b215](https://github.com/UQ-PAC/BASIL/pull/314/commits/5e2b2150fddb5923991374f4f590ed461d0c7308)it will remove r3 as an out-param.

![image](https://github.com/user-attachments/assets/b731624a-854c-4ec2-b258-b9b4abb7f8c1)

fixed: 

![f2](https://github.com/user-attachments/assets/049e65c1-11e7-46f2-8320-2bb189f940c3)


I added an invariant check to make sure the dynamic single assignment doesn't produce an uninitialised variables (variables with ssa index 0). Making this check pass was the main goal of this pr. (The check is enabled with flag `--validate-simplify`). 

The general fix to capture all flow in the in-params is;

- (0) make live vars inline across returns so that we consider the variables live after the procedure as live at the start, i.e. we have inparams that exist solely for flow through the function. This is overapproximate if a register is only read after the call however, but we probably remove this case with the remove-redundant-inparams post-pass which uses an intraproc liveness analysis.

1. Identify the in and out parameters
   - in: everything live at the entry
   - out: everything assigned-to and (live after any call to the procedure or in [R0...R7]**).
   - out if the procedure is main: everything assigned to on all paths
2. Calculate the flow-on effects of this with a fix-point over the call graph. For each use introduced by a return or procedure in-param, check if it is reaching the procedure entry (using a reaching-defs analysis) and if so add it to the in-param list. For each assignment introduced by a procedure call, if it is live at exit add it to the outparams list.

Both (0) and (2) are neccessary due to uses introduced by outparameters (for not-live but clobbered variables) that the liveness analysis doesn't know about.  

- The reaching-procedure-entry analysis slightly reduces the number of in-params we find initially:  [see diff of param counts](https://diffvisualizer.com/?state=eJztXF2P47YV%2FSsDPy8KkeKX9rVFgAL5eGry0BaCRpLHwtqSK8nxTor%2B95LilUdXJEVnd9JOggECBNg9pMjLc8%2B9pE%2Fy7113rH4sjpd693H3979%2B%2F80P%2F3x4ePjTtzlLKCdJzmiSyow%2BNO1Dmjx0l%2FGB%2FqNd40qLy4QyOEotjiyA3%2Fzte4Ok0iIJTRbIxAPMAMiXnybcgywAaT8%2BI5kH%2BQhIxZZI6UHChmhilyksUnmQFSCJiM1ZAzJFO%2FIA9wBkdkNkAqYuME0AKNgy7B4gnCNVaDvCg6SAzNB2PBtPU4vUR7mc07PxlAGSWnYoi%2FRtiAOSsUjYUwFIkcTWCYxLpYjNqQCJ2O6NEpCTJTHKpUBORqM7AnIylkSIlAI5Gbc7yoKpkQI5maSxOYGcTKEz8iGBnTxhkSgxoCeHXFfBvTPgJ0%2FtjmSQIQz4yXlsRwz4ybEs%2BL4O%2FORWFuZ4%2BpDATwGykIUykwE9BYmlEQN6CqsKWx8HegqmYlsHegrQhfBhMqCnsMKQWgXx8JgBOwXSBY9uMyCnBFng4f0AOSWN7gfIKVn0gICcUsQox4GcUooIjTlQTiUxInGgnKJonR4gME5Fc50D45TNdTggD%2BM4ME7JmHhxYJyyqZ4GqwYHwmVJrFxyIFyGqrqv%2FnMgXJZGww6My6INAAciZdH85ZZIWpiS2Nf3gLQJvLEjkQAyja1TEEDaBJ5VzrNOQQEplpH3fj0FpEq281IwAGbRDVnKMQIZvIEUgMQZ7AmnkIC0GZxuzKkAKWKpITJAShGbswCkLewbqiAs6fQ%2FKhLOEoCQ6mGZExUgWbKdwQLISTkqgh4xFkBOinLds0oJ3KQqJrESuJniXPfsRwI3U7o8II98SKBmmi7bFN8qgZopj20HmJlGS7oEZqYgCTI4JRCTJbE%2BUgIxWbSkSyAmA0UInrgEXjIW3Q%2FwkomYFEsgJlPRDQExGW71PcIlgZmcIInzMFMCMzmN7UgBNTlDCeTZkQJq8mirr4CaHFr9cN%2BjgJs8i7WRCsgpotVfATsFrv4eNVTATmElYc5039eBnoLHSKeAngJpgueIFLBTqOiGgJ4yiYm2AnpKmsSQQE8JosDCQQJ6Slz%2FfesEekoRK0MK6CkVujB71pkBPVUSqqt5XnX507F7LI55NXb9kBeXz3oMuVHafdvIq2Pe18euLMY6H8ZibMr83NTTKFAg36h90zYaI%2FWtR4QwGjJOXRAu8Aijv9iP08dAk1MXVJTHvKiqCTVzHsLEVrDyUJefDJAzJAzLwJfF8Zhf6%2BJTvm9hm8HQl4dL%2B6mu8qoYi3yoW7OIlM7yBAOy5YCu3TdPeXnshimGMktDXfIM7S7taKGUBSIA0O5cTysWK%2FozF3ruztOciqJ4eb4%2F1PbrcD%2Fxfv38rJk0HqbASqT3ao3rexss3TOoOU%2Fg40sZL%2FuuMAfFOcd7WVZtFHUiZTDqVd3XT80w1n0%2Bnkzw23qwR5uihhFN3vR1OWru%2F%2BtSD1MIshQHS7no8dK29VGDKYXObQYvlbK6nM63gAmahC411WUBI%2BjjhKxwi7hmBF%2BTlnHdd%2F216KvFtijleKXKA3%2FZl1CoRUBh3vfFqc717k7PVlUyGsjrfV%2FXiAoJpgLGdqf8sRhqwTRUkBRdqZdxfTL0T0h%2BLp5McjHGkyVnSeZg5QsW%2Bq4Zu56XJ%2FQFK%2BVytUjgDbaq20aLwg0u0E14BR%2Fzwzie80NdaJbmrYmgDrPKMNfIxpifzUu4GaRvvaGGXY%2Fpi7bqThBEidmEIqOLg06PunzMy%2F75bDgiUo5qNF6OxTeDFc1PtTl8QSkmIXVHnIpPNaBTJkPqDmAtQ%2FPMPJyGNiKDpnf58xQRgjQTsXXG3gSEoFOly5pwOGr1gCLDBUNPT%2BjNzwJnzeZyfkDOnOS2yGrKKi4UbkPcKSfNMDNyFFd3kUYMzIy4BpDEAU45aGZkKP%2BZA3yqYS%2Fhq70FNu2Eo6gBoe6XT90UR33VCx%2FkBBwuj6XddsYQtakbScCa4m3wXAVL4OFUlPmp4qY%2F0W01qhrLtD9001Fq5Ssn%2FVcJkhOkq1M%2BPnbVc171U2lNb1cPH%2FVu6Jl8jJBg9bK5Xgx2hAbPj7neYBjwueh1e6E1UzdrZvJVoV0GummhdE1tz7G4tOXhXFShqqizfCk9RqkUugqi49boU33q%2BufpWH6p%2B84kcJKhK8yS6%2BYktYDaREs5VgV0OMfuWvdlMXVRus6gCyFaw6l40lGYymhVj%2FYozUU%2FWBlOxcRj3UgLFsi0U8Xyx8t%2BP0VAKI6AdI00vfBwyMvR9NpCn8USndIVeuqKZyyw3iMfBnruu7IeNC90e26aJWH0Zmvu24DncWqAhMR1wBnQ62N%2BWYxcvkUlK%2BgwavBpigd%2BN8JA%2FhI4SQWuo2skCpwkCrFhtVaOArcqn9kK6gQuI2rjULgTOEkJaoedAcvAZQllAb4b6C1w8vY7qydw9elzZ9km0Ts0%2BvBz%2FXm6UnG%2BksvlN9v6%2BtKtcxXq1g1s0aFJSUJJ23Y6PJ%2Bf56wVuN1B0jtDT8VYHibwRp%2FTjscTNcJ30II2DNeuN%2FMzkoTrtBlilKzUBzAYGWYJvjci0Z7Q0%2Fz638tPJKuWmHoH6RKPBilccuR60EvPzUgqwzGy2OHctZO6mTfg7YnNFc02R%2FpGjnqT5YGe9QV4ak403cZpYg7mB982ZzR0CUxSVKCQYs5Y2yiw1ZkmCNnX7dxIMc5x16M8yJ%2BL5lg8HmG9%2BMdWF35b7eqqhna27OU4R2RSDu7Wygl46%2FXcZs7LVo7jHyY9OOjkeIZ2Lx3g3KCJFLV8zAFCgybmX2mUG55Ff8bhh7kgzL4NcEFI8Hp%2B7msTcdsLvLRI5pcldKKIJX3TjlrHphaAI%2FlEt1kQE61Q%2BkSbEriqVtfkzBnxsgx9%2FOG3AAseD5NCawWShAflZMIu6MJYuK68YOGAdQMoglf2F%2FRMWZ6KYHf5goYU43DTgzNMg9i2%2FmwHkGR5a15yKPQ0otAPoxSNMIqDikMWvOEOZdHOpy6RFhO6grV6EYeuMxWZZYIEdXtong76MnucuoiUp0G5GTr70jalOsvCPZ8B3ujDb%2BYT37e7adeGPc%2FTrLhLXH0d%2BlmDS0SQvxpoLqxHm55JWO0BONoqwhmOJzqjCTp0R3MN1hdm%2FGiTeoHX5liVxVTMdEzDDzKDbpoGvkghhYsOSiF9LdMNzvTGw4KlaeyWDzwJ%2BuVgSdWxb052rtXPg8to3t6q0pTgt0PlouabRpYEgw7IhWLIcL9%2FaZuyq%2BqJ7VgLEdsv5%2FPi9qLQhlEPdOmPdXubkdLgfq59o4Xy2hdm5umZJKFBPbler2uBJYqEL1u%2FnPT9rSvtKaLN69PZfbjZMf986Yeu%2F9b8WNB07e4jMWaVDzvdSt7z1%2B9mzjdp5gxbxt7NnO9mznczZ2Cd%2Fwszpwxl5u%2FVzBm0ALybOd%2BGmdN9%2FflqM2fQjfVu5nwjZk6g8R%2FIzLnhTv1iM%2BfGnG%2FJzBnM4Hcz5x%2FUzBk88Xcz57uZc5Hpb93MGRbYtZlzA%2Flu5vz9mTnhOKNmTrjd%2FjZmTvuftN5n5nQV9%2BvNnJCl95g5IV53mDmJ5%2BseMyco2euZOSGYb8DMOYf1LjMnVIk7zJzE6Up8Zs5Zo%2B8xcxI3rltmzsTd1oaZ00PuVzBzetw4ITNnOkFf3cxJ3Mr2WmZO4oNHzJzEFZ2omdPz%2FBowc86Pe%2FeaOYn0LGfTzDkny51mTlddgmZOwl2%2BBs2cHrZ%2BvZkzcd%2F8QmZO5SS338zp0WG%2FmRPiGjVzzid8h5nT7b%2FeoJkzcem0aeb0NAJeMydxZTpk5pytdb%2BJmdNH1KCZ0xeM%2F5eZc47K%2FWZOj0wFzJyew3klM6fnx2DHzEmcTAuYOYkrHBtmTvgfntxl5nTlY9PMCUn%2FK8ycgcV8lZkTVnGHmZO4GrVh5kx8a%2FWbOYFid5s5iTdwW2bOwGJ8Zk6P88Zv5vQFzjFz%2Bgy%2BX2zmhGpyh5nT8wNSwMw5k%2FYuMyf1NBYxM6cn3TbMnJ5mOG7m9Ahs3MyZuGr1KmbO%2BcTvMXNCd%2Fz6Zs75%2FnGHmdPzfPpKZk7oaVy4Y%2Bb0HKDfzOm6mb%2FSzOmRSb%2BZE6h%2Fh5nTbdDerJkzcduYVzJzehqkoJlzzpi7zJweOQmbOROnroTNnL4r%2B4aZM%2FGFO2TmdNU4YuaUDode08zpefH8SjOnr9kOmDndu6PfzElcBfObOecK9ppmznnOuJnTU0YCZk7fHdtr5gTh%2FBVmznnqu8yc81m9jpnTQ9UvNXMSt74EzJyem8bv3czp0ZNNM6cnBD4zJ5lPZ%2FdhVxX9p%2B%2F0Incf98VxqD%2FsBl1Jxh%2Bb%2Brr7OPYX%2FQeHpqq%2Fbdr6%2B8vpse6H5R9%2FpwdPfwRjjxo2%2FLDfa43ZfUz0XIfu%2Bpdmv%2F%2BhPT7P4071eOiq3cddpf%2FiJ92ADTsL%2FEnvpj%2FpGWG6%2F%2FwXW3nwVg%3D%3D) for a fairly substantial time cost

@sadrabt I would appreciate if you checked the changes to `InterLiveVars` makes sense

---

This invariant check brought up a few other problems worth considering;

- The IDE analyses only work on the procedures reachable from main, it might be worth running it on every subgraph in the callgraph (nominating a sensible entry point for non-main subgraphs/sccs.) Currently about 1/2 of cntlm doesn't get a liveness result currently so we can't apply DSA form to it. This will eventually be culled regardless and I suppose there is some interaction with the indirect call resolution and DSA which will require future work.
- Its also possibly worth adding a pre-pass that removes every procedure from which main is reachable via calls, assuming we don't have recursion over the main procedure.
- I also added `coalesceBlocks` to the initial cleanup pass to help the ReplaceReturns pass, this improves the coverage of the InterLiveVars analysis by making more code reachable from `return`.
  - In doing this i notice there's a few cases where R30 is explicitly set to an address towards the start of main immediately before calling `__assert_fail`, which I don't understand. 
- The invariant also has to ignore blocks that aren't reachable from procedure entry (but are reachable backwards from return), but this seems sensible. These blocks are now highlighted red in the blockgraph.
- ** : cntlm's `to_base64` returns a constant 0, and otherwise returns through outparam pointers so if we treat out params as just those written-to and live after the call we get the signature `proc to_base64_4270508(R0_in:bv64, R1_in:bv64, R2_in:bv64, R31_in:bv64, R3_in:bv64) -> (R31_out:bv64)`. This is fine unless we introduce a use of R0 after a call to base64, so its not preserving all clobbers. Introducing a use is possible if we have a call after it which modifies R0 on one path, requiring it to return the initial R0 value on the other path. Since this use is introduced after the liveness analysis is run we don't know R0 is live in this procedure, and hence its not live in to_base64 and we lose the return value. Generally because of this it seems easier to overapproximate initially and prove that specific registers are definitely not parameters, subsequently removing them. It is generally harder to add parameters than remove them. Alternatively we make the interproc fixed point in (2) also update the liveness used to cull return parameters. Not this is not a problem if we simply require return parameters be live since then we aren't adding uses unknown to the liveness analysis, but this breaks down if we later resolve an indirect call which does introduce a use of the return value. 
- 
---

This also introduces a pretty significant performance regression (testing cntlm-noduk.gts --simplify):

before

```
Executed in   38.53 secs    fish           external
   usr time    1.43 secs  740.00 micros    1.43 secs
   sys time    0.60 secs  305.00 micros    0.60 secs
```

after:

```
Executed in   59.25 secs    fish           external
   usr time    1.65 secs  749.00 micros    1.65 secs
   sys time    1.01 secs  109.00 micros    1.01 secs

```