### PR TITLE
Fixes issue with IndirectCallTests expecting incorrect names for procedures

### DIFF
--- a/src/test/scala/IndirectCallTests.scala
+++ b/src/test/scala/IndirectCallTests.scala
@@ -207,7 +207,7 @@ class IndirectCallTests extends AnyFunSuite, BASILTest {
       if (resolution.procTargets.size == 1) {
         // only one procedure target -> check if call is resolved to direct call
         callSite match {
-          case d: DirectCall if d.target.name == resolution.procTargets.head =>
+          case d: DirectCall if d.target.procName == resolution.procTargets.head =>
             IndirectCallResult(resolution, true, None)
           case _ =>
             // fail - expected call to be resolved to direct call with target x
@@ -221,7 +221,7 @@ class IndirectCallTests extends AnyFunSuite, BASILTest {
             if (targets.size == resolution.procTargets.size) {
               val targetNames = targets.flatMap {
                 _.statements.lastElem match {
-                  case Some(DirectCall(target, _, _, _)) => Some(target.name)
+                  case Some(DirectCall(target, _, _, _)) => Some(target.procName)
                   case _ => None
                 }
               }


### PR DESCRIPTION
Partially fixes #358

Does not fix the issue with jumptable3/clang:GTIRB and switch2/clang:GTIRB failing due to the DSA producing expressions with mismatched sizes