### PR TITLE
tests: redirect test stdout/err to info() messages 

### DIFF
--- a/.github/workflows/check-test-tagging.sh
+++ b/.github/workflows/check-test-tagging.sh
@@ -14,15 +14,21 @@ grep --color=always '@test_util\.tags\.DisabledTest' --context=1 -R $test_dir
 echo '::endgroup::'
 echo
 
+find_test_definition() {
+  t="$1"
+  shift
+  exec grep 'class\s\+'"$t"'\([ (]\|$\)' --before-context=2 -R "$test_dir" "$@"
+}
+
 ok=true
 echo '::group::Test suites with no tag annotations:'
 for t in $tests; do
-  defn="$(grep 'class\s\+'"$t"'[ (]' --before-context=2 -R $test_dir)"
+  defn="$(find_test_definition $t)"
   # search for lines which are entirely "@test_util.tags.*Test"
-  # leading - is produced by grep to mark prefixes
+  # a leading "-" is output by grep for context lines
   if ! grep -q -- '-@test_util\.tags\..\+Test$' <<< "$defn"; then
-    echo 'test suite has no `@test_util.tags.*Test` annotation:' >&2
-    grep --color=always 'class\s\+'"$t"'[ (]' --before-context=2  -R $test_dir
+    echo 'test suite has no `@test_util.tags.*Test` annotation: '"$t" >&2
+    find_test_definition $t --color=always
     echo
     ok=false
   fi

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -14,9 +14,12 @@ enum LogLevel(val id: Int):
 class GenericLogger(
   val name: String,
   val defaultLevel: LogLevel = LogLevel.INFO,
-  output: => PrintStream = Console.out,
+  defaultOutput: => PrintStream = Console.out,
   var ANSIColour: Boolean = true
 ) {
+
+  private var _output = () => defaultOutput
+  def output = _output()
 
   val children: HashSet[GenericLogger] = HashSet()
 
@@ -38,7 +41,7 @@ class GenericLogger(
   def disableColour(setChildren: Boolean = false) = setColour(false, setChildren)
   def enableColour(setChildren: Boolean = false): Unit = setColour(true, setChildren)
 
-  def deriveLogger(sname: String, stream: PrintStream): GenericLogger = {
+  def deriveLogger(sname: String, stream: => PrintStream): GenericLogger = {
     val l = GenericLogger(name + "." + sname, level, stream, ANSIColour)
     children.add(l)
     l
@@ -50,7 +53,7 @@ class GenericLogger(
 
   def deriveLogger(name: String): GenericLogger = deriveLogger(name, output)
 
-  // def setOutput(stream: PrintStream) = output = stream
+  def setOutput(stream: => PrintStream) = _output = () => stream
 
   def writeToFile(file: File, content: => String) = {
     if (level.id < LogLevel.OFF.id) {

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -2,7 +2,7 @@ package util
 import sourcecode.Line, sourcecode.FileName
 import scala.io.AnsiColor
 import collection.mutable.HashSet
-import java.io.*
+import java.io.{File, PrintStream}
 
 enum LogLevel(val id: Int):
   case DEBUG extends LogLevel(0)
@@ -14,7 +14,7 @@ enum LogLevel(val id: Int):
 class GenericLogger(
   val name: String,
   val defaultLevel: LogLevel = LogLevel.INFO,
-  var output: PrintStream = System.out,
+  output: => PrintStream = Console.out,
   var ANSIColour: Boolean = true
 ) {
 
@@ -50,7 +50,7 @@ class GenericLogger(
 
   def deriveLogger(name: String): GenericLogger = deriveLogger(name, output)
 
-  def setOutput(stream: PrintStream) = output = stream
+  // def setOutput(stream: PrintStream) = output = stream
 
   def writeToFile(file: File, content: => String) = {
     if (level.id < LogLevel.OFF.id) {
@@ -160,17 +160,17 @@ class GenericLogger(
 // doesn't work with `mill run`
 def isAConsole = System.console() != null
 
-val Logger = GenericLogger("log", LogLevel.DEBUG, System.out, isAConsole).setLevel(LogLevel.INFO, true)
-val StaticAnalysisLogger = Logger.deriveLogger("analysis", System.out)
-val SimplifyLogger = Logger.deriveLogger("simplify", System.out)
+val Logger = GenericLogger("log", LogLevel.DEBUG, Console.out, isAConsole).setLevel(LogLevel.INFO, true)
+val StaticAnalysisLogger = Logger.deriveLogger("analysis", Console.out)
+val SimplifyLogger = Logger.deriveLogger("simplify", Console.out)
 val DebugDumpIRLogger = Logger.deriveLogger("debugdumpir").setLevel(LogLevel.OFF)
 val AnalysisResultDotLogger = Logger.deriveLogger("analysis-results-dot").setLevel(LogLevel.OFF)
 val VSALogger = StaticAnalysisLogger.deriveLogger("vsa")
 val MRALogger = StaticAnalysisLogger.deriveLogger("mra").setLevel(LogLevel.INFO)
 val SteensLogger = StaticAnalysisLogger.deriveLogger("steensgaard")
 // DSA Loggers
-val DSALogger = Logger.deriveLogger("DSA", System.out).setLevel(LogLevel.OFF)
-val ConstGenLogger = DSALogger.deriveLogger("Constraint Gen", System.out).setLevel(LogLevel.INFO)
-val SVALogger = DSALogger.deriveLogger("SVA", System.out)
-val IntervalDSALogger = DSALogger.deriveLogger("SadDSA", System.out).setLevel(LogLevel.OFF)
-val StackLogger = Logger.deriveLogger("Stack", System.out).setLevel(LogLevel.INFO)
+val DSALogger = Logger.deriveLogger("DSA", Console.out).setLevel(LogLevel.OFF)
+val ConstGenLogger = DSALogger.deriveLogger("Constraint Gen", Console.out).setLevel(LogLevel.INFO)
+val SVALogger = DSALogger.deriveLogger("SVA", Console.out)
+val IntervalDSALogger = DSALogger.deriveLogger("SadDSA", Console.out).setLevel(LogLevel.OFF)
+val StackLogger = Logger.deriveLogger("Stack", Console.out).setLevel(LogLevel.INFO)

--- a/src/test/scala/BitVectorAnalysisTests.scala
+++ b/src/test/scala/BitVectorAnalysisTests.scala
@@ -6,7 +6,7 @@ import util.Logger
 import scala.runtime.stdLibPatches.Predef.assert
 
 @test_util.tags.UnitTest
-class BitVectorAnalysisTests extends AnyFunSuite {
+class BitVectorAnalysisTests extends AnyFunSuite with test_util.CaptureOutput {
 
   test("BitVector to Natural - should convert BitVector to natural number") {
     val result = bv2nat(BitVecLiteral(2, 4))

--- a/src/test/scala/DataStructureAnalysisTest.scala
+++ b/src/test/scala/DataStructureAnalysisTest.scala
@@ -28,7 +28,7 @@ import translating.PrettyPrinter.*
   * the set of graphs from the end of the top-down phase
   */
 @test_util.tags.UnitTest
-class DataStructureAnalysisTest extends AnyFunSuite {
+class DataStructureAnalysisTest extends AnyFunSuite with test_util.CaptureOutput {
 
   def runAnalysis(program: Program): StaticAnalysisContext = {
     cilvisitor.visit_prog(transforms.ReplaceReturns(), program)

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -30,7 +30,7 @@ import util.RunUtils.loadAndTranslate
 
 import scala.collection.mutable
 
-abstract class DifferentialTest extends AnyFunSuite, TestCustomisation {
+abstract class DifferentialTest extends AnyFunSuite, test_util.CaptureOutput, TestCustomisation {
 
   override def customiseTestsByName(name: String) = name match {
     case "analysis_differential:floatingpoint/clang:GTIRB" | "analysis_differential:floatingpoint/gcc:GTIRB" =>

--- a/src/test/scala/IndirectCallTests.scala
+++ b/src/test/scala/IndirectCallTests.scala
@@ -26,7 +26,7 @@ import util.DSAAnalysis.Norm
 import java.io.{BufferedWriter, File, FileWriter}
 
 @test_util.tags.AnalysisSystemTest
-class IndirectCallTests extends AnyFunSuite, BASILTest, TestCustomisation {
+class IndirectCallTests extends AnyFunSuite, test_util.CaptureOutput, BASILTest, TestCustomisation {
 
   override def customiseTestsByName(name: String) = name match {
     case "indirect_call_outparam/clang:BAP" | "indirect_call_outparam/clang:GTIRB" | "indirect_call_outparam/gcc:BAP" |

--- a/src/test/scala/InterpretTestConstProp.scala
+++ b/src/test/scala/InterpretTestConstProp.scala
@@ -32,7 +32,10 @@ import util.RunUtils.loadAndTranslate
 import scala.collection.mutable
 
 @test_util.tags.StandardSystemTest
-class ConstPropInterpreterValidate extends AnyFunSuite with test_util.CaptureOutput with TestValueDomainWithInterpreter[FlatElement[BitVecLiteral]] {
+class ConstPropInterpreterValidate
+    extends AnyFunSuite
+    with test_util.CaptureOutput
+    with TestValueDomainWithInterpreter[FlatElement[BitVecLiteral]] {
 
   Logger.setLevel(LogLevel.ERROR)
 

--- a/src/test/scala/InterpretTestConstProp.scala
+++ b/src/test/scala/InterpretTestConstProp.scala
@@ -32,7 +32,7 @@ import util.RunUtils.loadAndTranslate
 import scala.collection.mutable
 
 @test_util.tags.StandardSystemTest
-class ConstPropInterpreterValidate extends AnyFunSuite with TestValueDomainWithInterpreter[FlatElement[BitVecLiteral]] {
+class ConstPropInterpreterValidate extends AnyFunSuite with test_util.CaptureOutput with TestValueDomainWithInterpreter[FlatElement[BitVecLiteral]] {
 
   Logger.setLevel(LogLevel.ERROR)
 

--- a/src/test/scala/IntervalDSATest.scala
+++ b/src/test/scala/IntervalDSATest.scala
@@ -22,7 +22,7 @@ import util.{
 }
 
 @test_util.tags.UnitTest
-class IntervalDSATest extends AnyFunSuite {
+class IntervalDSATest extends AnyFunSuite with test_util.CaptureOutput {
   def runAnalysis(program: Program): StaticAnalysisContext = {
     cilvisitor.visit_prog(transforms.ReplaceReturns(), program)
     transforms.addReturnBlocks(program)

--- a/src/test/scala/IrreducibleLoop.scala
+++ b/src/test/scala/IrreducibleLoop.scala
@@ -16,7 +16,7 @@ import test_util.BASILTest.writeToFile
   * directory structure and file-name patterns.
   */
 @test_util.tags.UnitTest
-class IrreducibleLoop extends AnyFunSuite {
+class IrreducibleLoop extends AnyFunSuite with test_util.CaptureOutput {
   val testPath = "./src/test/irreducible_loops"
   Logger.setLevel(LogLevel.ERROR)
 

--- a/src/test/scala/LiveVarsAnalysisTests.scala
+++ b/src/test/scala/LiveVarsAnalysisTests.scala
@@ -22,7 +22,7 @@ import util.{BASILResult, StaticAnalysisConfig}
 import translating.PrettyPrinter.*
 
 @test_util.tags.UnitTest
-class LiveVarsAnalysisTests extends AnyFunSuite, BASILTest {
+class LiveVarsAnalysisTests extends AnyFunSuite, test_util.CaptureOutput, BASILTest {
   Logger.setLevel(LogLevel.ERROR)
   private val correctPath = "./src/test/correct/"
   def runExample(name: String): BASILResult = {

--- a/src/test/scala/ParamAnalysisTests.scala
+++ b/src/test/scala/ParamAnalysisTests.scala
@@ -5,7 +5,7 @@ import test_util.BASILTest
 import util.{BASILResult, StaticAnalysisConfig, Logger, LogLevel}
 
 @test_util.tags.UnitTest
-class ParamAnalysisTests extends AnyFunSuite, BASILTest {
+class ParamAnalysisTests extends AnyFunSuite, test_util.CaptureOutput, BASILTest {
   private val correctPath = "./src/test/correct/"
 
   def runExample(name: String): BASILResult = {

--- a/src/test/scala/PointsToTest.scala
+++ b/src/test/scala/PointsToTest.scala
@@ -13,7 +13,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import ir.dsl.*
 
 @test_util.tags.DisabledTest
-class PointsToTest extends AnyFunSuite with OneInstancePerTest {
+class PointsToTest extends AnyFunSuite with test_util.CaptureOutput with OneInstancePerTest {
 
   def runAnalyses(
     program: Program,

--- a/src/test/scala/SATTest.scala
+++ b/src/test/scala/SATTest.scala
@@ -7,7 +7,7 @@ import util.*
 import translating.BasilIRToSMT2
 
 @test_util.tags.UnitTest
-class SATTest extends AnyFunSuite {
+class SATTest extends AnyFunSuite with test_util.CaptureOutput {
   test(" basic taut ") {
     // Logger.setLevel(LogLevel.DEBUG)
     val e = BinaryExpr(BoolEQ, BinaryExpr(BVNEQ, R0, bv64(0)), BinaryExpr(BVEQ, bv64(0), R0))

--- a/src/test/scala/SVATest.scala
+++ b/src/test/scala/SVATest.scala
@@ -10,7 +10,7 @@ import util.*
 import scala.collection.immutable.{AbstractSeq, LinearSeq}
 
 @test_util.tags.UnitTest
-class SVATest extends AnyFunSuite {
+class SVATest extends AnyFunSuite with test_util.CaptureOutput {
 
   def runAnalysis(program: Program): StaticAnalysisContext = {
     cilvisitor.visit_prog(transforms.ReplaceReturns(), program)

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -24,7 +24,7 @@ object SystemTests {
   val locks = LockManager[String]()
 }
 
-trait SystemTests extends AnyFunSuite, BASILTest, TestCustomisation {
+trait SystemTests extends AnyFunSuite, test_util.CaptureOutput, BASILTest, TestCustomisation {
 
   /**
    * A suffix appended to output file names, in order to avoid clashes between test suites.

--- a/src/test/scala/TaintAnalysisTests.scala
+++ b/src/test/scala/TaintAnalysisTests.scala
@@ -6,7 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import test_util.BASILTest
 
 @test_util.tags.UnitTest
-class TaintAnalysisTests extends AnyFunSuite, BASILTest {
+class TaintAnalysisTests extends AnyFunSuite, test_util.CaptureOutput, BASILTest {
   def getTaintAnalysisResults(
     program: Program,
     taint: Map[CFGPosition, Set[Taintable]]

--- a/src/test/scala/ir/CILVisitorTest.scala
+++ b/src/test/scala/ir/CILVisitorTest.scala
@@ -52,7 +52,7 @@ class AddGammas extends CILVisitor {
 }
 
 @test_util.tags.UnitTest
-class CILVisitorTest extends AnyFunSuite {
+class CILVisitorTest extends AnyFunSuite with test_util.CaptureOutput {
 
   def getRegister(name: String) = Register(name, 64)
   test("trace prog") {

--- a/src/test/scala/ir/IRTest.scala
+++ b/src/test/scala/ir/IRTest.scala
@@ -9,7 +9,7 @@ import ir.dsl.*
 import ir.*
 
 @test_util.tags.UnitTest
-class IRTest extends AnyFunSuite {
+class IRTest extends AnyFunSuite with test_util.CaptureOutput {
 
   test("blockintralinks") {
     val p = prog(proc("main", block("lmain", goto("lmain1")), block("lmain1", goto("lmain2")), block("lmain2", ret)))

--- a/src/test/scala/ir/IRToDSLTest.scala
+++ b/src/test/scala/ir/IRToDSLTest.scala
@@ -23,7 +23,7 @@ import org.scalactic.Prettifier
 import org.scalactic._
 
 @test_util.tags.UnitTest
-class IRToDSLTest extends AnyFunSuite {
+class IRToDSLTest extends AnyFunSuite with test_util.CaptureOutput {
 
   val mainproc = proc(
     "main",

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -12,6 +12,7 @@ import translating.BAPToIR
 import util.{LogLevel, Logger}
 import util.IRLoading.{loadBAP, loadReadELF}
 import util.{ILLoadingConfig, IRContext, IRLoading, IRTransform}
+import test_util.CaptureOutput
 
 def load(s: InterpreterState, global: SpecGlobal): Option[BitVecLiteral] = {
   val f = NormalInterpreter
@@ -32,7 +33,7 @@ def mems[E, T <: Effects[T, E]](m: MemoryState): Map[BigInt, BitVecLiteral] = {
 }
 
 @test_util.tags.UnitTest
-class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
+class InterpreterTests extends AnyFunSuite with BeforeAndAfter with CaptureOutput {
 
   Logger.setLevel(LogLevel.WARN)
 

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -33,7 +33,7 @@ def mems[E, T <: Effects[T, E]](m: MemoryState): Map[BigInt, BitVecLiteral] = {
 }
 
 @test_util.tags.UnitTest
-class InterpreterTests extends AnyFunSuite with BeforeAndAfter with CaptureOutput {
+class InterpreterTests extends AnyFunSuite with test_util.CaptureOutput with BeforeAndAfter {
 
   Logger.setLevel(LogLevel.WARN)
 

--- a/src/test/scala/ir/SingleCallInvariant.scala
+++ b/src/test/scala/ir/SingleCallInvariant.scala
@@ -5,7 +5,7 @@ import ir.dsl._
 import org.scalatest.funsuite.AnyFunSuite
 
 @test_util.tags.UnitTest
-class InvariantTest extends AnyFunSuite {
+class InvariantTest extends AnyFunSuite with test_util.CaptureOutput {
 
   test("sat singleCallBlockEnd case") {
     var program: Program = prog(

--- a/src/test/scala/ir/ToScalaTest.scala
+++ b/src/test/scala/ir/ToScalaTest.scala
@@ -13,7 +13,11 @@ import ir.*
 import org.scalactic.source.Position
 
 @test_util.tags.UnitTest
-class ToScalaTest extends AnyFunSuite with test_util.CaptureOutput with TimeLimitedTests with BeforeAndAfterEachTestData {
+class ToScalaTest
+    extends AnyFunSuite
+    with test_util.CaptureOutput
+    with TimeLimitedTests
+    with BeforeAndAfterEachTestData {
 
   override def timeLimit = Span(2, Seconds)
   override val defaultTestSignaler = ThreadSignaler

--- a/src/test/scala/ir/ToScalaTest.scala
+++ b/src/test/scala/ir/ToScalaTest.scala
@@ -13,7 +13,7 @@ import ir.*
 import org.scalactic.source.Position
 
 @test_util.tags.UnitTest
-class ToScalaTest extends AnyFunSuite with TimeLimitedTests with BeforeAndAfterEachTestData {
+class ToScalaTest extends AnyFunSuite with test_util.CaptureOutput with TimeLimitedTests with BeforeAndAfterEachTestData {
 
   override def timeLimit = Span(2, Seconds)
   override val defaultTestSignaler = ThreadSignaler

--- a/src/test/scala/test_util/CaptureOutput.scala
+++ b/src/test/scala/test_util/CaptureOutput.scala
@@ -1,0 +1,23 @@
+package test_util
+
+import org.scalatest.{Informing, TestSuite}
+import java.io.PrintStream;
+
+trait CaptureOutput extends TestSuite {
+  this: Informing =>
+
+  private val newSystemOut = ThreadOutputStream(System.out)
+  private val newSystemErr = ThreadOutputStream(System.err)
+
+  override def withFixture(test: NoArgTest) = {
+    Console.withOut(newSystemOut) {
+      Console.withErr(newSystemErr) {
+        val functionOutputStream = PrintStream(FunctionOutputStream(x => info(x.stripLineEnd)))
+        newSystemOut.setThreadStream(functionOutputStream)
+        newSystemErr.setThreadStream(functionOutputStream)
+        super.withFixture(test)
+      }
+    }
+  }
+}
+

--- a/src/test/scala/test_util/CaptureOutput.scala
+++ b/src/test/scala/test_util/CaptureOutput.scala
@@ -3,21 +3,25 @@ package test_util
 import org.scalatest.{Informing, TestSuite}
 import java.io.PrintStream;
 
+/**
+ * A mixin which redirects stdout/stderr of test cases to the scalatest
+ * info() method. This helps organise the test output, especially when
+ * running in parallel. With this change, stdout/stderr get recorded
+ * and printed directly underneath the test case name.
+ */
 trait CaptureOutput extends TestSuite {
   this: Informing =>
 
-  private val newSystemOut = ThreadOutputStream(System.out)
-  private val newSystemErr = ThreadOutputStream(System.err)
-
   override def withFixture(test: NoArgTest) = {
+
+    val functionOutputStream = PrintStream(FunctionOutputStream(x => info(x.stripLineEnd)))
+    val newSystemOut = ThreadOutputStream(functionOutputStream)
+    val newSystemErr = ThreadOutputStream(functionOutputStream)
+
     Console.withOut(newSystemOut) {
       Console.withErr(newSystemErr) {
-        val functionOutputStream = PrintStream(FunctionOutputStream(x => info(x.stripLineEnd)))
-        newSystemOut.setThreadStream(functionOutputStream)
-        newSystemErr.setThreadStream(functionOutputStream)
         super.withFixture(test)
       }
     }
   }
 }
-

--- a/src/test/scala/test_util/FunctionOutputStream.java
+++ b/src/test/scala/test_util/FunctionOutputStream.java
@@ -1,0 +1,29 @@
+package test_util;
+
+import java.io.OutputStream;
+import java.util.function.Consumer;
+
+public class FunctionOutputStream extends OutputStream {
+
+  private final Consumer<String> f;
+
+  public FunctionOutputStream(Consumer<String> f) {
+    this.f = f;
+  }
+
+  @Override
+  public void write(byte[] b) {
+    f.accept(new String(b));
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) {
+    f.accept(new String(b, off, len));
+  }
+
+  @Override
+  public void write(int b) {
+    f.accept(new String(new byte[] { (byte)b }));
+  }
+
+}

--- a/src/test/scala/test_util/FunctionOutputStream.java
+++ b/src/test/scala/test_util/FunctionOutputStream.java
@@ -3,6 +3,10 @@ package test_util;
 import java.io.OutputStream;
 import java.util.function.Consumer;
 
+/**
+ * An OutputStream which invokes a given function as its "output" effect.
+ * Encoding is assumed to be the system default encoding.
+ */
 public class FunctionOutputStream extends OutputStream {
 
   private final Consumer<String> f;

--- a/src/test/scala/test_util/ThreadOutputStream.java
+++ b/src/test/scala/test_util/ThreadOutputStream.java
@@ -1,0 +1,100 @@
+package test_util;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.FileOutputStream;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.io.IOException;
+
+/** A ThreadPrintStream replaces the normal System.out and
+ * ensures that output to System.out goes to a different
+ * PrintStream for each thread. It does this by using
+ * ThreadLocal to maintain a PrintStream for each thread. */
+public class ThreadOutputStream extends OutputStream {
+
+  /** Thread specific storage to hold
+   * a PrintStream for each thread. */
+  private final ThreadLocal<PrintStream> out;
+  private final PrintStream base;
+  private final PrintStream printStream;
+
+  public ThreadOutputStream(PrintStream base) {
+    this.base = base;
+    out = ThreadLocal.withInitial(() -> base);
+    printStream = new PrintStream(this);
+  }
+
+  public PrintStream printStream() {
+    return this.printStream;
+  }
+
+  /** Create and open a text file where System.out.println()
+   * will send its data for the current thread. */
+  public void createThreadStream() throws Exception {
+    // Create a text file where System.out.println()
+    // will send its data for this thread.
+    var name = Thread.currentThread().getName();
+    var fos = new FileOutputStream(name + ".txt");
+
+    // Create a PrintStream that will write to the new file.
+    var stream = new PrintStream(new BufferedOutputStream(fos));
+
+    setThreadStream(stream);
+  }
+
+  /** Sets the PrintStream for the
+   * currently executing thread. */
+  public void setThreadStream(PrintStream out) {
+    this.out.set(out);
+  }
+
+  /** Returns the PrintStream for the
+   * currently executing thread. */
+  public PrintStream getThreadStream() {
+    return this.out.get();
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    this.getThreadStream().write(b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    this.getThreadStream().write(b, off, len);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    this.getThreadStream().write(b);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    this.getThreadStream().flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.getThreadStream().close();
+  }
+
+  public void replaceSystemOut() {
+    System.setOut(this.printStream());
+  }
+
+  public void replaceSystemErr() {
+    System.setErr(this.printStream());
+  }
+
+  public void restoreSystemOut() {
+    System.setOut(base);
+  }
+
+  public void restoreSystemErr() {
+    System.setErr(base);
+  }
+
+}

--- a/src/test/scala/test_util/ThreadOutputStream.java
+++ b/src/test/scala/test_util/ThreadOutputStream.java
@@ -8,6 +8,8 @@ import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.io.IOException;
 
+// taken, with modifications and simplifications from: https://barzeer.github.io/java/thread_sys_out.html
+
 /** A ThreadPrintStream replaces the normal System.out and
  * ensures that output to System.out goes to a different
  * PrintStream for each thread. It does this by using

--- a/src/test/scala/util/ScalatestPrettierTest.scala
+++ b/src/test/scala/util/ScalatestPrettierTest.scala
@@ -14,7 +14,7 @@ object ScalatestPrettierTest {
 }
 
 @test_util.tags.UnitTest
-class ScalatestPrettierTest extends AnyFunSuite {
+class ScalatestPrettierTest extends AnyFunSuite with test_util.CaptureOutput {
 
   import ScalatestPrettierTest.*
 

--- a/src/test/scala/util/StateMonad.scala
+++ b/src/test/scala/util/StateMonad.scala
@@ -13,7 +13,7 @@ import util.ILLoadingConfig
 def add: State[Int, Unit, Unit] = State(s => (s + 1, Right(())))
 
 @test_util.tags.UnitTest
-class StateMonadTest extends AnyFunSuite {
+class StateMonadTest extends AnyFunSuite with test_util.CaptureOutput {
 
   test("forcompre") {
     val s = for {

--- a/src/test/scala/util/StringUtilsTests.scala
+++ b/src/test/scala/util/StringUtilsTests.scala
@@ -3,7 +3,7 @@ import util.{Twine, indent, indentNested, StringEscape}
 import org.scalatest.funsuite.AnyFunSuite
 
 @test_util.tags.UnitTest
-class StringUtilsTest extends AnyFunSuite {
+class StringUtilsTest extends AnyFunSuite with test_util.CaptureOutput {
   test("indent one line") {
     assert(indent(LazyList("a")) == LazyList("a"))
     assert(indent(LazyList("a", " b")) == LazyList("a", " b"))

--- a/src/test/scala/util/intrusive_list/IntrusiveListPublicInterfaceTest.scala
+++ b/src/test/scala/util/intrusive_list/IntrusiveListPublicInterfaceTest.scala
@@ -3,7 +3,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.mutable
 
 @test_util.tags.UnitTest
-class IntrusiveListPublicInterfaceTest extends AnyFunSuite {
+class IntrusiveListPublicInterfaceTest extends AnyFunSuite with test_util.CaptureOutput {
   class Elem(val t: Int) extends IntrusiveListElement[Elem]
 
   def getSequentialList(elems: Int = 15): IntrusiveList[Elem] = {

--- a/src/test/scala/util/intrusive_list/IntrusiveListTest.scala
+++ b/src/test/scala/util/intrusive_list/IntrusiveListTest.scala
@@ -3,7 +3,7 @@ package util.intrusive_list
 import org.scalatest.funsuite.AnyFunSuite
 
 @test_util.tags.UnitTest
-class IntrusiveListTest extends AnyFunSuite {
+class IntrusiveListTest extends AnyFunSuite with test_util.CaptureOutput {
   case class Elem(t: Float) extends IntrusiveListElement[Elem]
 
   test("basic") {


### PR DESCRIPTION
Since test suits have been parallelised, there is this problem where logging stdout/stderr is printed to console and it is not clear which test suite an output message relates to. This is because the standard streams are shared by all threads.

This change will redirect stdout/err within test cases to info() messages.
This helps organise the test output, especially when running in
parallel. With this change, stdout/stderr are redirected through
scalatest's info() method, allowing the output to be associated and
printed with the name of the test case.

The output now looks something like this. You can see the stdout/err lines are prefixed with `+` and indented underneath the test case name.
![image](https://github.com/user-attachments/assets/f5957855-fd66-4927-8341-d627155d9dfc)

This change does have some disadvantages.
- Both stdout/stderr are redirected to info() with no distinction between them, making it impossible to pipe only stdout/stderr into, e.g., grep.
- The mechanism for redirecting the standard streams is very stateful. This is unpleasing and might complicate things if we would like more parallelism in the future.
- There's a lot of Java code. This could have been written in Scala, but it's very tied to Java-specific APIs so it felt more fitting to use Java.