### PR TITLE
create more generic interpreter test for value analysis

### DIFF
--- a/src/test/scala/InterpretTestConstProp.scala
+++ b/src/test/scala/InterpretTestConstProp.scala
@@ -31,9 +31,17 @@ import util.RunUtils.loadAndTranslate
 
 import scala.collection.mutable
 
-class ConstPropInterpreterValidate extends AnyFunSuite {
+class ConstPropInterpreterValidate extends AnyFunSuite with TestValueDomainWithInterpreter[FlatElement[BitVecLiteral]] {
 
   Logger.setLevel(LogLevel.ERROR)
+
+  def valueInAbstractValue(absval: FlatElement[BitVecLiteral], concrete: Expr) = {
+    absval match {
+      case Top => TrueLiteral
+      case Bottom => TrueLiteral /* deliberately don't check */
+      case FlatEl(value) => BinaryExpr(BVEQ, value, concrete)
+    }
+  }
 
   def testInterpretConstProp(testName: String, examplePath: String) = {
     val loading = ILLoadingConfig(
@@ -44,98 +52,26 @@ class ConstPropInterpreterValidate extends AnyFunSuite {
 
     var ictx = IRLoading.load(loading)
     ictx = IRTransform.doCleanup(ictx)
-    val analysisres = RunUtils.staticAnalysis(StaticAnalysisConfig(None, None, None), ictx)
+    ir.transforms.clearParams(ictx.program)
+    val analyses = RunUtils.staticAnalysis(StaticAnalysisConfig(None, None, None), ictx)
 
-    val breaks: List[BreakPoint] = analysisres.intraProcConstProp.collect {
-      // convert analysis result to a list of breakpoints, each which evaluates an expression describing
-      // the invariant inferred by the analysis (the assignment of registers) at a corresponding program point
+    val analysisres = analyses.intraProcConstProp.collect { case (block: Block, v) =>
+      block -> v
+    }.toMap
 
-      case (command: Command, v) => {
-        val expectedPredicates: List[(String, Expr)] = v.toList.map(r => {
-          val (variable, value) = r
-          val assertion = value match {
-            case Top => TrueLiteral
-            case Bottom => FalseLiteral /* unreachable */
-            case FlatEl(value) => BinaryExpr(BVEQ, variable, value)
-          }
-          (variable.name, assertion)
-        })
-        BreakPoint(
-          location = BreakPointLoc.CMD(command),
-          BreakPointAction(saveState = false, evalExprs = expectedPredicates)
-        )
-      }
-    }.toList
+    val result = runTestInterpreter(ictx, analysisres)
+    assertCorrectResult(result)
 
-    assert(breaks.nonEmpty)
-
-    // run the interpreter evaluating the analysis result at each command with a breakpoint
-    val interpretResult = interpretWithBreakPoints(ictx, breaks.toList, NormalInterpreter, InterpreterState())
-    val breakres: List[(BreakPoint, _, List[(String, Expr, Expr)])] = interpretResult._2
-    assert(interpretResult._1.nextCmd == Stopped())
-    assert(breakres.nonEmpty)
-
-    // assert all the collected breakpoint watches have evaluated to true
-    for (b <- breakres) {
-      val (_, _, evaluatedexprs) = b
-      evaluatedexprs.forall(c => {
-        val (n, before, evaled) = c
-        evaled == TrueLiteral
-      })
-    }
   }
 
-  test("indirect_call_example") {
-    val testName = "indirect_call"
-    val examplePath = System.getProperty("user.dir") + s"/examples/$testName/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("indirect_call_gcc_example") {
-    val testName = "indirect_call"
-    val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/gcc/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("indirect_call_clang_example") {
-    val testName = "indirect_call"
+  test("function1/clang") {
+    val testName = "function1"
     val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/clang/"
     testInterpretConstProp(testName, examplePath)
   }
-
-  test("jumptable2_example") {
-    val testName = "jumptable2"
-    val examplePath = System.getProperty("user.dir") + s"/examples/$testName/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("jumptable2_gcc_example") {
-    val testName = "jumptable2"
+  test("function1/gcc") {
+    val testName = "function1"
     val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/gcc/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("jumptable2_clang_example") {
-    val testName = "jumptable2"
-    val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/clang/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("functionpointer_example") {
-    val testName = "functionpointer"
-    val examplePath = System.getProperty("user.dir") + s"/examples/$testName/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("functionpointer_gcc_example") {
-    val testName = "functionpointer"
-    val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/gcc/"
-    testInterpretConstProp(testName, examplePath)
-  }
-
-  test("functionpointer_clang_example") {
-    val testName = "functionpointer"
-    val examplePath = System.getProperty("user.dir") + s"/src/test/correct/$testName/clang/"
     testInterpretConstProp(testName, examplePath)
   }
 

--- a/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
+++ b/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
@@ -67,7 +67,6 @@ trait TestValueDomainWithInterpreter[T] {
 
   def assertCorrectResult(breakres: List[CheckResult]) = {
     assert(breakres.nonEmpty)
-    assert(breakres.nonEmpty)
 
     // assert all the collected breakpoint watches have evaluated to true
     for (b <- breakres) {

--- a/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
+++ b/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
@@ -12,7 +12,7 @@ import translating.PrettyPrinter.*
 trait TestValueDomainWithInterpreter[T] {
 
   /**
-   * Construct a Basil IR expression which evaluates to true true iff 
+   * Construct a Basil IR expression which evaluates to true iff 
    * the concrete expression `concrete` is contained in the abstract value `absval`.
    */
   def valueInAbstractValue(absval: T, concrete: Expr): Expr

--- a/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
+++ b/src/test/scala/util/TestValueAnalysisWithInterpreter.scala
@@ -1,0 +1,81 @@
+import ir.*
+import ir.eval.*
+import org.scalatest.*
+import org.scalatest.funsuite.*
+import specification.*
+import util.{Logger, LogLevel}
+import org.scalatest.funsuite.AnyFunSuite
+import test_util.BASILTest
+import util.{BASILResult, StaticAnalysisConfig, IRContext}
+import translating.PrettyPrinter.*
+
+trait TestValueDomainWithInterpreter[T] {
+
+  /**
+   * Construct a Basil IR expression which evaluates to true true iff 
+   * the concrete expression `concrete` is contained in the abstract value `absval`.
+   */
+  def valueInAbstractValue(absval: T, concrete: Expr): Expr
+
+  case class CheckResult(name: String, breakpoint: BreakPoint, testExpr: Expr, evaluatedTestExpr: Expr)
+
+  enum Heuristic:
+    case AllVarsInAbstract
+    case VarsLiveInBlock
+
+  def runTestInterpreter(
+    ictx: IRContext,
+    testResultBefore: Map[Block, Map[Variable, T]],
+    testVars: Heuristic = Heuristic.AllVarsInAbstract
+  ): List[CheckResult] = {
+
+    val breaks: List[BreakPoint] = ictx.program.collect {
+      // convert analysis result to a list of breakpoints, each which evaluates an expression describing
+      // the invariant inferred by the analysis (the assignment of registers) at a corresponding program point
+      case (block: Block) if (testResultBefore.contains(block)) => {
+        val result = testResultBefore(block)
+        // only create assertion for variables relevant to the block and defined in the abstract state,
+        // on the assumption they are likely to be defined in the concrete state
+        val vars = (testVars match {
+          case Heuristic.AllVarsInAbstract => result.keySet
+          case Heuristic.VarsLiveInBlock => freeVarsPos(block).filter(result.contains)
+        }).map(v => (v, result(v)))
+
+        val expectedPredicates: List[(String, Expr)] = vars.toList.flatMap(r => {
+          val (variable, value) = r
+          val assertion = valueInAbstractValue(value, variable)
+          Seq((s"${variable.name} ⊆ ${value}", assertion))
+        })
+        BreakPoint(
+          location = BreakPointLoc.CMD(IRWalk.firstInBlock(block)),
+          BreakPointAction(saveState = false, evalExprs = expectedPredicates)
+        )
+      }
+    }.toList
+
+    // run the interpreter evaluating the analysis result at each command with a breakpoint
+    val interpretResult = interpretWithBreakPoints(ictx, breaks.toList, NormalInterpreter, InterpreterState())
+
+    assert(interpretResult._1.nextCmd == Stopped())
+    val breakres: List[(BreakPoint, _, List[(String, Expr, Expr)])] = interpretResult._2
+    breakres.flatMap { case (bp, _, l) =>
+      l.map { case (name, test, evaled) =>
+        CheckResult(name, bp, test, evaled)
+      }
+    }.toList
+  }
+
+  def assertCorrectResult(breakres: List[CheckResult]) = {
+    assert(breakres.nonEmpty)
+    assert(breakres.nonEmpty)
+
+    // assert all the collected breakpoint watches have evaluated to true
+    for (b <- breakres) {
+      val loc = b.breakpoint.location match {
+        case BreakPointLoc.CMD(c) => c.parent.label
+        case _ => ??? /* not used here */
+      }
+      assert(b.evaluatedTestExpr == TrueLiteral, s"${b.name} @ $loc")
+    }
+  }
+}


### PR DESCRIPTION
This factors out the `InterpretConstProp` test into a more reasonable separate generic test for checking value analyses against the interpreter. 

You have to provide 

1. An analysis result `block -> variable -> absval`
2. A function `valueInAbstractVal: abstract:absval -> concrete:expr -> expr` which encodes the soundness check as a basil IR expression that evaluates to true when the `concrete` is an element of `abstract`. 

Its a bit iffy on choosing which variables to generate assertions for, if you test uninitialised variables it will crash the interpreter, but its fairly normal for uninitialised variables to appear in abstract domains.