### PR TITLE
Factor out Boogie tool output parsing

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -263,12 +263,18 @@ object Main {
       dsaConfig = dsa
     )
 
-    RunUtils.run(q)
+    val result = RunUtils.run(q)
     if (conf.verify.value) {
-      Logger.info("Running boogie")
-      val timer = PerformanceTimer("Verify", LogLevel.INFO)
-      Seq("boogie", "/useArrayAxioms", q.outputPrefix).!
-      timer.checkPoint("Finish")
+      assert(result.boogie.nonEmpty)
+      for (b <- result.boogie) {
+        val fname = b.filename
+        val timer = PerformanceTimer("Verify", LogLevel.INFO)
+        val cmd = Seq("boogie", "/useArrayAxioms", fname, "/printVerifiedProceduresCount:0")
+        Logger.info(s"Running: ${cmd.mkString(" ")}")
+        val output = cmd.!!
+        Logger.info(util.boogie_interaction.parseOutput(output))
+        timer.checkPoint("Finish")
+      }
     }
   }
 

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -698,10 +698,11 @@ object StaticAnalysis {
 
 object RunUtils {
 
-  def run(q: BASILConfig): Unit = {
+  def run(q: BASILConfig): BASILResult = {
     val result = loadAndTranslate(q)
     Logger.info("Writing output")
     writeOutput(result)
+    result
   }
 
   def writeOutput(result: BASILResult): Unit = {

--- a/src/main/scala/util/boogie/Boogie.scala
+++ b/src/main/scala/util/boogie/Boogie.scala
@@ -1,0 +1,93 @@
+package util.boogie_interaction
+
+enum BoogieResultKind {
+  case Verified
+  case Timeout
+  case Unknown(string: String)
+  case AssertionFailed
+}
+
+case class BoogieResult(kind: BoogieResultKind, errors: Array[BoogieError]) {
+  override def toString() = {
+    s"Boogie result: $kind\n"
+      + errors.flatMap(_.formattedAssertionSnippet).mkString("\n")
+  }
+}
+
+case class BoogieLine(number: Int, text: String, isError: Boolean) {
+  def prettyPrint(numPadding: Integer = (number / 10 + 1)) = {
+    val padded = number.toString().reverse.padTo(7, ' ').reverse
+    val carat = if isError then " > " else "   "
+    s"$carat ${number} | ${text}"
+  }
+}
+
+case class BoogieError(fileName: String, line: Int, errorSnippet: Option[List[BoogieLine]]) {
+  def formattedAssertionSnippet: Option[String] = {
+    for {
+      x <- errorSnippet
+      lineNoPadding = (x.map(_.number).max / 10) + 1
+      header = s"Failing assertion: $fileName:$line\n"
+    } yield (header + x.map(_.prettyPrint(lineNoPadding)).mkString("\n"))
+  }
+}
+
+def parseOutput(boogieStdout: String): BoogieResult = {
+  println(boogieStdout)
+  val verified = boogieStdout.strip().equals("Boogie program verifier finished with 0 errors")
+  val proveFailed = boogieStdout.contains("could not be proved")
+  val timedOut = boogieStdout.strip().contains("timed out")
+
+  val errors = parseErrors(boogieStdout)
+
+  val kind = if (timedOut) then {
+    BoogieResultKind.Timeout
+  } else if (verified) then {
+    BoogieResultKind.Verified
+  } else if (proveFailed) then {
+    BoogieResultKind.AssertionFailed
+  } else {
+    BoogieResultKind.Unknown(boogieStdout)
+  }
+
+  BoogieResult(kind, errors)
+}
+
+def parseErrors(boogieStdoutMessage: String, snippetContext: Int = 3): Array[BoogieError] = {
+  val lines = boogieStdoutMessage.split('\n')
+  lines.collect {
+    case l
+        if (
+          l.endsWith(": Error: this assertion could not be proved") || l
+            .contains("this is the postcondition that could not be proved")
+        ) => {
+      val b = l.trim()
+      val parts = b.split("\\(").flatMap(_.split("\\)")).flatMap(_.split(","))
+      val fname = parts(0)
+      val line = Integer.parseInt(parts(1))
+      val col = parts(2)
+
+      val lines = util.readFromFile(fname).toArray
+
+      val lineOffset = line - 1
+
+      val beginLine = Integer.max(0, lineOffset - snippetContext)
+      val endLine = Integer.min(lines.length, lineOffset + snippetContext)
+
+      val boogieLines = (beginLine to endLine).map(x => {
+        val isError = x == lineOffset
+        val text = lines(x)
+        val lineNo = x + 1
+        BoogieLine(lineNo, text, isError)
+      })
+
+      val errorLines = (beginLine to endLine).map(x => {
+        val carat = if x == lineOffset then " > " else "   "
+        s"$carat ${x + 1} | ${lines(x)}"
+      })
+
+      val errorSnippet = errorLines.mkString("\n").trim
+      BoogieError(fname, line, Some(boogieLines.toList))
+    }
+  }
+}

--- a/src/main/scala/util/boogie/Boogie.scala
+++ b/src/main/scala/util/boogie/Boogie.scala
@@ -15,6 +15,16 @@ case class BoogieResult(kind: BoogieResultKind, errors: Array[BoogieError]) {
 }
 
 case class BoogieLine(number: Int, text: String, isError: Boolean) {
+
+  /**
+   * Print this line in the format: 
+   *
+   *     line number | line content
+   *
+   *  If this line reprsents a failing assertion (isError) then:
+   *
+   *   > line number | line content
+   */
   def prettyPrint(numPadding: Integer = (number / 10 + 1)) = {
     val padded = number.toString().reverse.padTo(7, ' ').reverse
     val carat = if isError then " > " else "   "
@@ -22,6 +32,16 @@ case class BoogieLine(number: Int, text: String, isError: Boolean) {
   }
 }
 
+/**
+ * Information about a line containing a failing assertion.
+ *
+ * @param fileName
+ *  The Boogie file the assertion is from
+ * @param line 
+ *  the line number containing the assertion
+ * @param errorSnippet
+ *  List of surrounding lines in the Boogie file
+ */
 case class BoogieError(fileName: String, line: Int, errorSnippet: Option[List[BoogieLine]]) {
   def formattedAssertionSnippet: Option[String] = {
     for {
@@ -32,6 +52,12 @@ case class BoogieError(fileName: String, line: Int, errorSnippet: Option[List[Bo
   }
 }
 
+/*
+ * Parse the output of the boogie tool and return a symbolic structure representing
+ * the verification decision, and a list of errors.
+ *
+ * Assumes boogie is invoked with [/printVerifiedProceduresCount:0].
+ */
 def parseOutput(boogieStdout: String): BoogieResult = {
   println(boogieStdout)
   val verified = boogieStdout.strip().equals("Boogie program verifier finished with 0 errors")
@@ -53,6 +79,9 @@ def parseOutput(boogieStdout: String): BoogieResult = {
   BoogieResult(kind, errors)
 }
 
+/**
+ * Get a list of assertion failures from the boogie output. 
+ */
 def parseErrors(boogieStdoutMessage: String, snippetContext: Int = 3): Array[BoogieError] = {
   val lines = boogieStdoutMessage.split('\n')
   lines.collect {

--- a/src/test/scala/IndirectCallTests.scala
+++ b/src/test/scala/IndirectCallTests.scala
@@ -110,7 +110,8 @@ class IndirectCallTests extends AnyFunSuite, BASILTest, TestCustomisation {
     Logger.debug(s"$name/$variation$testSuffix DONE")
 
     val boogieResult = runBoogie(directoryPath, BPLPath, conf.boogieFlags)
-    val (boogieFailureMsg, _, _) = checkVerify(boogieResult, resultPath, conf.expectVerify)
+    BASILTest.writeToFile(boogieResult, resultPath)
+    val (boogieFailureMsg, _, _) = checkVerify(boogieResult, conf.expectVerify)
 
     val fresolvedcalls = resolvedCalls.zip(indirectCallBlock).map((cr, l) => cr.copy(label = l))
     val indirectResolutionFailureMsg =

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -13,6 +13,7 @@ import test_util.Histogram
 import test_util.TestConfig
 import test_util.LockManager
 import test_util.TestCustomisation
+import util.boogie_interaction.*
 
 /** Add more tests by simply adding them to the programs directory. Refer to the existing tests for the expected
   * directory structure and file-name patterns.
@@ -190,44 +191,24 @@ trait SystemTests extends AnyFunSuite, BASILTest, TestCustomisation {
     val translateTime = timer.checkPoint("translate-boogie")
     Logger.info(s"$name/$variation$testSuffix DONE")
 
-    val boogieResult = runBoogie(directoryPath, BPLPath, conf.boogieFlags)
+    val boogieOutput = runBoogie(directoryPath, BPLPath, conf.boogieFlags)
+
     val verifyTime = timer.checkPoint("verify")
-    val (boogieFailureMsg, verified, timedOut) = checkVerify(boogieResult, resultPath, conf.expectVerify)
+    val boogieResult = parseOutput(boogieOutput)
 
-    def parseError(e: String, context: Int = 3) = {
-      val lines = e.split('\n')
-      for (l <- lines) {
-        if (
-          l.endsWith(": Error: this assertion could not be proved") || l.contains(
-            "this is the postcondition that could not be proved"
-          )
-        ) {
-          val b = l.trim()
-          val parts = b.split("\\(").flatMap(_.split("\\)")).flatMap(_.split(","))
-          val fname = parts(0)
-          val line = Integer.parseInt(parts(1))
-          val col = parts(2)
+    BASILTest.writeToFile(boogieOutput, resultPath)
+    val (boogieFailureMsg, verified, timedOut) = checkVerify(boogieResult, conf.expectVerify)
 
-          val lines = util.readFromFile(fname).toArray
+    if (boogieFailureMsg.isDefined) {
+      info(boogieResult.toString)
 
-          val lineOffset = line - 1
-
-          val beginLine = Integer.max(0, lineOffset - context)
-          val endLine = Integer.min(lines.length, lineOffset + context)
-
-          val errorLines = (beginLine to endLine).map(x => {
-            val carat = if x == lineOffset then " > " else "   "
-            s"$carat ${x + 1} | ${lines(x)}"
-          })
-
-          info(s"Failing assertion $fname:$line")
-          info(errorLines.mkString("\n").trim)
-
+      for (e <- boogieResult.errors) {
+        info(s"Failing assertion ${e.fileName}:${e.line}")
+        for (msg <- e.formattedAssertionSnippet) {
+          info(msg.trim + "\n")
         }
       }
     }
-
-    if (conf.expectVerify) parseError(boogieResult)
 
     val (hasExpected, matchesExpected) = if (conf.checkExpected) {
       checkExpected(expectedOutPath, BPLPath)

--- a/src/test/scala/test_util/BASILTest.scala
+++ b/src/test/scala/test_util/BASILTest.scala
@@ -13,6 +13,7 @@ import util.{
   RunUtils,
   StaticAnalysisConfig
 }
+import util.boogie_interaction.*
 
 import scala.sys.process.*
 import scala.io.Source
@@ -71,31 +72,26 @@ trait BASILTest {
   }
 
   /** @return
-    *   param 0: None if passes, Some(failure message) if doesn't pass param 1: whether the Boogie output verified param
-    *   2: whether Boogie timed out
+   *
+    *   param 0: None if passes, Some(failure message) if doesn't pass 
+    *   param 1: whether the Boogie output verified 
+    *   param 2: whether Boogie timed out
     */
-  def checkVerify(
-    boogieResult: String,
-    resultPath: String,
-    shouldVerify: Boolean
-  ): (Option[String], Boolean, Boolean) = {
-    BASILTest.writeToFile(boogieResult, resultPath)
-    val verified = boogieResult.strip().equals("Boogie program verifier finished with 0 errors")
-    val proveFailed = boogieResult.contains("could not be proved")
-    val timedOut = boogieResult.strip().contains("timed out")
+  def checkVerify(boogieStdout: String, expectVerify: Boolean): (Option[String], Boolean, Boolean) = {
+    val boogieResult = parseOutput(boogieStdout)
+    checkVerify(boogieResult, expectVerify)
+  }
 
-    val failureMsg = if (timedOut) {
-      Some("SMT Solver timed out")
-    } else {
-      (verified, shouldVerify, BASILTest.xor(verified, proveFailed)) match {
-        case (true, true, true) => None
-        case (false, false, true) => None
-        case (_, _, false) => Some("Prover error: unknown result: " + boogieResult)
-        case (true, false, true) => Some("Expected verification failure, but got success.")
-        case (false, true, true) => Some("Expected verification success, but got failure.")
-      }
+  def checkVerify(boogieResult: BoogieResult, expectVerify: Boolean): (Option[String], Boolean, Boolean) = {
+    val failureMsg = boogieResult.kind match {
+      case BoogieResultKind.Verified if expectVerify => None
+      case BoogieResultKind.AssertionFailed if !expectVerify => None
+      case BoogieResultKind.Timeout => Some("SMT Solver timed out")
+      case BoogieResultKind.Verified if !expectVerify => Some("Expected verification failure, but got success.")
+      case BoogieResultKind.AssertionFailed if expectVerify => Some("Expected verification success, but got failure.")
+      case k: BoogieResultKind.Unknown => Some(k.toString)
     }
-    (failureMsg, verified, timedOut)
+    (failureMsg, boogieResult.kind == BoogieResultKind.Verified, boogieResult.kind == BoogieResultKind.Timeout)
   }
 }
 


### PR DESCRIPTION
This factors out the Boogie output parsing from system tests to share with the implementation of basil's `--verify` flag. 

This means we now have the output below:

```
$ mill run --load-directory-gtirb src/test/correct/initialisation/gcc --analyse --memory-regions mra --verify -o basil-out-2.bpl
...
[INFO]   [!] Translating to Boogie
[INFO]   Writing output
[INFO]   Running: boogie /useArrayAxioms basil-out-2.bpl /printVerifiedProceduresCount:0
basil-out-2.bpl(192,5): Error: a postcondition could not be proved on this return path
basil-out-2.bpl(124,3): Related location: this is the postcondition that could not be proved
Execution trace:
    basil-out-2.bpl(137,3): main_1812__0__ulEp46faSbyYIP08N0ny3w

Boogie program verifier finished with 1 error

[INFO]   Boogie result: AssertionFailed
         Failing assertion: basil-out-2.bpl:124
             121 |   free requires (memory_load64_le(data_14, 69664bv64) == 8589934593bv64);
             122 |   free requires (memory_load32_le(data_27, 69668bv64) == 2bv32);
             123 |   ensures (memory_load32_le(data_12, $x_addr) == 6bv32);
          >  124 |   ensures (memory_load32_le(data_14, bvadd64($a_addr, 4bv64)) == 4bv32);
             125 |   ensures (memory_load32_le(data_14, bvadd64($a_addr, 0bv64)) == 1bv32);
             126 | 
             127 | implementation main_1812()
[INFO]   PerformanceTimer Verify [Finish]: 674ms
```