### PR TITLE
Liftmake script

### DIFF
--- a/scripts/liftmake.sh
+++ b/scripts/liftmake.sh
@@ -20,7 +20,7 @@ shift $((OPTIND-1))
 
 if [[ -z "$CFILE_NAME" ]] ; then 
     echo "Usage: -c cfile.c [-b binaryname] [ -- make args]"
-    echo "Optinoally variables CC, CFLAGS, DDISASM, READELF, GTIRBSEM, BAP to change the the binary path to the lifter tools"
+    echo "Optionally variables CC, CFLAGS, DDISASM, READELF, GTIRBSEM, BAP to change the the binary path to the lifter tools"
     exit 1
 fi
 
@@ -28,7 +28,7 @@ BIN_NAME=${BIN_NAME:=$(echo "$CFILE_NAME" | sed -s 's/.c$//' | tr -d ' ')}
 export BIN_NAME
 export CFILE_NAME
 
-make $@ -f - << 'EOF'
+make "$@" -f - << 'EOF'
 CC ?= aarch64-linux-gnu-gcc
 DDISASM ?= ddisasm
 READELF ?= readelf

--- a/scripts/liftmake.sh
+++ b/scripts/liftmake.sh
@@ -31,14 +31,14 @@ BIN_NAME=${BIN_NAME:=$(echo "$CFILE_NAME" | sed -s 's/.c$//')}
 export BIN_NAME
 export CFILE_NAME
 
-make -f - $@ << EOF
+make $@ -f - << EOF
 CC ?= aarch64-linux-gnu-gcc
 DDISASM ?= ddisasm
 READELF ?= readelf
 GTIRBSEM ?= gtirb_semantics
 BAP ?= bap
-DDISASM ?= ddisasm
 
+.PHONY=all clean 
 all: \$(BIN_NAME).adt \$(BIN_NAME).relf \$(BIN_NAME).gts
 
 \$(BIN_NAME): \$(CFILE_NAME)
@@ -54,5 +54,9 @@ all: \$(BIN_NAME).adt \$(BIN_NAME).relf \$(BIN_NAME).gts
 	\$(GTIRBSEM) \$(BIN_NAME).gtirb \$(BIN_NAME).gts
 
 \$(BIN_NAME).gtirb: \$(BIN_NAME)
-	ddisasm \$(BIN_NAME) --ir \$(BIN_NAME).gtirb
+	\$(DDISASM) \$(BIN_NAME) --ir \$(BIN_NAME).gtirb
+
+clean:
+	rm -f \$(BIN_NAME).adt \$(BIN_NAME).relf \$(BIN_NAME).gts \$(BIN_NAME)
 EOF
+

--- a/scripts/liftmake.sh
+++ b/scripts/liftmake.sh
@@ -10,9 +10,6 @@ case "${o}" in
     c)
         CFILE_NAME="$CFILE_NAME ${OPTARG}"
         ;;
-    j)
-        JOBS=${OPTARG}
-        ;;
     *) 
         if ${OPTARG} == "--" ; then
         	break;
@@ -23,15 +20,15 @@ shift $((OPTIND-1))
 
 if [[ -z "$CFILE_NAME" ]] ; then 
     echo "Usage: -c cfile.c [-b binaryname] [ -- make args]"
-    echo "Set variables CC, CFLAGS, "
+    echo "Optinoally variables CC, CFLAGS, DDISASM, READELF, GTIRBSEM, BAP to change the the binary path to the lifter tools"
     exit 1
 fi
 
-BIN_NAME=${BIN_NAME:=$(echo "$CFILE_NAME" | sed -s 's/.c$//')}
+BIN_NAME=${BIN_NAME:=$(echo "$CFILE_NAME" | sed -s 's/.c$//' | tr -d ' ')}
 export BIN_NAME
 export CFILE_NAME
 
-make $@ -f - << EOF
+make $@ -f - << 'EOF'
 CC ?= aarch64-linux-gnu-gcc
 DDISASM ?= ddisasm
 READELF ?= readelf
@@ -39,24 +36,24 @@ GTIRBSEM ?= gtirb_semantics
 BAP ?= bap
 
 .PHONY=all clean 
-all: \$(BIN_NAME).adt \$(BIN_NAME).relf \$(BIN_NAME).gts
+all: $(BIN_NAME).adt $(BIN_NAME).relf $(BIN_NAME).gts
 
-\$(BIN_NAME): \$(CFILE_NAME)
-	\$(CC) \$(CFILE_NAME) \$(CFLAGS)  -o \$(BIN_NAME)
+$(BIN_NAME): $(CFILE_NAME)
+	$(CC) $(CFILE_NAME) $(CFLAGS)  -o $(BIN_NAME)
 
-\$(BIN_NAME).adt: \$(BIN_NAME)
-	\$(BAP) \$(BIN_NAME) -d adt:\$(BIN_NAME).adt -d bir:\$(BIN_NAME).bir
+$(BIN_NAME).adt: $(BIN_NAME)
+	$(BAP) $(BIN_NAME) -d adt:$(BIN_NAME).adt -d bir:$(BIN_NAME).bir
 
-\$(BIN_NAME).relf: \$(BIN_NAME)
-	\$(READELF) -s -r -W \$(BIN_NAME) > \$(BIN_NAME).relf
+$(BIN_NAME).relf: $(BIN_NAME)
+	$(READELF) -s -r -W $(BIN_NAME) > $(BIN_NAME).relf
 
-\$(BIN_NAME).gts: \$(BIN_NAME).gtirb
-	\$(GTIRBSEM) \$(BIN_NAME).gtirb \$(BIN_NAME).gts
+$(BIN_NAME).gts: $(BIN_NAME).gtirb
+	$(GTIRBSEM) $(BIN_NAME).gtirb $(BIN_NAME).gts
 
-\$(BIN_NAME).gtirb: \$(BIN_NAME)
-	\$(DDISASM) \$(BIN_NAME) --ir \$(BIN_NAME).gtirb
+$(BIN_NAME).gtirb: $(BIN_NAME)
+	$(DDISASM) $(BIN_NAME) --ir $(BIN_NAME).gtirb
 
 clean:
-	rm -f \$(BIN_NAME).adt \$(BIN_NAME).relf \$(BIN_NAME).gts \$(BIN_NAME)
+	rm -f $(BIN_NAME).adt $(BIN_NAME).relf $(BIN_NAME).gts $(BIN_NAME)
 EOF
 


### PR DESCRIPTION
This is a small script to compile and lift examples by wrapping make. It is compatible with the reproducible build environment by pulling compiler and lifter binary paths from environment variables. 