### PR TITLE
utils: add a thread-safe Counter, and use it to replace all counters

### DIFF
--- a/src/main/scala/analysis/data_structure_analysis/DSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/DSA.scala
@@ -8,23 +8,6 @@ import java.io.File
 
 import scala.collection.{SortedSet, mutable}
 
-trait Counter(val init: Int = 0) {
-  private var counter = init
-  def increment(by: Int = 1): Int = {
-    counter += by
-    counter
-  }
-
-  def decrement(by: Int = 1): Int = {
-    counter -= by
-    counter
-  }
-
-  def get: Int = counter
-
-  def reset(): Unit = counter = init
-}
-
 enum DSAPhase {
   case Pre, Local, BU, TD
 }

--- a/src/main/scala/analysis/data_structure_analysis/DataStructureAnalysis.scala
+++ b/src/main/scala/analysis/data_structure_analysis/DataStructureAnalysis.scala
@@ -2,6 +2,7 @@ package analysis.data_structure_analysis
 
 import analysis.*
 import ir.*
+import util.Counter
 import specification.{ExternalFunction, SymbolTableEntry}
 import boogie.SpecGlobal
 
@@ -35,8 +36,8 @@ class DataStructureAnalysis(
   params: Map[Procedure, Set[Variable]]
 ) extends Analysis[Map[Procedure, Graph]] {
 
-  private val nodeCounter = NodeCounter()
-  given NodeCounter = nodeCounter
+  private val counter = Counter()
+  given Counter = counter
 
   val local: mutable.Map[Procedure, Graph] = mutable.Map()
   val bottomUp: mutable.Map[Procedure, Graph] = mutable.Map()

--- a/src/main/scala/analysis/data_structure_analysis/Graph.scala
+++ b/src/main/scala/analysis/data_structure_analysis/Graph.scala
@@ -5,6 +5,7 @@ import analysis.solvers.DSAUnionFindSolver
 import analysis.evaluateExpression
 import cfg_visualiser.*
 import ir.*
+import util.Counter
 import specification.{ExternalFunction, FuncEntry, SymbolTableEntry}
 import boogie.SpecGlobal
 
@@ -26,7 +27,7 @@ import scala.util.control.Breaks.{break, breakable}
   * @param writesTo
   * @param params
   */
-class Graph(using NodeCounter)(
+class Graph(using Counter)(
   val proc: Procedure,
   constProp: Map[CFGPosition, Map[Variable, FlatElement[BitVecLiteral]]],
   varToSym: Map[CFGPosition, Map[Variable, Set[SymbolicAddress]]],

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -13,7 +13,7 @@ import util.{DSALogger, IRContext, IntervalDSALogger as Logger}
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{SortedSet, mutable}
 
-object IntervalNodeCounter extends Counter
+private val intervalNodeCounter = util.Counter()
 
 case class NodeTerm(v: IntervalNode) extends analysis.solvers.Var[NodeTerm]
 
@@ -678,7 +678,7 @@ class IntervalNode(
   val graph: IntervalGraph,
   val bases: mutable.Map[SymBase, Int] = mutable.Map.empty,
   val size: Option[Int] = None,
-  val id: Int = IntervalNodeCounter.increment()
+  val id: Int = intervalNodeCounter.next().toInt
 ) {
   Logger.debug(s"created node with id $id")
 
@@ -915,9 +915,9 @@ object IntervalCell {
 
 /**
  * A data structure cell
- * @param node the node this cell belongs to 
+ * @param node the node this cell belongs to
  * @param interval the interval of the cell
- * 
+ *
  * Additionally may have a pointee only cells in the node have their pointees updated
  * All pointee operations (set, remove, hasPointee) on
  * dummy cells (old slices) are treated as operations on their corresponding cell in the node

--- a/src/main/scala/analysis/data_structure_analysis/LocalPhase.scala
+++ b/src/main/scala/analysis/data_structure_analysis/LocalPhase.scala
@@ -3,6 +3,7 @@ package analysis.data_structure_analysis
 import ir.eval.BitVectorEval.{bv2SignedInt, isNegative}
 import analysis.*
 import ir.*
+import util.Counter
 import boogie.SpecGlobal
 import specification.{ExternalFunction, SymbolTableEntry}
 import util.writeToFile
@@ -26,7 +27,7 @@ import scala.util.control.Breaks.{break, breakable}
   * @param params
   *   mapping from procedures to their parameters
   */
-class LocalPhase(using NodeCounter)(
+class LocalPhase(using Counter)(
   proc: Procedure,
   symResults: Map[CFGPosition, Map[SymbolicAddress, TwoElement]],
   constProp: Map[CFGPosition, Map[Variable, FlatElement[BitVecLiteral]]],

--- a/src/main/scala/ir/transforms/Inline.scala
+++ b/src/main/scala/ir/transforms/Inline.scala
@@ -8,13 +8,7 @@ import ir.dsl.*
 import scala.collection.mutable
 import scala.collection.immutable.{ArraySeq}
 
-object Counter {
-  var id = 0
-  def next() = {
-    id += 1
-    id
-  }
-}
+private val counter = util.Counter()
 
 def memoise[K, V](f: K => V): K => V = {
   val rn = mutable.Map[K, V]()
@@ -30,7 +24,7 @@ def memoise[K, V](f: K => V): K => V = {
 }
 
 def renameBlock(s: String): String = {
-  s + "_" + (Counter.next())
+  s + "_" + (counter.next())
 }
 
 class VarRenamer(proc: Procedure) extends CILVisitor {

--- a/src/main/scala/util/Counter.scala
+++ b/src/main/scala/util/Counter.scala
@@ -1,0 +1,29 @@
+package util
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * A thread-safe incrementing counter. The first number returned
+ * will be 1, and each successive call to next() will return an
+ * incremented value.
+ *
+ * An instance of this class may be safely shared across threads.
+ * The counter value will be shared.
+ *
+ * This counter cannot be reset. If you have an application which
+ * needs to reset its counters, you must create a new Counter as
+ * needed and pass this to functions which need it.
+ *
+ * NOTE: Please do not roll your own global counter class! This
+ *       will cause problems when the test suites are run concurrently
+ *       with multiple threads.
+ */
+class Counter {
+  private val n = AtomicLong(0)
+
+  /**
+   * Increment the counter, then get and return it.
+   * This method may be safely called by multiple threads.
+   */
+  def next() = n.incrementAndGet()
+}

--- a/src/main/scala/util/ThreadUtils.scala
+++ b/src/main/scala/util/ThreadUtils.scala
@@ -1,0 +1,44 @@
+package util
+
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * This mixin helps a class ensure that it is only accessed from a single
+ * thread. This can be useful for debugging concurrency issues.
+ */
+case class ThreadLocalCheck private (thread: Thread) {
+  def this() = this(Thread.currentThread)
+
+  /**
+   * Asserts that the caller is the same thread as the one which
+   * originally constructed this object. This is intended to be called
+   * within methods of classes which mix in this class.
+   */
+  def assertUniqueThread() = {
+    lazy val cls = this.getClass.getCanonicalName
+    val current = Thread.currentThread
+    assert(
+      current eq thread,
+      s"unexpected multi-threaded usage of class '$cls'.\n"
+        + s"object created by thread $thread but now accessed by $current"
+    )
+  }
+}
+
+/**
+ * Sleeps for a randomised length of time. While debugging, this can be placed
+ * between computations where there is a suspected race condition. Hopefully,
+ * this will make race conditions more obvious.
+ *
+ * Optionally, an argument can be given. If given, it will compute the
+ * argument, then return its result after the randomised length of time. This
+ * simulates a computation which takes a longer length of time.
+ */
+def magicBugRevealingSleep[T](e: => T): T = {
+  val result = e
+  Thread.sleep(ThreadLocalRandom.current.nextInt(10, 1000))
+  // Thread.`yield`()
+  result
+}
+
+def magicBugRevealingSleep(): Unit = magicBugRevealingSleep {}


### PR DESCRIPTION
This change unifies all counter implementations in the codebase with a single class at util.Counter. The util.Counter implementation is specifically made thread-safe.

This is my leading hypothesis for the cause of https://github.com/UQ-PAC/BASIL/issues/370. This is not based on any evidence, but this kind of thing is likely to cause problems with concurrent code.

Also adds some helper functions to try and help debug concurrency problems. They did not help in this case but might in future.