### PR TITLE
parameter form: Keep Old() when rewriting spec to support memload/store

### DIFF
--- a/src/main/scala/ir/transforms/ProcedureParameters.scala
+++ b/src/main/scala/ir/transforms/ProcedureParameters.scala
@@ -570,7 +570,7 @@ def specToProcForm(
       case b: QuantifierExpr => b
       case b: Old => {
         if (isPost) {
-          convVarToOld(varInPre, varInPost, false)(b.body)
+          Old(convVarToOld(varInPre, varInPost, false)(b.body))
         } else {
           throw Exception("Illegal nested or non-relation Old()")
         }


### PR DESCRIPTION
Fixes https://github.com/UQ-PAC/BASIL/issues/363