### PR TITLE
IndirectCallTest fixes

### DIFF
--- a/src/main/scala/analysis/data_structure_analysis/Utility.scala
+++ b/src/main/scala/analysis/data_structure_analysis/Utility.scala
@@ -247,14 +247,19 @@ case class AddressRange(start: BigInt, end: BigInt)
 case class Field(node: Node, offset: BigInt)
 
 // unwraps internal padding and slicing and returns the expression
-def unwrapPaddingAndSlicing(expr: Expr): Expr =
-  expr match
-    case literal: Literal => literal
-    case Repeat(repeats, body) => Repeat(repeats, unwrapPaddingAndSlicing(body))
-    case SignExtend(extension, body) => SignExtend(extension, unwrapPaddingAndSlicing(body))
-    case UnaryExpr(op, arg) => UnaryExpr(op, arg)
-    case BinaryExpr(op, arg1, arg2) => BinaryExpr(op, unwrapPaddingAndSlicing(arg1), unwrapPaddingAndSlicing(arg2))
-    case variable: Variable => variable
-    case Extract(_, _, body) /*if start == 0 && end == 32*/ => unwrapPaddingAndSlicing(body) // this may make it unsound
-    case ZeroExtend(_, body) => unwrapPaddingAndSlicing(body)
-    case _ => expr
+def unwrapPaddingAndSlicing(expr: Expr): Expr = {
+  // TODO: if we really want we can implement a rewriter to coerce
+  // an expression to a 64 bit precision expression in a similar way to
+  // the rewriter that converts bv1 to bool exprs:
+  // Expand inner expressions, wrap in an extract(32, 0) expr to maintain
+  // internal type safety, and push the extract up the until until it is at the
+  // outermost expression.
+  val r = ir.eval.simplifyPaddingAndSlicingExprFixpoint(expr)(0) match {
+    case Extract(_, 0, x) => x
+    case ZeroExtend(_, x) => x
+    case BinaryExpr(BVADD, Extract(hi, 0, x), y: Literal) =>
+      ir.eval.fastPartialEvalExpr(BinaryExpr(BVADD, x, SignExtend(size(x).get - size(y).get, y)))(0)
+    case o => o
+  }
+  r
+}

--- a/src/main/scala/ir/eval/SimplifyExpr.scala
+++ b/src/main/scala/ir/eval/SimplifyExpr.scala
@@ -149,6 +149,13 @@ def simplifyExprFixpoint: Simplifier = simpFixedPoint(
   SimpExpr(simpFixedPoint(sequenceSimp(simplifyExpr, SimpExpr(fastPartialEvalExpr))))
 )
 
+/**
+ * Perform regular simplification to a fixed point, then cleanup bitvector extension ops.
+ */
+def simplifyPaddingAndSlicingExprFixpoint: Simplifier = simpFixedPoint(
+  sequenceSimp(simplifyExprFixpoint, SimpExpr(cleanupExtends))
+)
+
 /** Perform (expensive) simplification of inequalities and attempt to lift flag calculations to inequalities.
   *
   * Sequences [[simplifyCmpInequalities]] with [[simplifyExprFixpoint]] since we expect the normal form to apply for

--- a/src/test/scala/IndirectCallTests.scala
+++ b/src/test/scala/IndirectCallTests.scala
@@ -71,6 +71,7 @@ class IndirectCallTests extends AnyFunSuite, BASILTest {
   }
 
   def runTest(name: String, variation: String, conf: TestConfig, resolvedCalls: Seq[IndirectCallResolution]): Unit = {
+    Logger.setLevel(LogLevel.ERROR)
     val directoryPath = "./src/test/indirect_calls/" + name + "/"
     val variationPath = directoryPath + variation + "/" + name
     val inputPath = if conf.useBAPFrontend then variationPath + ".adt" else variationPath + ".gts"

--- a/src/test/scala/IndirectCallTests.scala
+++ b/src/test/scala/IndirectCallTests.scala
@@ -207,7 +207,7 @@ class IndirectCallTests extends AnyFunSuite, BASILTest {
       if (resolution.procTargets.size == 1) {
         // only one procedure target -> check if call is resolved to direct call
         callSite match {
-          case d: DirectCall if d.target.name == resolution.procTargets.head =>
+          case d: DirectCall if d.target.procName == resolution.procTargets.head =>
             IndirectCallResult(resolution, true, None)
           case _ =>
             // fail - expected call to be resolved to direct call with target x
@@ -221,7 +221,7 @@ class IndirectCallTests extends AnyFunSuite, BASILTest {
             if (targets.size == resolution.procTargets.size) {
               val targetNames = targets.flatMap {
                 _.statements.lastElem match {
-                  case Some(DirectCall(target, _, _, _)) => Some(target.name)
+                  case Some(DirectCall(target, _, _, _)) => Some(target.procName)
                   case _ => None
                 }
               }


### PR DESCRIPTION
Addresses the low hanging fruit issues with `IndirectCallTests`: fixes https://github.com/UQ-PAC/BASIL/issues/358

- Reimplement `unwrapPaddingAndSlicing` using the expression simplifier, this works fine for most genuine pointer arithmetic that appears in the simple tests, but I'm unsure how to fully test that it doesn't produce any precision regressions. 
- Fix the procedure name testing in IndirectCallTests

This goes from 28 failing to 11 failing in `IndirectCallTests`

The remaining failures are, which are expected to fail due to missing features. 

```
- indirect_call_outparam/clang:BAP *** FAILED ***
  Resolving IndirectCall main: %0000037a -> Procedures[seven] failed:
    call not resolved to correct target: %0000037a: IndirectCall(Register(R8, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
- indirect_call_outparam/clang:GTIRB *** FAILED ***
  Resolving IndirectCall main: 1880_3 -> Procedures[seven] failed:
    call not resolved to correct target: 1880_3: IndirectCall(Register(R8, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
- indirect_call_outparam/gcc:BAP *** FAILED ***
  Resolving IndirectCall main: %000003c7 -> Procedures[seven] failed:
    call not resolved to correct target: %000003c7: IndirectCall(Register(R0, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
^[- indirect_call_outparam/gcc:GTIRB *** FAILED ***
  Resolving IndirectCall main: 2152_3 -> Procedures[seven] failed:
    call not resolved to correct target: 2152_3: IndirectCall(Register(R0, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
- jumptable/clang:BAP *** FAILED ***
  Resolving IndirectCall main: %00000431 -> Procedures[add_two] failed:
    call not resolved to correct target: %00000431: GoTo(lmainadd_two_1876, lmainadd_six_1896)
  Resolving IndirectCall main: %00000440 -> Procedures[add_six] failed:
    call not resolved to correct target: %00000440: GoTo(l00000433add_two_1876, l00000433add_six_1896) (IndirectCallTests.scala:97)
- jumptable/clang:GTIRB *** FAILED ***
  Resolving IndirectCall main: 1996_3 -> Procedures[add_two] failed:
    call not resolved to correct target: 1996_3: GoTo(main_1936__0__5xCxiIqdSQuaZCyObkbAPQadd_two_1876, main_1936__0__5xCxiIqdSQuaZCyObk
bAPQadd_six_1896)
  Resolving IndirectCall main: 2004_3 -> Procedures[add_six] failed:
    call not resolved to correct target: 2004_3: GoTo(main_1936__1__DFkVeDIQRCelWO6ni_nOGgadd_two_1876, main_1936__1__DFkVeDIQRCelWO6ni_
nOGgadd_six_1896) (IndirectCallTests.scala:97)
- jumptable/gcc:BAP *** FAILED ***
  Expected verification success, but got failure. (IndirectCallTests.scala:98)
- jumptable/gcc:GTIRB *** FAILED ***
  Expected verification success, but got failure. (IndirectCallTests.scala:98)

- jumptable3/clang:GTIRB *** FAILED ***
  Resolving IndirectCall main: 1944_2 -> Blocks[1956, 2020, 1992, 2032, 1964, 1984, 1948, 2012, 2004, 2066, 1980, 2044] failed:
    call not resolved to GoTo: 1944_2: IndirectCall(Register(R8, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
- jumptable3/clang_O2:GTIRB *** FAILED ***
  Resolving IndirectCall main: 1908_2 -> Blocks[1992, 2032, 1920, 1936, 1964, 1948, 1980, 2004, 1912, 2048, 2016] failed:
    call not resolved to GoTo: 1908_2: IndirectCall(Register(R11, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)
- switch2/clang:GTIRB *** FAILED ***
  Resolving IndirectCall main: 1892_2 -> Blocks[1896, 1920, 1932, 1908, 1944] failed:
    call not resolved to GoTo: 1892_2: IndirectCall(Register(R8, bv64))
  Expected verification success, but got failure. (IndirectCallTests.scala:99)

```

Note the jumptable failures due to precision loss, I wonder whether that was due to the SSA change. 

I'm not sure we want to spend more time trying to fix these analyses since we are in the process of re-implementing them anyway. 

