### PR TITLE
Support parameters IR DSL

### DIFF
--- a/src/main/scala/ir/Expr.scala
+++ b/src/main/scala/ir/Expr.scala
@@ -375,7 +375,7 @@ case class LocalVar(varName: String, override val irType: IRType, val index: Int
 }
 
 object LocalVar {
-  def unapply(l: LocalVar): Option[(String, IRType)] = Some((s"${l.name}_${l.index}", l.irType))
+  def unapply(l: LocalVar): Option[(String, IRType, Int)] = Some((l.name, l.irType, l.index))
 
 }
 

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -3,7 +3,7 @@ import util.Logger
 import sourcecode.Line, sourcecode.FileName
 import java.io.*
 
-val monlog = Logger.deriveLogger("statemonad", PrintStream(File("monad")))
+val monlog = Logger.deriveLogger("statemonad")
 
 /*
  * Flattened state monad with error.

--- a/src/test/scala/ir/CILVisitorTest.scala
+++ b/src/test/scala/ir/CILVisitorTest.scala
@@ -171,7 +171,7 @@ class CILVisitorTest extends AnyFunSuite {
       val res = mutable.ArrayBuffer[String]()
       override def vlvar(e: Variable) = {
         e match {
-          case LocalVar(n, _) =>
+          case LocalVar(n, _, _) =>
             ChangeDoChildrenPost(LocalVar("e" + n, e.getType), e => { res.append(e.name); e });
           case _ => DoChildren()
         }
@@ -179,7 +179,7 @@ class CILVisitorTest extends AnyFunSuite {
 
       override def vrvar(e: Variable) = {
         e match {
-          case LocalVar(n, _) =>
+          case LocalVar(n, _, _) =>
             ChangeDoChildrenPost(LocalVar("e" + n, e.getType), e => { res.append(e.name); e });
           case _ => DoChildren()
         }


### PR DESCRIPTION
Example

```scala
    val p = prog(
      proc("p1", Seq(("R0_in" -> BitVecType(64))), Seq(("R0_out", BitVecType(64))),
        block("b1",
          ret("R0_out" -> LocalVar("R0_in", BitVecType(64)))
        )
      ),
      proc("main", Seq(), Seq(("R0_out") -> BitVecType(64)),
        block("l_main",
          indirectCall(R1), goto("returntarget")
        ),
        block("block2",
          directCall(Seq(("R0_out" -> R0)), "p1", "R0_in" -> BitVecLiteral(150, 64)), goto("returntarget")
        ),
        block("returntarget",
          ret("R0_out" -> BitVecLiteral(1, 64))
        )
      ),
    )
```