### PR TITLE
Interpreter: callProcedure with return values

### DIFF
--- a/src/main/scala/ir/eval/InterpretBasilIR.scala
+++ b/src/main/scala/ir/eval/InterpretBasilIR.scala
@@ -627,13 +627,6 @@ object InterpFuns {
     s = State.execute(s, f.call("init_activation", Stopped(), Stopped()))
     s = initMemory(s, "mem", p.initialMemory.values)
     s = initMemory(s, "stack", p.initialMemory.values)
-
-    // val initialParams = mainfun.formalInParam.map(lv => lv -> BitVecLiteral(0, size(lv).get))
-
-    // mainfun.entryBlock.foreach(startBlock =>
-    //  s = State.execute(s, f.call(mainfun.name, Run(IRWalk.firstInBlock(startBlock)), Stopped()))
-    // )
-    // l <- State.sequence(State.pure(()), mainfun.formalInParam.toList.map(i => f.storeVar(i.name, i.toBoogie.scope, Scalar(BitVecLiteral(0, size(i).get)))))
     s
   }
 
@@ -695,41 +688,6 @@ object InterpFuns {
         }
     } yield (rv)
   }
-  // /*
-  //  * Lookup procsig in program and call it, attempting to tdispatch to an intrinsic if the
-  //  * procedure is not resolved, or resolves to a stub.
-  //  */
-  // def callProcedure[S, T <: Effects[S, InterpreterError]](f: T)(
-  //   program: Program,
-  //   proc: ProcSig,
-  //   actualParams: Map[LocalVar, Literal],
-  //   returnTo: Option[DirectCall] = None
-  // ): State[S, Unit, InterpreterError] = {
-
-  //   val target = program.procedures.find(_.name == proc.name)
-
-  //   val call = for {
-  //     // evaluate actual parms
-  //     v <- {
-  //       // perform call and push return stack frame and continuation
-  //       if (LibcIntrinsic.intrinsics.contains(target.map(_.procName).getOrElse(proc.name))) {
-  //         f.call(proc.name, Intrinsic(proc.name), ReturnFrom(proc))
-  //       } else if (target.exists(_.entryBlock.isDefined)) {
-  //         val block = target.get.entryBlock.get
-  //         val continue = returnTo.map(ReturnTo(_)).getOrElse(ReturnFrom(proc))
-  //         f.call(target.get.name, Run(IRWalk.firstInBlock(block)), continue)
-  //       } else {
-  //         State.setError(Errored(s"call to empty procedure: ${proc.name} / $target"))
-  //       }
-  //     }
-  //     // set actual params in the callee state
-  //     _ <- State.sequence(
-  //       State.pure(()),
-  //       actualParams.map(m => f.storeVar(m._1.name, m._1.toBoogie.scope, Scalar(m._2)))
-  //     )
-  //   } yield ()
-  //   call
-  // }
 
   def initBSS[S, T <: Effects[S, InterpreterError]](f: T)(is: S, p: IRContext): S = {
     val bss = for {

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -18,6 +18,13 @@ import scala.util.control.Breaks.{break, breakable}
  * Procedure signature used when returning from procedures and intrinsics.
  * This is mainly used to describe the formalOutparams, where the return values of the procedure
  * are stored to be read by the return value.
+ *
+ * @param name
+ *  The full name of the procedure (i.e. procedure.name if a real procedure, otherwise the name of the intrinsic)
+ * @param formalInParam
+ *  The list of formal input parameters (corresponding to procedure.formalInParam)
+ * @param formalOutParam
+ *  The list of formal outpur params (corresponding to procedure.formalOutParam)
  */
 case class ProcSig(name: String, formalInParam: List[LocalVar], formalOutParam: List[LocalVar])
 
@@ -53,6 +60,12 @@ case class FunPointer(addr: BitVecLiteral, name: String, call: ExecutionContinua
 
 sealed trait MapValue {
   def value: Map[BasilValue, BasilValue]
+}
+
+def normalTermination(is: ExecutionContinuation) = is match {
+  case Stopped() => true
+  case ReturnFrom(_) => true
+  case _ => false
 }
 
 /* We erase the type of basil values and enforce the invariant that
@@ -364,7 +377,8 @@ object LibcIntrinsic {
       "__libc_malloc_impl" -> singleArg("malloc"),
       "free" -> singleArg("free"),
       "#free" -> singleArg("free"),
-      "calloc" -> calloc
+      "calloc" -> calloc,
+      "strlen" -> singleArg("strlen") 
     )
 
 }
@@ -638,29 +652,36 @@ object NormalInterpreter extends Effects[InterpreterState, InterpreterError] {
     )
 }
 
-trait Interpreter[S, V, E](val f: Effects[S, E]) {
+enum Next[+V] {
+  case Continue
+  case Stop(value: V)
+}
 
-  enum Next {
-    case Continue
-    case Stop(value: V)
+/**
+ * Force the evaluation of the state monad steps in an explicit iteration to avoid too much buildup
+ */
+def evalInterpreter[S, V, E](f: Effects[S, E], doStep: State[S, Next[V], E]): State[S, Option[V], E] = {
+  @tailrec
+  def runEval(begin: S) : (S, Either[E, Option[V]]) = {
+    val (fs, cont) = doStep.f(begin)
+
+    cont match {
+      case Right(Next.Stop(v)) => (fs, Right(Some(v)))
+      case Right(Next.Continue) => runEval(fs)
+      case Left(e) => (fs, Left(e))
+    }
   }
+
+  State(begin => runEval(begin))
+}
+
+trait Interpreter[S, V, E](val f: Effects[S, E]) {
 
   /*
    * Returns value deciding whether to continue.
    */
-  def interpretOne: State[S, Next, E]
+  def interpretOne: State[S, Next[V], E]
 
-  @tailrec
-  final def eval(begin: S): (S, Option[V]) = {
-    val (fs, cont) = interpretOne.f(begin)
-
-    cont match {
-      case Right(Next.Stop(v)) => (fs, Some(v))
-      case Right(Next.Continue) => eval(fs)
-      case Left(_) => (fs, None)
-    }
-  }
-
-  final def run(begin: S): S = (eval(begin))._1
+  final def run(begin: S): S = State.execute(begin, (evalInterpreter(f, interpretOne)))
 
 }

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -34,7 +34,6 @@ sealed trait ExecutionContinuation
 case class Stopped() extends ExecutionContinuation /* normal program stop  */
 case class ErrorStop(error: InterpreterError) extends ExecutionContinuation /* program stop in error state */
 case class Run(next: Command) extends ExecutionContinuation /* continue by executing next command */
-case class ReturnTo(call: DirectCall) extends ExecutionContinuation /* return from a call and continue at caller */
 case class ReturnFrom(target: ProcSig) extends ExecutionContinuation /* return from a call without continuing */
 case class Intrinsic(name: String) extends ExecutionContinuation /* a named intrinsic instruction */
 

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -378,7 +378,7 @@ object LibcIntrinsic {
       "free" -> singleArg("free"),
       "#free" -> singleArg("free"),
       "calloc" -> calloc,
-      "strlen" -> singleArg("strlen") 
+      "strlen" -> singleArg("strlen")
     )
 
 }
@@ -662,7 +662,7 @@ enum Next[+V] {
  */
 def evalInterpreter[S, V, E](f: Effects[S, E], doStep: State[S, Next[V], E]): State[S, Option[V], E] = {
   @tailrec
-  def runEval(begin: S) : (S, Either[E, Option[V]]) = {
+  def runEval(begin: S): (S, Either[E, Option[V]]) = {
     val (fs, cont) = doStep.f(begin)
 
     cont match {

--- a/src/main/scala/translating/IRExpToSMT2.scala
+++ b/src/main/scala/translating/IRExpToSMT2.scala
@@ -205,7 +205,7 @@ object BasilIRToSMT2 extends BasilIRExpWithVis[Sexp] {
     }
 
     val terms = list(sym("push")) :: BasilIRToSMT2.extractDecls(e)
-      ++ List(assert, list(sym("set-option"), sym(":smt.timeout"), sym("1")), list(sym("check-sat")))
+      ++ List(assert, list(sym("check-sat")))
       ++ (if (getModel) then
             List(list(sym("echo"), sym("\"" + name.getOrElse("") + "  ::  " + e + "\"")), list(sym("get-model")))
           else List())

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -11,6 +11,7 @@ import gtirb.*
 import translating.PrettyPrinter.*
 import ir.dsl.*
 import ir.dsl.given
+import ir.eval.*
 
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.ArrayBuffer
@@ -916,11 +917,17 @@ object RunUtils {
 
     if (q.runInterpret) {
       Logger.info("Start interpret")
-      val (fs, trace) = eval.interpretTrace(ctx)
+
+      val ((fs, trace), value) =
+        InterpFuns.interpretEvalProg(tracingInterpreter(NormalInterpreter))(ctx, (InterpreterState(), Trace(List())))
 
       val stdout = fs.memoryState.getMem("stdout").toList.sortBy(_._1.value).map(_._2.value.toChar).mkString("")
 
       Logger.info(s"Interpreter stdout:\n${stdout}")
+      value match {
+        case Right(r) => Logger.info(s"Interpreter returned: ${r.map(v => v._1.name + " -> " + v._2).mkString(", ")}")
+        case _ => ()
+      }
 
       q.loading.dumpIL.foreach(f => {
         val tf = f"${f}-interpret-trace.txt"
@@ -929,7 +936,7 @@ object RunUtils {
       })
 
       val stopState = fs.nextCmd
-      if (stopState != eval.Stopped()) {
+      if (!normalTermination(stopState)) {
         Logger.error(s"Interpreter exited with $stopState")
       } else {
         Logger.info("Interpreter stopped normally.")

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -919,7 +919,7 @@ object RunUtils {
       Logger.info("Start interpret")
 
       val ((fs, trace), value) =
-        InterpFuns.interpretEvalProg(tracingInterpreter(NormalInterpreter))(ctx, (InterpreterState(), Trace(List())))
+        InterpFuns.interpretEvalProg(tracingInterpreter(NormalInterpreter))(ctx, (InterpreterState(), Trace.empty))
 
       val stdout = fs.memoryState.getMem("stdout").toList.sortBy(_._1.value).map(_._2.value.toChar).mkString("")
 

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -1,9 +1,9 @@
 package util.functional
-import util.Logger
+import util.{GenericLogger, LogLevel}
 import sourcecode.Line, sourcecode.FileName
 import java.io.*
 
-val monlog = Logger.deriveLogger("statemonad")
+val monlog = GenericLogger("monad", LogLevel.ERROR, System.out, System.console() != null)
 
 /*
  * Flattened state monad with error.
@@ -67,7 +67,7 @@ object State {
     file: sourcecode.FileName,
     name: sourcecode.Name
   ): S = {
-    // Logger.debug(s"state.execute")(line, file, name)
+    // monlog.debug(s"state.execute")(line, file, name)
     c.f(s) match {
       case (s, Left(r)) => {
         monlog.info(s"ERROR: $r")

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -46,6 +46,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
 
     val p = IRLoading.load(loading)
     val ctx = IRTransform.doCleanup(p)
+    ir.transforms.clearParams(ctx.program)
     // val bapProgram = loadBAP(loading.inputFile)
     // val (symbols, externalFunctions, globals, _, mainAddress) = loadReadELF(loading.relfFile, loading)
     // val IRTranslator = BAPToIR(bapProgram, mainAddress)
@@ -82,7 +83,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
     val actual: Map[String, Int] = expected.flatMap((name, expected) =>
       globals.find(_.name == name).flatMap(global => load(fstate, global).map(gv => name -> gv.value.toInt))
     )
-    assert(fstate.nextCmd == Stopped())
+    assert(normalTermination(fstate.nextCmd), fstate.nextCmd)
     assert(expected == actual)
   }
 
@@ -248,7 +249,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
     Logger.setLevel(LogLevel.ERROR)
     val fib = fibonacciProg(8)
     val r = interpret(fib)
-    assert(r.nextCmd == Stopped())
+    assert(normalTermination(r.nextCmd), r.nextCmd)
     // Show interpreted result
     // r.regs.foreach { (key, value) =>
     //   Logger.info(s"$key := $value")
@@ -299,9 +300,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
 
     val r = interpretTrace(fib)
 
-    assert(r._1.nextCmd == Stopped())
-    // Show interpreted result
-    //
+    assert(normalTermination(r._1.nextCmd), r._1.nextCmd)
 
   }
 


### PR DESCRIPTION
This refactors the interpreter entrypoint around the function `callProcedure`, which returns a future which immediately evaluates the call to the procedure and returns its return values (if the procedure has out-parameters defined). The goal here is to make it easier to write tests such that you can simply write a procedure literal, and evaluate it, and assert the return value. 

This also lays the groundwork to cleanup the implementation of intrinsic functions. Currently we have intrinsics that expect to read/write global registers, so calls with formal parameters are stored to the expected global variables before the call, and read back after. This can be substantially cleaned up (and some indirection removed) by instead standardising intrinsics on the parameter form, and if the IR doesn't have parameters then storing the return values to the appropriate registers (i.e. the reverse).

This also simplifies the return value handling in the interpreter by putting it back in the DirectCall, because now we can immediately get the state & return value after the call. This is possible because `callProcedure` is evaluating the procedure immediately through the call to `evalInterpreter(f, interpretContinuation(f))`. (Recall our general approach to dealing with statemonad closures producing stack overflows is to perform eval at each interpreter step (ir statement), this is now additionally doing an eval at each call). I'm not sure what the downside to this is but it is not great. 


