### PR TITLE
IRToDSL: touch up the NonCallStatement with comment

### DIFF
--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -51,11 +51,15 @@ import scala.collection.immutable.*
  * and build the Basil IR with the correct links.
  */
 
-// TODO: naming?
+/**
+ *  Type of `Statement`s which are *not* `Call`s.
+ *
+ *  Basically, this is needed to express `Statement & ~Call` which
+ *  cannot be expressed through Scala's subtyping hierarchy.
+ *  Together, NonCallStatement and Call should partition Statement.
+ */
 type NonCallStatement =
   LocalAssign | MemoryStore | MemoryLoad | NOP | Assert | Assume
-
-type CallStatement = DirectCall | IndirectCall
 
 def cloneStatement(x: NonCallStatement): NonCallStatement = x match {
   case LocalAssign(a, b, c) => LocalAssign(a, b, c)

--- a/src/main/scala/ir/dsl/IRToDSL.scala
+++ b/src/main/scala/ir/dsl/IRToDSL.scala
@@ -24,9 +24,9 @@ object IRToDSL {
     case GoTo(targs, label) => EventuallyGoto(targs.map(t => DelayNameResolve(t.label)).toList, label)
   }
 
-  def convertNonControlStatement(x: NonCallStatement): EventuallyStatement = clonedStmt(x)
+  def convertNonCallStatement(x: NonCallStatement): EventuallyStatement = clonedStmt(x)
 
-  def convertControlStatement(x: CallStatement): EventuallyStatement = x match {
+  def convertCallStatement(x: Call): EventuallyStatement = x match {
     case DirectCall(targ, outs, actuals, label) =>
       // XXX: be aware of ordering, .map() on a SortedMap may return a HashMap.
       directCall(outs.toArray.map(keyToString), targ.name, actuals.toArray.map(keyToString): _*)
@@ -34,8 +34,8 @@ object IRToDSL {
   }
 
   def convertStatement(x: Statement) = x match {
-    case x: NonCallStatement => convertNonControlStatement(x)
-    case x: CallStatement => convertControlStatement(x)
+    case x: NonCallStatement => convertNonCallStatement(x)
+    case x: Call => convertCallStatement(x)
   }
 
   def convertBlock(x: Block) =


### PR DESCRIPTION
also,
- remove CallStatement because it was just Call, and
- replace leftover use of ControlStatement in function names with CallStatement.