### PR TITLE
expr: make BinOp and UnOp sealed

### DIFF
--- a/src/main/scala/analysis/ConstantPropagation.scala
+++ b/src/main/scala/analysis/ConstantPropagation.scala
@@ -38,12 +38,14 @@ trait ConstantPropagation {
           case BVASHR => bvashr(left, right)
           case BVCOMP => bvcomp(left, right)
           case BVCONCAT => concat(left, right)
+          case x => Top
         }
       case un: UnaryExpr =>
         val arg = eval(un.arg, env)
         un.op match {
           case BVNOT => bvnot(arg)
           case BVNEG => bvneg(arg)
+          case x => Top
         }
       case _ => valuelattice.top
     }

--- a/src/main/scala/analysis/Lattice.scala
+++ b/src/main/scala/analysis/Lattice.scala
@@ -341,7 +341,6 @@ class ValueSetLattice[T] extends Lattice[ValueSet[T]] {
           case BoolEQUIV => ???
       case intOp: IntBinOp =>
         applyOp(intOp.toBV, lhs, rhs)
-      case _ => ???
   }
 
   def applyOp(op: UnOp, rhs: ValueSet[T]): ValueSet[T] = {
@@ -356,7 +355,6 @@ class ValueSetLattice[T] extends Lattice[ValueSet[T]] {
           case BoolToBV1 => ???
       case intOp: IntUnOp =>
         applyOp(intOp.toBV, rhs)
-      case _ => ???
   }
 
   def add(x: ValueSet[T], y: ValueSet[T]): ValueSet[T] = {

--- a/src/main/scala/ir/Expr.scala
+++ b/src/main/scala/ir/Expr.scala
@@ -144,7 +144,7 @@ case class UnaryExpr(op: UnOp, arg: Expr) extends Expr {
   override def acceptVisit(visitor: Visitor): Expr = visitor.visitUnaryExpr(this)
 }
 
-trait UnOp
+sealed trait UnOp
 
 sealed trait BoolUnOp(op: String) extends UnOp {
   override def toString: String = op
@@ -231,7 +231,7 @@ case class BinaryExpr(op: BinOp, arg1: Expr, arg2: Expr) extends Expr {
 
 }
 
-trait BinOp {
+sealed trait BinOp {
   def opName: String
 }
 


### PR DESCRIPTION
idk why they weren't sealed, but it everything seems to compile with this change so it's probably fine

new non-exhaustive warnings:
```scala
[warn] -- [E029] Pattern Match Exhaustivity Warning: /home/rina/progs/basil/src/main/scala/analysis/ConstantPropagation.scala:21:12 
[warn] 21 |        bin.op match {
[warn]    |        ^^^^^^
[warn]    |match may not be exhaustive.
[warn]    |
[warn]    |It would fail on pattern case: BoolEQ, BoolNEQ, BoolAND, BoolOR, BoolIMPLIES, BoolEQUIV
[warn]    |(More unmatched cases are elided)
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E029] Pattern Match Exhaustivity Warning: /home/rina/progs/basil/src/main/scala/analysis/ConstantPropagation.scala:44:11 
[warn] 44 |        un.op match {
[warn]    |        ^^^^^
[warn]    |        match may not be exhaustive.
[warn]    |
[warn]    |        It would fail on pattern case: BoolNOT, BoolToBV1, IntNEG
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
```

there were also two unreachable case warnings (due to exhaustive cases being defined). i've fixed these in the same commit.
```scala
[warn] -- [E121] Pattern Match Warning: /home/rina/progs/basil/src/main/scala/analysis/Lattice.scala:344:11 
[warn] 344 |      case _ => ???
[warn]     |           ^
[warn]     |Unreachable case except for null (if this is intentional, consider writing case null => instead).
[warn] -- [E121] Pattern Match Warning: /home/rina/progs/basil/src/main/scala/analysis/Lattice.scala:359:11 
[warn] 359 |      case _ => ???
[warn]     |           ^
[warn]     |Unreachable case except for null (if this is intentional, consider writing case null => instead).
```