### PR TITLE
micro-optimisations: cached hashcode and reduce hashmap lookups

### DIFF
--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -51,7 +51,7 @@ private class ILLexicalIterator(private val begin: Iterable[CFGPosition]) extend
 
     stack.pushAll(n match {
       case p: Procedure => p.blocks
-      case b: Block => Seq() ++ b.statements.toSeq ++ Seq(b.jump)
+      case b: Block => b.statements ++ Iterator(b.jump)
       case s: Command => Seq()
     })
     n

--- a/src/main/scala/ir/eval/SimplifyExpr.scala
+++ b/src/main/scala/ir/eval/SimplifyExpr.scala
@@ -1079,6 +1079,9 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
   (res, changedAnything)
 }
 
+private val assocOps: Set[BinOp] =
+  Set(BVADD, BVMUL, BVOR, BVAND, BVEQ, BoolAND, BoolEQ, BoolOR, BoolEQUIV, BoolEQ, IntADD, IntMUL, IntEQ)
+
 /** Simplifier implementing basic canonicalisation and simplifications of experssions without changing them too much.
   *
   *   - Normalises predicate calculations to boolean form rather than bitvector form.
@@ -1087,9 +1090,6 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
   *   - Removes redundant expressions
   */
 def simplifyExpr(e: Expr): (Expr, Boolean) = {
-
-  val assocOps: Set[BinOp] =
-    Set(BVADD, BVMUL, BVOR, BVAND, BVEQ, BoolAND, BoolEQ, BoolOR, BoolEQUIV, BoolEQ, IntADD, IntMUL, IntEQ)
 
   // println((0 until indent).map(" ").mkString("") + e)
 

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1005,19 +1005,16 @@ object CopyProp {
 
   def clobberFull(c: mutable.HashMap[Variable, PropState], l: Variable): Unit = {
     clobberOne(c, l)
-    for (v <- c.keys) {
-      if (c(v).deps.contains(l)) {
+    for ((v, x) <- c) {
+      if (x.deps.contains(l)) {
         clobberOne(c, v)
       }
     }
   }
 
   def clobberOne(c: mutable.HashMap[Variable, PropState], l: Variable): Unit = {
-    if (c.contains(l) && !c(l).clobbered) {
-      c(l).clobbered = true
-    } else if (!c.contains(l)) {
-      c(l) = PropState(FalseLiteral, mutable.Set(), true, 0, false)
-    }
+    val entry = c.getOrElseUpdate(l, PropState(FalseLiteral, mutable.Set(), true, 0, false))
+    entry.clobbered = true
   }
 
   def isTrivial(e: Expr): Boolean = e match {

--- a/src/main/scala/util/CachedHashCode.scala
+++ b/src/main/scala/util/CachedHashCode.scala
@@ -1,0 +1,22 @@
+package util
+
+/**
+ * A mixin for **case classes** to cache the hashCode the first time it is
+ * computed. This can yield speedups for case classes which contain complex
+ * structures (e.g., string list) and/or values which are frequently searched
+ * in a hashed data structure.
+ *
+ * WARNING: this must /not/ be used for classes which have mutable fields.
+ *          doing so would lead to inconsistencies between equals and hashcode,
+ *          causing unpredictable (read: incorrect) behaviour in hashmap/set.
+ */
+trait CachedHashCode {
+  this: Product =>
+
+  // this is the default implementation of hashCode for case classes.
+  // we need to call it explicitly because Scala will not generate a hashCode
+  // if we have provided one ourself.
+  private lazy val hash = scala.runtime.ScalaRunTime._hashCode(this)
+
+  override def hashCode = hash
+}


### PR DESCRIPTION
This implements two separate micro-optimisations to speed up the simplification pass, using cntlm-noduk as a benchmark and guided by profiling.

- First, we cache the hashCode() result of case classes the first time they are computed. Given the prevalence of hashmaps, this is a very frequent operation and hashCode of strings and bigints is slow (enough) that it matters.
- Second, we make some very minor changes to the simp CopyProp to reduce the number of hashmap searches needed.  This is again a hotspot and each individual `c(l)` performs a lookup of the hashmap.

I have benchmarked this against 72338dd25eb984bd8dcec83e773327e1fe0d0573 and we see a 36\% speedup on this cntlm-noduk example. (The size of this example might exaggerate the performance improvements.)

```python
Benchmark 1: java -jar original.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify
  Time (mean ± σ):     68.636 s ±  2.387 s    [User: 106.720 s, System: 1.255 s]
  Range (min … max):   64.802 s … 72.607 s    10 runs
 
Benchmark 2: java -jar new.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify
  Time (mean ± σ):     50.367 s ±  0.967 s    [User: 91.243 s, System: 1.328 s]
  Range (min … max):   48.822 s … 51.631 s    10 runs
 
Summary
  java -jar new.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify ran
    1.36 ± 0.05 times faster than java -jar original.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify
```

To show the impact of only the hashcode optimisation, we benchmarked that separately as well.
```python
Benchmark 1: java -jar cachedhashcode.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify
  Time (mean ± σ):     59.590 s ±  2.890 s    [User: 96.942 s, System: 1.403 s]
  Range (min … max):   56.284 s … 65.880 s    10 runs
```

These benchmarks use the hyperfine tool and can be run with:
```bash
git checkout main
./mill assembly
cp out/assembly.dest/out.jar original.jar

git checkout microopt
./mill assembly
cp out/assembly.dest/out.jar asdf.jar
hyperfine 'java -jar original.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify' 'java -jar asdf.jar --load-directory-gtirb examples/cntlm-noduk/ --simplify'
```
This will take at least 20 minutes because hyperfine repeats each version at least 10 times.