### PR TITLE
formatting: disable formatting of docstrings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,3 +5,4 @@ maxColumn = 120
 indent.defnSite = 2
 optIn.configStyleArguments = false
 align.preset = none
+docstrings.style = keep


### PR DESCRIPTION
this changes the docstring formatting mode to "keep", which tells scalafmt to make no modifications to docstring formatting

scalafmt is, by default, very enthusiastic about formatting docstrings. it will replace syntax like

    /**
     * aaa
     * ---
     */

with the asterisks moved and, worse, the subheading line merged into the preceding line,

    /**
      * aaa ---
      */

i don't believe the docstrings need to be subjected to this level of re-formatting, and it breaks markdown formatting (despite markdown being [preferred] by scaladoc). slight differences in otherwise well-formatted docstrings are fine. if a docstring is truly very bad, it should be pointed out in code review.

[preferred]: https://docs.scala-lang.org/scala3/guides/scaladoc/docstrings.html#markup