### PR TITLE
Use PrettyPrinter for prog/proc toString

### DIFF
--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -118,7 +118,8 @@ class Program(
   }
 
   override def toString(): String = {
-    serialiseIL(this)
+    // serialiseIL(this)
+    translating.PrettyPrinter.pp_prog(this)
   }
 
   def setModifies(specModifies: Map[String, List[String]]): Unit = {
@@ -314,7 +315,8 @@ class Procedure private (
   }
 
   override def toString: String = {
-    s"Procedure $name at ${address.getOrElse("None")} with ${blocks.size} blocks and ${formalInParam.size} in and ${formalOutParam.size} out parameters"
+    // s"Procedure $name at ${address.getOrElse("None")} with ${blocks.size} blocks and ${formalInParam.size} in and ${formalOutParam.size} out parameters"
+    translating.PrettyPrinter.pp_proc(this)
   }
 
   def calls: Set[Procedure] = blocks.iterator.flatMap(_.calls).toSet


### PR DESCRIPTION
Honestly, idk if this change is what we want because it makes the toString very large. this would be
troublesome when displaying procedures as elements of a collection, for example.

This reverts commit ff30fb7d3e45bb3f190ffa99a06d51e2acc0db29.