### PR TITLE
Interpreter: use Vector for trace instead of List

### DIFF
--- a/src/main/scala/ir/eval/InterpretTrace.scala
+++ b/src/main/scala/ir/eval/InterpretTrace.scala
@@ -64,7 +64,7 @@ def interpretWithTrace[I](
   innerInterpreter: Effects[I, InterpreterError],
   innerInitialState: I
 ): (I, Trace) = {
-  InterpFuns.interpretProg(tracingInterpreter(innerInterpreter))(p, (innerInitialState, Trace(Vector())))
+  InterpFuns.interpretProg(tracingInterpreter(innerInterpreter))(p, (innerInitialState, Trace.empty))
 }
 
 def interpretWithTrace[I](
@@ -73,9 +73,9 @@ def interpretWithTrace[I](
   innerInitialState: I
 ): (I, Trace) = {
   val tracingInterpreter = ProductInterpreter(innerInterpreter, TraceGen())
-  val begin = InterpFuns.initProgState(tracingInterpreter)(p, (innerInitialState, Trace(Vector())))
+  val begin = InterpFuns.initProgState(tracingInterpreter)(p, (innerInitialState, Trace.empty))
   // throw away initialisation trace
-  BASILInterpreter(tracingInterpreter).run((begin._1, Trace(Vector())))
+  BASILInterpreter(tracingInterpreter).run((begin._1, Trace.empty))
 }
 
 def interpretTrace(p: Program) = {

--- a/src/main/scala/ir/eval/InterpretTrace.scala
+++ b/src/main/scala/ir/eval/InterpretTrace.scala
@@ -23,12 +23,13 @@ enum ExecEffect:
   case LoadMem(vname: String, addrs: List[BasilValue])
   case FindProc(addr: Int)
 
-case class Trace(val t: List[ExecEffect])
+case class Trace(val t: Vector[ExecEffect])
 
 case object Trace {
   def add[E](e: ExecEffect): State[Trace, Unit, E] = {
     State.modify((t: Trace) => Trace(t.t.appended(e)))
   }
+  def empty = Trace(Vector())
 }
 
 case class TraceGen[E]() extends NopEffects[Trace, E] {
@@ -63,7 +64,7 @@ def interpretWithTrace[I](
   innerInterpreter: Effects[I, InterpreterError],
   innerInitialState: I
 ): (I, Trace) = {
-  InterpFuns.interpretProg(tracingInterpreter(innerInterpreter))(p, (innerInitialState, Trace(List())))
+  InterpFuns.interpretProg(tracingInterpreter(innerInterpreter))(p, (innerInitialState, Trace(Vector())))
 }
 
 def interpretWithTrace[I](
@@ -72,9 +73,9 @@ def interpretWithTrace[I](
   innerInitialState: I
 ): (I, Trace) = {
   val tracingInterpreter = ProductInterpreter(innerInterpreter, TraceGen())
-  val begin = InterpFuns.initProgState(tracingInterpreter)(p, (innerInitialState, Trace(List())))
+  val begin = InterpFuns.initProgState(tracingInterpreter)(p, (innerInitialState, Trace(Vector())))
   // throw away initialisation trace
-  BASILInterpreter(tracingInterpreter).run((begin._1, Trace(List())))
+  BASILInterpreter(tracingInterpreter).run((begin._1, Trace(Vector())))
 }
 
 def interpretTrace(p: Program) = {

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -84,7 +84,7 @@ class GenericLogger(
 
   private def writeLog(
     logLevel: LogLevel,
-    arg: Any,
+    arg: => Any,
     line: sourcecode.Line,
     file: sourcecode.FileName,
     name: sourcecode.Name

--- a/src/main/scala/util/PerformanceTimer.scala
+++ b/src/main/scala/util/PerformanceTimer.scala
@@ -19,7 +19,7 @@ case class RegionTimer(name: String) {
     total += (System.currentTimeMillis() - entered)
   }
 
-  def getTotal() =  total
+  def getTotal() = total
 
   override def toString() = {
     s"$name : ${getTotal()} (ms)"

--- a/src/main/scala/util/PerformanceTimer.scala
+++ b/src/main/scala/util/PerformanceTimer.scala
@@ -7,6 +7,13 @@ case class RegionTimer(name: String) {
   private var entered: Long = 0
   private var inside: Boolean = false
 
+  def within[T](body: => T): T = {
+    enter()
+    val result = body
+    exit()
+    result
+  }
+
   def enter() = {
     require(!inside)
     inside = true

--- a/src/main/scala/util/PerformanceTimer.scala
+++ b/src/main/scala/util/PerformanceTimer.scala
@@ -2,6 +2,30 @@ package util
 import scala.collection.mutable
 import scala.collection
 
+case class RegionTimer(name: String) {
+  private var total: Long = 0
+  private var entered: Long = 0
+  private var inside: Boolean = false
+
+  def enter() = {
+    require(!inside)
+    inside = true
+    entered = System.currentTimeMillis()
+  }
+
+  def exit() = {
+    require(inside)
+    inside = false
+    total += (System.currentTimeMillis() - entered)
+  }
+
+  def getTotal() =  total
+
+  override def toString() = {
+    s"$name : ${getTotal()} (ms)"
+  }
+}
+
 case class PerformanceTimer(timerName: String = "", logLevel: LogLevel = LogLevel.DEBUG) {
   private var lastCheckpoint: Long = System.currentTimeMillis()
   private var end: Long = 0

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -20,7 +20,7 @@ case class State[S, A, E](f: S => (S, Either[E, A])) {
   def flatMap[B](
     f: A => State[S, B, E]
   )(implicit line: sourcecode.Line, file: sourcecode.FileName, name: sourcecode.Name): State[S, B, E] = State(s => {
-    monlog.debug(s"State.flatMap ${file.value}:${line.value}")
+    // monlog.debug(s"State.flatMap ${file.value}:${line.value}")
     val (s2, a) = this.f(s)
     val r = a match {
       case Left(l) => (s2, Left(l))
@@ -67,7 +67,7 @@ object State {
     file: sourcecode.FileName,
     name: sourcecode.Name
   ): S = {
-    Logger.debug(s"state.execute")(line, file, name)
+    // Logger.debug(s"state.execute")(line, file, name)
     c.f(s) match {
       case (s, Left(r)) => {
         monlog.info(s"ERROR: $r")
@@ -109,7 +109,7 @@ object State {
     file: sourcecode.FileName,
     name: sourcecode.Name
   ): State[S, List[B], E] = {
-    monlog.debug(s"State.mapM (${xs.size} items) ${file.value}:${line.value}")
+    //monlog.debug(s"State.mapM (${xs.size} items) ${file.value}:${line.value}")
     xs.foldRight(pure(List[B]()))((b, acc) => acc.flatMap(c => m(b).map(v => v :: c)))
   }
 

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -109,7 +109,7 @@ object State {
     file: sourcecode.FileName,
     name: sourcecode.Name
   ): State[S, List[B], E] = {
-    //monlog.debug(s"State.mapM (${xs.size} items) ${file.value}:${line.value}")
+    // monlog.debug(s"State.mapM (${xs.size} items) ${file.value}:${line.value}")
     xs.foldRight(pure(List[B]()))((b, acc) => acc.flatMap(c => m(b).map(v => v :: c)))
   }
 

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -42,7 +42,7 @@ class DifferentialTest extends AnyFunSuite {
       val interpreter = LayerInterpreter(tracingInterpreter(NormalInterpreter), EffectsRLimit(instructionLimit))
       val initialState = InterpFuns.initProgState(NormalInterpreter)(p, InterpreterState())
       // Logger.setLevel(LogLevel.DEBUG)
-      val r = BASILInterpreter(interpreter).run((initialState, Trace(List())), 0)._1
+      val r = BASILInterpreter(interpreter).run((initialState, Trace.empty), 0)._1
       // Logger.setLevel(LogLevel.WARN)
       r
     }
@@ -50,7 +50,7 @@ class DifferentialTest extends AnyFunSuite {
     val (initialRes, traceInit) = interp(initial)
     val (result, traceRes) = interp(transformed)
 
-    def filterEvents(trace: List[ExecEffect]) = {
+    def filterEvents(trace: Iterable[ExecEffect]) = {
       trace.collect {
         case e @ ExecEffect.Call(_, _, _) => e
         case e @ ExecEffect.StoreMem("mem", _) => e

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -288,7 +288,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
       info(t.toString)
     }
     val total = NormalInterpreter.getTimes().map(_.getTotal()).sum
-    info("Total time: "  + totalTime)
+    info("Total time: " + totalTime)
     info("Effects[T] time: " + total)
 
   }

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -261,6 +261,7 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
     Logger.setLevel(LogLevel.ERROR)
     var res = List[(Int, Double, Double, Int)]()
 
+    val initial = PerformanceTimer("total")
     for (i <- 0 to 20) {
       val prog = fibonacciProg(i)
 
@@ -275,12 +276,20 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
       res = (i, native.toDouble, it.toDouble, ir._2) :: res
 
     }
+    val totalTime = initial.elapsed()
 
     info(
       ("fibonacci runtime table:\nFibNumber,ScalaRunTime,interpreterRunTime,instructionCycleCount" :: (res.map(x =>
         s"${x._1},${x._2},${x._3},${x._4}"
       ))).mkString("\n")
     )
+
+    for (t <- NormalInterpreter.getTimes()) {
+      info(t.toString)
+    }
+    val total = NormalInterpreter.getTimes().map(_.getTotal()).sum
+    info("Total time: "  + totalTime)
+    info("Effects[T] time: " + total)
 
   }
 


### PR DESCRIPTION
This was concatenating to the end of a list making the tracing interpreter quadratic (ty @katrinafyi for spotting this). 

This makes the runtime go from ~30s to 4s for the examples here https://github.com/UQ-PAC/BASIL/pull/322.


Commenting out the disabled `Logger.debug` calls seems to save ~1% of runtime, since these aren't actually evaluated I can only assume its the overhead of 2-3 method calls and branching. 