### PR TITLE
Simplify cleanup branches guards

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -65,7 +65,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill compile
-      - run: ./scripts/scalatest.sh -oID -PS3 -T 1000000 -n test_util.tags.StandardSystemTest
+      - run: ./scripts/scalatest.sh -oGD -PS3 -T 1000000 -n test_util.tags.StandardSystemTest
 
       - uses: actions/upload-artifact@v4
         with:
@@ -116,7 +116,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./scripts/scalatest.sh -oID -PS3 -T 1000000 -n test_util.tags.UnitTest
+      - run: ./scripts/scalatest.sh -oGD -PS3 -T 1000000 -n test_util.tags.UnitTest
 
         # every test with package prefix:
         # sbt "show test:definedTests"
@@ -144,4 +144,4 @@ jobs:
       - run: echo "All systemtest suites:" && ./mill test.testOnly '*SystemTests*' -- -z 'xxxx'
 
       - run: ./mill compile
-      - run: ./scripts/scalatest.sh -oID -PS3 -T 1000000 -n test_util.tags.AnalysisSystemTest
+      - run: ./scripts/scalatest.sh -oGD -PS3 -T 1000000 -n test_util.tags.AnalysisSystemTest

--- a/src/main/scala/analysis/MemoryRegionAnalysis.scala
+++ b/src/main/scala/analysis/MemoryRegionAnalysis.scala
@@ -146,9 +146,9 @@ trait MemoryRegionAnalysis(
             val stackRegions = ctx.flatMap {
               case l: LocalAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
               case _: MemoryLoad => Set()
-              case unhandled =>
+              case unhandled: DirectCall =>
                 throw Exception(
-                  s"Memory Regions Analysis attempted to retrieve stack regions from unsupported instruction :$unhandled"
+                  s"Memory Regions Analysis attempted to retrieve stack regions from direct call, unsupported: $unhandled"
                 )
             }
             for (stackRegion <- stackRegions) yield {
@@ -183,8 +183,8 @@ trait MemoryRegionAnalysis(
         i match {
           case l: LocalAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
           case m: MemoryLoad => eval(m.index, stackPointerVariables, m, m.size)
-          case unhandled =>
-            throw Exception(s"attempted to reduce variables from an instruction which is not supported: $unhandled")
+          case d: DirectCall =>
+            throw Exception(s"attempted to reduce variables from direct call, unssupported: $d")
         }
       } else {
         Set()

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -297,6 +297,24 @@ class Procedure private (
     )
   }
 
+  def normaliseBlockNames() = {
+    var counter = 0
+    var loopCounter = 0
+    ir.transforms.reversePostOrder(this)
+    val bl = Array.from(blocks).sortInPlaceBy(_.rpoOrder)
+    for (b <- bl) {
+      counter += 1
+      val loop = if b.isLoopHeader() then {
+        loopCounter += 1
+        "_loop_header_" + loopCounter
+      } else ""
+
+      b.label = name + "_" + counter + loopCounter
+
+    }
+
+  }
+
   def makeCall(label: Option[String] = None) = DirectCall(this, label, outParamDefaultBinding, inParamDefaultBinding)
 
   var isExternal: Option[Boolean] = None
@@ -478,7 +496,7 @@ class Procedure private (
 }
 
 class Block private (
-  val label: String,
+  var label: String,
   val address: Option[BigInt],
   val statements: IntrusiveList[Statement],
   private var _jump: Jump,

--- a/src/main/scala/ir/eval/InterpretBasilIR.scala
+++ b/src/main/scala/ir/eval/InterpretBasilIR.scala
@@ -671,7 +671,7 @@ object InterpFuns {
                  for {
                    fs <- (State.mapM(
                      (p: LocalVar) =>
-                       f.loadVar(p.name.stripSuffix("_in")).catchS {
+                       f.loadVar(p.name.stripSuffix("_in")).catchE {
                          case Left(l) if !intrinsic.variadic =>
                            State.setError(Errored(s"Undefined intrinsic param $p in call $targetProc ($l)"))
                          case Left(l) => State.pure(None)

--- a/src/main/scala/ir/eval/InterpretTrace.scala
+++ b/src/main/scala/ir/eval/InterpretTrace.scala
@@ -22,6 +22,7 @@ enum ExecEffect:
   case StoreMem(vname: String, update: Map[BasilValue, BasilValue])
   case LoadMem(vname: String, addrs: List[BasilValue])
   case FindProc(addr: Int)
+  case SetNext(continuation: ExecutionContinuation)
 
 case class Trace(val t: Vector[ExecEffect])
 
@@ -45,6 +46,10 @@ case class TraceGen[E]() extends NopEffects[Trace, E] {
 
   override def doReturn() = for {
     s <- Trace.add(ExecEffect.Return)
+  } yield (())
+
+  override def setNext(c: ExecutionContinuation) = for {
+    s <- Trace.add(ExecEffect.SetNext(c))
   } yield (())
 
   override def storeVar(v: String, scope: Scope, value: BasilValue) = for {

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -35,7 +35,7 @@ case class Stopped() extends ExecutionContinuation /* normal program stop  */
 case class ErrorStop(error: InterpreterError) extends ExecutionContinuation /* program stop in error state */
 case class Run(next: Command) extends ExecutionContinuation /* continue by executing next command */
 case class ReturnFrom(target: ProcSig) extends ExecutionContinuation /* return from a call without continuing */
-case class Intrinsic(name: String) extends ExecutionContinuation /* a named intrinsic instruction */
+case class Intrinsic(target: ProcSig) extends ExecutionContinuation /* a named intrinsic instruction */
 
 sealed trait InterpreterError
 case class FailedAssertion(a: Assert) extends InterpreterError
@@ -382,6 +382,8 @@ object LibcIntrinsic {
     "calloc" -> ProcSig("calloc", List(r0), List()),
     "strlen" -> ProcSig("strlen", List(r0), List(r0))
   )
+
+
 }
 
 object IntrinsicImpl {

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -383,7 +383,6 @@ object LibcIntrinsic {
     "strlen" -> ProcSig("strlen", List(r0), List(r0))
   )
 
-
 }
 
 object IntrinsicImpl {
@@ -492,8 +491,6 @@ case class InterpreterState(
   val nextCmd: ExecutionContinuation = Stopped(),
   val callStack: List[ExecutionContinuation] = List.empty,
   val memoryState: MemoryState = MemoryState().pushStackFrame("entryinit")
-
-
 )
 
 /** Implementation of Effects for InterpreterState concrete state representation.

--- a/src/main/scala/ir/eval/Interpreter.scala
+++ b/src/main/scala/ir/eval/Interpreter.scala
@@ -365,6 +365,28 @@ object LibcIntrinsic {
     _ <- s.doReturn()
   } yield (())
 
+  val r0_out = LocalVar("R0_out", BitVecType(64))
+  val r0 = LocalVar("R0_in", BitVecType(64))
+  val r1 = LocalVar("R0_in", BitVecType(64))
+
+  def intrinsicSigs = Map(
+    "putc" -> ProcSig("putc", List(r0), List()),
+    "puts" -> ProcSig("puts", List(r0), List()),
+    "printf" -> ProcSig("print", List(r0), List()),
+    "write" -> ProcSig("write", List(r0, r1), List()),
+    "malloc" -> ProcSig("malloc", List(r0), List(r0_out)),
+    "__libc_malloc_impl" -> ProcSig("malloc", List(r0), List(r0_out)),
+    "free" -> ProcSig("free", List(r0), List()),
+    "#free" -> ProcSig("free", List(r0), List()),
+    "calloc" -> ProcSig("calloc", List(r0), List()),
+    "strlen" -> ProcSig("strlen", List(r0), List(r0))
+  )
+
+  // def callIntrinsic(sig: ProcSig, actual: List[BasilValue]) = {
+  //def callIntrinsic[S, E, T <: Effects[S, E]](s: T)(name: String, params: List[BasilValue]): State[S, Unit, E] =
+  //  s.callIntrinsic(name, actual)
+  //}
+
   def intrinsics[S, T <: Effects[S, InterpreterError]] =
     Map[String, T => State[S, Unit, InterpreterError]](
       "putc" -> singleArg("putc"),
@@ -487,7 +509,9 @@ object IntrinsicImpl {
 case class InterpreterState(
   val nextCmd: ExecutionContinuation = Stopped(),
   val callStack: List[ExecutionContinuation] = List.empty,
-  val memoryState: MemoryState = MemoryState()
+  val memoryState: MemoryState = MemoryState().pushStackFrame("entryinit")
+
+
 )
 
 /** Implementation of Effects for InterpreterState concrete state representation.

--- a/src/main/scala/ir/transforms/LinuxAssertFail.scala
+++ b/src/main/scala/ir/transforms/LinuxAssertFail.scala
@@ -42,10 +42,14 @@ def liftLinuxAssertFail(ctx: IRContext) = {
   val asserts: Map[DirectCall, Replace] = ctx.program.collect {
     case d: DirectCall if d.target.procName == "__assert_fail" => {
       d -> AssertFail(
-        getBV(d.actualParams(assertParam)).flatMap(getString),
-        getBV(d.actualParams(fileParam)).flatMap(getString),
-        getBV(d.actualParams(lineNo)).map(_.value.toInt),
-        getBV(d.actualParams(funNameParam)).flatMap(getString)
+        None,
+        None,
+        None,
+        None
+        // getBV(d.actualParams(assertParam)).flatMap(getString),
+        // getBV(d.actualParams(fileParam)).flatMap(getString),
+        // getBV(d.actualParams(lineNo)).map(_.value.toInt),
+        // getBV(d.actualParams(funNameParam)).flatMap(getString)
       )
     }
     case d: DirectCall if d.target.procName == "abort" => {
@@ -63,7 +67,7 @@ def liftLinuxAssertFail(ctx: IRContext) = {
               val msg = af.info.getOrElse("")
               val line = af.filename.map(fn => s" $fn:${af.lineNo.map(_.toString).getOrElse("?")}").getOrElse("")
               val fun = af.function.map(f => s" @ $f").getOrElse("")
-              ChangeTo(List(Assert(FalseLiteral, Some(s"$msg$fun$line"))))
+              ChangeTo(List(Assert(FalseLiteral, Some(s"call __assert_fail $msg$fun$line"))))
             }
             case a: Abort => {
               ChangeTo(List(Assert(FalseLiteral, Some("abort"))))

--- a/src/main/scala/ir/transforms/ProcedureParameters.scala
+++ b/src/main/scala/ir/transforms/ProcedureParameters.scala
@@ -37,7 +37,7 @@ val builtinSigs: Map[String, FunSig] = Map(
   // https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/baselib---assert-fail-1.html
   "__assert_fail" -> FunSig(List(R(0), R(1), R(2), R(3)), List()),
   "__stack_chk_fail" -> FunSig(List(), List()),
-  "__printf_chk" -> FunSig(List(R(0), R(1)), List(R(0))),
+  // "__printf_chk" -> FunSig(List(R(0), R(1)), List(R(0))),
   "__syslog_chk" -> FunSig(List(R(0)), List()),
   "indirect_call_launchpad" -> indirectCallFunsig,
   "__VERIFIER_assert" -> FunSig(List(R(0)), List()),

--- a/src/main/scala/ir/transforms/ReplaceReturn.scala
+++ b/src/main/scala/ir/transforms/ReplaceReturn.scala
@@ -33,7 +33,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             i.parent.replaceJump(Return())
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin)), i))
+              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), i))
             } else {
               SkipChildren()
             }
@@ -51,7 +51,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             d.parent.replaceJump(GoTo((d.parent.parent.entryBlock.get)))
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin)), d))
+              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
             } else {
               SkipChildren()
             }
@@ -60,7 +60,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             d.parent.replaceJump(Return())
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin)), d))
+              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
             } else {
               SkipChildren()
             }

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1536,9 +1536,6 @@ def fixupGuards(p: Program) = {
 
   for (bl <- concerning) {
     val assume = findAssume(bl)
-    if (assume.isEmpty) {
-      println("no assume " + bl.label)
-    }
     for (a <- assume) {
       bl.statements.prepend(a)
     }

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -981,6 +981,7 @@ object CopyProp {
     entry.clobbered = true
   }
 
+  // TODO: consider copies where there is only one use trivial
   def isTrivial(e: Expr): Boolean = e match {
     case l: Literal => true
     case l: Variable => true

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1007,14 +1007,7 @@ object CopyProp {
     }
   }
 
-
-  case class PropState(
-    var e: Expr,
-    val deps: mutable.Set[Variable],
-    var clobbered: Boolean,
-    var useCount: Int,
-  )
-
+  case class PropState(var e: Expr, val deps: mutable.Set[Variable], var clobbered: Boolean, var useCount: Int)
 
   def clobberFull(c: mutable.HashMap[Variable, PropState], l: Variable): Unit = {
     clobberOne(c, l)
@@ -1041,10 +1034,7 @@ object CopyProp {
     case _ => false
   }
 
-  def canPropTo(
-    s: mutable.HashMap[Variable, PropState],
-    e: Expr
-  ): Option[(Expr, Set[Variable])] = {
+  def canPropTo(s: mutable.HashMap[Variable, PropState], e: Expr): Option[(Expr, Set[Variable])] = {
 
     def proped(e: Expr) = {
       var deps = Set[Variable]() ++ e.variables

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -927,7 +927,6 @@ object CopyProp {
       s match {
         case l: LocalAssign => {
           val nrhs = subst(l.rhs)
-          st = st.removedAll(st.keys)
           st = st.updated(l.lhs, nrhs)
           l.rhs = nrhs
           SkipChildren()

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1514,9 +1514,9 @@ def fixupGuards(p: Program) = {
       for (s <- block.statements) {
         s match {
           case l: LocalAssign => assignment(l.lhs) = l.rhs
-          case a: Assume => {
-            val body = Substitute(assignment.get, true)(a.body).getOrElse(a.body)
-            break(Some(Assume(body, Some("propagated"))))
+          case Assume(oBody, a, b, c) => {
+            val body = Substitute(assignment.get, true)(oBody).getOrElse(oBody)
+            break(Some(Assume(body, a, b, c)))
           }
           case n: NOP => ()
           case _ => break(None)

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -448,8 +448,8 @@ def copypropTransform(
   val solve = t.checkPoint("Solve CopyProp")
 
   if (result.nonEmpty) {
-    val r = CopyProp.toResult(result, false)
-    val vis = Simplify(CopyProp.toResult(result, false))
+    val r = CopyProp.toResult(result, true)
+    val vis = Simplify(CopyProp.toResult(result, true))
     visit_proc(vis, p)
 
     val gvis = GuardVisitor()

--- a/src/main/scala/util/RingTrace.scala
+++ b/src/main/scala/util/RingTrace.scala
@@ -1,6 +1,6 @@
 package util
 
-class RingTrace[T](bound: Int, name: String = "")  {
+class RingTrace[T](bound: Int, name: String = "") {
 
   private var log = Vector[T]()
 

--- a/src/main/scala/util/RingTrace.scala
+++ b/src/main/scala/util/RingTrace.scala
@@ -1,0 +1,16 @@
+package util
+
+class RingTrace[T](bound: Int, name: String = "")  {
+
+  private var log = Vector[T]()
+
+  def add(elem: T) = {
+    log = log.prepended(elem)
+    log = log.take(bound)
+  }
+
+  def trace = log
+
+  override def toString() = s"$name backtrace (most recent event last)\n" + log.mkString("\n")
+
+}

--- a/src/main/scala/util/RingTrace.scala
+++ b/src/main/scala/util/RingTrace.scala
@@ -1,5 +1,8 @@
 package util
 
+/**
+ * Bounded list for storing a trace of at most [[bound]] items.
+ */
 class RingTrace[T](bound: Int, name: String = "") {
 
   private var log = Vector[T]()
@@ -11,6 +14,6 @@ class RingTrace[T](bound: Int, name: String = "") {
 
   def trace = log
 
-  override def toString() = s"$name backtrace (most recent event last)\n" + log.mkString("\n")
+  override def toString() = s"$name backtrace (most recent event last)\n    " + log.mkString("\n    ")
 
 }

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -936,6 +936,8 @@ object RunUtils {
       q.loading.dumpIL.foreach(f => {
         val tf = f"${f}-interpret-trace.txt"
         writeToFile(trace.t.mkString("\n"), tf)
+        val sf = f"${f}-stdout.txt"
+        writeToFile(stdout, sf)
         Logger.info(s"Finished interpret: trace written to $tf")
       })
 

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -789,8 +789,6 @@ object RunUtils {
 
     transforms.fixupGuards(program)
     transforms.removeDuplicateGuard(program)
-    // transforms.copyPropParamFixedPoint(program, ctx.globalOffsets)
-    transforms.copyPropParamFixedPoint(program, ctx.globalOffsets)
 
     AnalysisResultDotLogger.writeToFile(File("blockgraph-after-simp.dot"), dotBlockGraph(program.mainProcedure))
 

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -721,7 +721,6 @@ object RunUtils {
 
     ctx.program.sortProceduresRPO()
 
-    transforms.liftLinuxAssertFail(ctx)
     transforms.liftSVComp(ctx.program)
 
     DebugDumpIRLogger.writeToFile(File("il-before-simp.il"), pp_prog(program))

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -719,6 +719,14 @@ object RunUtils {
     val timer = PerformanceTimer("Simplify")
     val program = ctx.program
 
+    val foundLoops = LoopDetector.identify_loops(program)
+    val newLoops = foundLoops.reducibleTransformIR()
+    newLoops.updateIrWithLoops()
+
+    for (p <- program.procedures) {
+      p.normaliseBlockNames()
+    }
+
     ctx.program.sortProceduresRPO()
 
     transforms.liftSVComp(ctx.program)
@@ -732,7 +740,7 @@ object RunUtils {
     transforms.coalesceBlocks(program)
     transforms.removeEmptyBlocks(program)
 
-    transforms.coalesceBlocksCrossBranchDependency(program)
+    // transforms.coalesceBlocksCrossBranchDependency(program)
     DebugDumpIRLogger.writeToFile(File("blockgraph-before-dsa.dot"), dotBlockGraph(program.mainProcedure))
 
     Logger.info("[!] Simplify :: DynamicSingleAssignment")
@@ -781,6 +789,8 @@ object RunUtils {
 
     transforms.fixupGuards(program)
     transforms.removeDuplicateGuard(program)
+    // transforms.copyPropParamFixedPoint(program, ctx.globalOffsets)
+    transforms.copyPropParamFixedPoint(program, ctx.globalOffsets)
 
     AnalysisResultDotLogger.writeToFile(File("blockgraph-after-simp.dot"), dotBlockGraph(program.mainProcedure))
 

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -740,8 +740,6 @@ object RunUtils {
 
     transforms.OnePassDSA().applyTransform(program)
 
-    transforms.fixupGuards(program)
-
     transforms.inlinePLTLaunchpad(ctx.program)
 
     transforms.removeEmptyBlocks(program)
@@ -781,6 +779,7 @@ object RunUtils {
     Logger.info("Copyprop Start")
     transforms.copyPropParamFixedPoint(program, ctx.globalOffsets)
 
+    transforms.fixupGuards(program)
     transforms.removeDuplicateGuard(program)
 
     AnalysisResultDotLogger.writeToFile(File("blockgraph-after-simp.dot"), dotBlockGraph(program.mainProcedure))

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -48,9 +48,34 @@ case class State[S, A, E](f: S => (S, Either[E, A])) {
       }
     })
   }
+
+  def catchS[A2](f: Either[E, A] => State[S, A2, E]): State[S, A2, E] = {
+    State(s => {
+      val (s2, a) = this.f(s)
+      f(a).f(s2)
+    })
+  }
+
 }
 
 object State {
+
+  // def catchh[S, E]: State[S, Either[A,E], E] = ???
+  // def bimap[S, A, E, A2, E2](f: A => Either[E2, A2], g: E => Either[E2, A2]): State[S, Either[A,E], E] = ???
+  // def catchE[S, A, E, E2](f: E => Either[E2, A]): State[S, A, E] => State[S, A, E2] =  {
+  //   State(s => {
+  //
+
+  //   })
+  // }
+
+  // x <- State.getE
+  // match x {
+  //  case Left(l : A) => State.pure(l)
+  //  case Left(l : B) => State.setError(l)
+  //  case Right(l) => State.pure(l)
+  // }
+
   def get[S, A, E](f: S => A): State[S, A, E] = State(s => (s, Right(f(s))))
   def getE[S, A, E](f: S => Either[E, A]): State[S, A, E] = State(s => (s, f(s)))
   def getS[S, E]: State[S, S, E] = State((s: S) => (s, Right(s)))

--- a/src/main/scala/util/functional/State.scala
+++ b/src/main/scala/util/functional/State.scala
@@ -49,7 +49,7 @@ case class State[S, A, E](f: S => (S, Either[E, A])) {
     })
   }
 
-  def catchS[A2](f: Either[E, A] => State[S, A2, E]): State[S, A2, E] = {
+  def catchE[A2](f: Either[E, A] => State[S, A2, E]): State[S, A2, E] = {
     State(s => {
       val (s2, a) = this.f(s)
       f(a).f(s2)
@@ -59,22 +59,6 @@ case class State[S, A, E](f: S => (S, Either[E, A])) {
 }
 
 object State {
-
-  // def catchh[S, E]: State[S, Either[A,E], E] = ???
-  // def bimap[S, A, E, A2, E2](f: A => Either[E2, A2], g: E => Either[E2, A2]): State[S, Either[A,E], E] = ???
-  // def catchE[S, A, E, E2](f: E => Either[E2, A]): State[S, A, E] => State[S, A, E2] =  {
-  //   State(s => {
-  //
-
-  //   })
-  // }
-
-  // x <- State.getE
-  // match x {
-  //  case Left(l : A) => State.pure(l)
-  //  case Left(l : B) => State.setError(l)
-  //  case Right(l) => State.pure(l)
-  // }
 
   def get[S, A, E](f: S => A): State[S, A, E] = State(s => (s, Right(f(s))))
   def getE[S, A, E](f: S => Either[E, A]): State[S, A, E] = State(s => (s, f(s)))

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -36,12 +36,6 @@ abstract class DifferentialTest extends AnyFunSuite, TestCustomisation {
     case "analysis_differential:floatingpoint/clang:GTIRB" | "analysis_differential:floatingpoint/gcc:GTIRB" =>
       Mode.NotImplemented("needs FP_Mul")
 
-    case "analysis_differential:function1/gcc_O2:BAP" | "analysis_differential:function1/gcc_O2:GTIRB" |
-        "analysis_differential:malloc_with_local/gcc_O2:BAP" | "analysis_differential:malloc_with_local/gcc_O2:GTIRB" |
-        "analysis_differential:malloc_with_local3/gcc_O2:BAP" |
-        "analysis_differential:malloc_with_local3/gcc_O2:GTIRB" =>
-      Mode.NotImplemented("needs printf_chk")
-
     case "analysis_differential:syscall/clang:BAP" | "analysis_differential:syscall/clang:GTIRB" |
         "analysis_differential:syscall/clang_O2:GTIRB" | "analysis_differential:syscall/gcc:BAP" |
         "analysis_differential:syscall/gcc:GTIRB" =>
@@ -141,8 +135,12 @@ abstract class DifferentialTest extends AnyFunSuite, TestCustomisation {
   }
 }
 
-@test_util.tags.AnalysisSystemTest
-@test_util.tags.Fast
+
+/**
+ * Disable analysis differential test because it makes no 
+ * IR transforms, these examples contain no indirect calls.
+ */
+@test_util.tags.DisabledTest
 class DifferentialAnalysisTest extends DifferentialTest {
 
   def runSystemTests(): Unit = {
@@ -177,7 +175,6 @@ class DifferentialAnalysisTest extends DifferentialTest {
 }
 
 @test_util.tags.AnalysisSystemTest
-@test_util.tags.Fast
 class DifferentialAnalysisTestSimplification extends DifferentialTest {
 
   def runSystemTests(): Unit = {

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -135,7 +135,6 @@ abstract class DifferentialTest extends AnyFunSuite, TestCustomisation {
   }
 }
 
-
 /**
  * Disable analysis differential test because it makes no 
  * IR transforms, these examples contain no indirect calls.


### PR DESCRIPTION
A set of changes to make the differential testing of the simplification pass work. 

- fix the handling of intrinsics for the new callProcedure structure (indirect calls dispatching to intrinsics is likely still broken)
- enable simplify pass in the DifferentialAnalysisTest, disable the other test as `--analyse` doesn't make any transforms to test (aside from indirect calls which aren't in this set of examples here, and the interpreter doesn't support memory regions yet. The interpreter also tends to fall over on the indirect call examples, partly due to stack protection).
- add a transform pass to `--simplify` to pull the assume guards back in front of the phi/copies inserted on branch edges, after DSA. This substitutes the copies into the assume statement. When the assume sits on a, DSA ensures everything used by the assume is defined on both branches, so copying it to earlier in the program before the join by substituting the dependencies in between is syntactically valid, and it is semantically valid as it is evaluating it for a specific predecessor. The original branch condition at the join is left alone. Previously the copies between a jump and a guard broke the interpreter because it expects to be able to look ahead one instruction to evaluate the branch condition.

- transform pass to cleanup duplicated assume statements and assume true. 
- naive dead branch elimination deletes branches with guard `false`. This is enough to cleanup the sequential branch pattern clang tends to emit:

```
if (c):
  a = 1
  goto a, b
else:
  a = 0
  goto a, b
a : goto f
b : goto f
f: if (a):
  ... 
else:
  ...
```

Gets simplified to `if (c) ... else ...`. This is because the previous transform pulls the branch check into the labels `a` and `b`, enabling a the first else case to be eliminated. 

Note that dead branch elimination should be security preserving as we can only eliminate the branches on constants, which have to be classified low. 

- Also adds a transform to duplicate the join (i.e. create distinct labels `a` and `b`) in sequential branches to benefit from this in more cases. (gtirb produces two join blocks as below, whereas bap emits only one join block). As an example of what this simplifies:

`correct/cjump/clang:GTIRB` simplified output before this change
![initial program gtirb](https://github.com/user-attachments/assets/c725d680-e805-4add-8b16-173eff8507ca)

`correct/cjump/clang:GTIRB` simplified:

![simplified program](https://github.com/user-attachments/assets/57b919d8-24c0-4177-8b53-cf0527b45445)

This better matches the input program: 

```c
int x, y;
int main() {
    x = 1;
    if (x) {
        y = 3;
    } else {
        y = 2;
    }
}
```