### PR TITLE
fix: deprecation warnings caused by .toArray

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -9,7 +9,7 @@ import contrib.scalapblib._
 object basil extends RootModule with ScalaModule with antlr.AntlrModule with ScalaPBModule {
   def scalaVersion = "3.3.4"
 
-  // def scalacOptions: T[Seq[String]] = Seq("-Xprint:typer")
+  def scalacOptions: T[Seq[String]] = Seq("-deprecation")
 
   val javaTests = ivy"com.novocode:junit-interface:0.11"
   val scalaTests = ivy"org.scalatest::scalatest:3.2.19"

--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -190,7 +190,7 @@ def ret(params: (String, Expr)*): EventuallyReturn = EventuallyReturn(params)
 def unreachable: EventuallyUnreachable = EventuallyUnreachable()
 
 def directCall(lhs: Iterable[(String, Variable)], tgt: String, actualParams: (String, Expr)*): EventuallyCall =
-  EventuallyCall(DelayNameResolve(tgt), lhs.toArray, actualParams)
+  EventuallyCall(DelayNameResolve(tgt), lhs.to(ArraySeq), actualParams)
 
 def directCall(tgt: String): EventuallyCall = directCall(Nil, tgt)
 


### PR DESCRIPTION
The .toArray method converts an iterable to an Array. However, this is a minimal Java-esque array and does not support any of Scala's interfaces. Where an interface like Iterable or Seq was needed, this would require a coercion from Array to ArraySeq, which the compiler warns about because it incurs an additional copy.

This fixes the deprecation warning by using converting directly to ArraySeq, avoiding the implicit coercion and unnecessary copy.

**Also,** enables -deprecation in the mill build config. This will show deprecation warnings in the CI job.

Under the umbrella of: https://github.com/UQ-PAC/BASIL/issues/339.