### PR TITLE
simplifier: disable memory copyprop

### DIFF
--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1087,7 +1087,9 @@ object CopyProp {
     val state = mutable.HashMap[Variable, PropState]()
     var poisoned = false // we have an indirect call
 
-    val doLoadReasoning = true
+    // This is obviously invalid to do flow-insensitively as we don't have
+    // a DSA form on memory imposing the order of loads/stores
+    val doLoadReasoning = false
 
     def transfer(c: mutable.HashMap[Variable, PropState], s: Statement): Unit = {
       // val callClobbers = ((0 to 7) ++ (19 to 30)).map("R" + _).map(c => Register(c, 64))

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -786,13 +786,6 @@ object RunUtils {
       ir.eval.SimplifyValidation.makeValidation(w)
       w.close()
     }
-    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
-      val dir = File("./graphs/")
-      if (!dir.exists()) then dir.mkdirs()
-      for (p <- ctx.program.procedures) {
-        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
-      }
-    }
 
     Logger.info("[!] Simplify :: finished")
   }
@@ -849,6 +842,13 @@ object RunUtils {
       DebugDumpIRLogger.writeToFile(File("il-after-proccalls.il"), pp_prog(ctx.program))
 
       doSimplify(ctx, conf.staticAnalysis)
+    }
+    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
+      val dir = File("./graphs/")
+      if (!dir.exists()) then dir.mkdirs()
+      for (p <- ctx.program.procedures) {
+        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-after-simp.dot"), dotBlockGraph(p))
+      }
     }
 
     // SVA


### PR DESCRIPTION
The experimental copyprop through memory is incorrect because of cases like: https://github.com/UQ-PAC/BASIL/issues/329

Its making too strong an assumption of ordering of loads and stores which we only have in the case of variables because of the DSA. I should delete this code eventually, but I'm leaving it for now as it would probably be possible to hack in this assumption by also requiring the propagated store to dominate the load. It would make more sense to to memory promotion to variables and apply regular copyprop however. 

The case this fixes is here: It should not propagate load_27 to the right branch where it isn't reachable. 

![image](https://github.com/user-attachments/assets/428401df-2794-4dc3-9941-b834c784e59c)
