### PR TITLE
Fix dsa assertion

### DIFF
--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -368,7 +368,6 @@ class Procedure private (
 
   def entryBlock_=(value: Block): Unit = {
     if (!entryBlock.contains(value)) {
-      _entryBlock.foreach(removeBlocks)
       _entryBlock = Some(addBlock(value))
     }
   }

--- a/src/main/scala/ir/invariant/ProcEntryNoIncoming.scala
+++ b/src/main/scala/ir/invariant/ProcEntryNoIncoming.scala
@@ -1,0 +1,6 @@
+package ir.invariant
+import ir.Program
+
+def procEntryNoIncoming(p: Program): Boolean = {
+  p.procedures.forall(_.entryBlock.forall(_.prevBlocks.isEmpty))
+}

--- a/src/main/scala/ir/transforms/DynamicSingleAssignment.scala
+++ b/src/main/scala/ir/transforms/DynamicSingleAssignment.scala
@@ -69,9 +69,22 @@ class OnePassDSA(
   ): Unit = {
     def st(b: Block) = withDefault(state)(b)
 
+    val params = block.parent.formalInParam
     var renames = st(block).renamesBefore.toMap
 
     for (s <- block.statements) {
+
+      // to handle blocks unreachable from the entry we increment the index of the RHS variable
+      // for non-parameter free variables that don't have a rename defined by their predecessor
+      val incomingRenames = (freeVarsPos(s) -- params -- renames.keySet).map(v => {
+        count(v) = count(v) + 1
+        v -> count(v)
+      })
+      val paramDeps = (params.toSet -- renames.keySet).map(_ -> 0) // also add missing params to analysis state
+      st(block).renamesBefore.addAll(incomingRenames ++ paramDeps)
+      renames = renames ++ incomingRenames ++ paramDeps
+
+      // perform rename
       visit_stmt(StmtRenamer(Map(), renames), s)
       s match {
         case d: Assign => {
@@ -198,6 +211,7 @@ class OnePassDSA(
 
         for (v <- definedVars) {
           if (!state(nb).renamesAfter.contains(v)) {
+            // pre-emptively create a copy for this branch entry, e.g. to create a new copy for loop headers
             count(v) = count(v) + 1
             state(nb).renamesAfter(v) = count(v)
           }

--- a/src/main/scala/ir/transforms/Simp.scala
+++ b/src/main/scala/ir/transforms/Simp.scala
@@ -1609,3 +1609,15 @@ def removeTriviallyDeadBranches(p: Program, removeAllUnreachableBlocks: Boolean 
 
   dead.nonEmpty
 }
+
+// ensure procedure entry has no incoming jumps, if it does replace with new
+// block jumping to the old procedure entry
+def makeProcEntryNonLoop(p: Procedure) = {
+  if (p.entryBlock.exists(_.prevBlocks.nonEmpty)) {
+    val nb = Block(p.name + "_entry")
+    p.addBlock(nb)
+    val eb = p.entryBlock.get
+    nb.replaceJump(GoTo(eb))
+    p.entryBlock = nb
+  }
+}

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -259,6 +259,8 @@ object IRTransform {
       }
     }
 
+    ctx.program.procedures.foreach(ir.transforms.makeProcEntryNonLoop)
+
     // useful for ReplaceReturns
     // (pushes single block with `Unreachable` into its predecessor)
     while (transforms.coalesceBlocks(ctx.program)) {}
@@ -291,6 +293,7 @@ object IRTransform {
     assert(invariant.singleCallBlockEnd(ctx.program))
     assert(invariant.cfgCorrect(ctx.program))
     assert(invariant.blocksUniqueToEachProcedure(ctx.program))
+    assert(invariant.procEntryNoIncoming(ctx.program))
     ctx
   }
 
@@ -737,6 +740,13 @@ object RunUtils {
     DebugDumpIRLogger.writeToFile(File("il-before-dsa.il"), pp_prog(program))
 
     transforms.OnePassDSA().applyTransform(program)
+    if (DebugDumpIRLogger.getLevel().id < LogLevel.OFF.id) {
+      val dir = File("./graphs/")
+      if (!dir.exists()) then dir.mkdirs()
+      for (p <- ctx.program.procedures) {
+        DebugDumpIRLogger.writeToFile(File(s"graphs/blockgraph-${p.name}-dot-simp.dot"), dotBlockGraph(p))
+      }
+    }
 
     transforms.inlinePLTLaunchpad(ctx.program)
 

--- a/src/test/scala/SingleAssignmentTest.scala
+++ b/src/test/scala/SingleAssignmentTest.scala
@@ -1,0 +1,113 @@
+import analysis.ParamAnalysis
+import ir.dsl.*
+import ir.*
+import org.scalatest.funsuite.AnyFunSuite
+import test_util.BASILTest
+import util.*
+import translating.BasilIRToSMT2
+import ir.dsl.*
+import ir.transforms
+import translating.PrettyPrinter.*
+
+@test_util.tags.UnitTest
+class SingleAssignmentTest extends AnyFunSuite {
+
+  test("tight loop") {
+    val x = LocalVar("x", BitVecType(32))
+
+    val tightLoop = prog(
+      proc(
+        "errorFn_1848",
+        block("errorFn_1848_entry", LocalAssign(x, x), goto("loop")),
+        block("loop", LocalAssign(x, BinaryExpr(BVADD, x, BitVecLiteral(1, 32))), goto("loop"))
+      )
+    )
+
+    transforms.OnePassDSA().applyTransform(tightLoop)
+    while (transforms.coalesceBlocks(tightLoop)) {}
+    assert(transforms.rdDSAProperty(tightLoop.mainProcedure))
+
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.head)
+        == pp_stmt(
+          LocalAssign(
+            LocalVar("x", BitVecType(32), 4),
+            BinaryExpr(BVADD, LocalVar("x", BitVecType(32), 3), BitVecLiteral(1, 32)),
+            Some("phi")
+          )
+        )
+    )
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.tail.head)
+        == pp_stmt(LocalAssign(LocalVar("x", BitVecType(32), 3), LocalVar("x", BitVecType(32), 4), Some("phi")))
+    )
+  }
+
+  test("tight loop 2") {
+    val x = LocalVar("x", BitVecType(32))
+    // val x = LocalVar("x0", BitVecType(32))
+
+    val tightLoop = prog(
+      proc(
+        "errorFn_1848",
+        Seq("x" -> BitVecType(32)),
+        Seq(),
+        block("errorFn_1848_entry", goto("loop")),
+        block("loop", LocalAssign(x, BinaryExpr(BVADD, x, BitVecLiteral(1, 32))), goto("loop"))
+      )
+    )
+
+    transforms.OnePassDSA().applyTransform(tightLoop)
+    while (transforms.coalesceBlocks(tightLoop)) {}
+
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.head)
+        == pp_stmt(
+          LocalAssign(
+            LocalVar("x", BitVecType(32), 1),
+            BinaryExpr(BVADD, LocalVar("x", BitVecType(32), 0), BitVecLiteral(1, 32)),
+            Some("phi")
+          )
+        )
+    )
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.tail.head)
+        == pp_stmt(LocalAssign(LocalVar("x", BitVecType(32), 0), LocalVar("x", BitVecType(32), 1), Some("phi")))
+    )
+
+    assert(transforms.rdDSAProperty(tightLoop.mainProcedure))
+  }
+
+  test("tight loop 3") {
+    val x = LocalVar("x", BitVecType(32))
+    // val x = LocalVar("x0", BitVecType(32))
+
+    val tightLoop = prog(
+      proc(
+        "errorFn_1848",
+        block("errorFn_1848_entry", goto("loop")),
+        block("loop", LocalAssign(x, BinaryExpr(BVADD, x, BitVecLiteral(1, 32))), goto("loop"))
+      )
+    )
+
+    transforms.OnePassDSA().applyTransform(tightLoop)
+    while (transforms.coalesceBlocks(tightLoop)) {}
+
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.head)
+        == pp_stmt(
+          LocalAssign(
+            LocalVar("x", BitVecType(32), 2),
+            BinaryExpr(BVADD, LocalVar("x", BitVecType(32), 1), BitVecLiteral(1, 32)),
+            Some("phi")
+          )
+        )
+    )
+    assert(
+      pp_stmt(tightLoop.mainProcedure.blocks.find(_.label == "loop").get.statements.tail.head)
+        == pp_stmt(LocalAssign(LocalVar("x", BitVecType(32), 1), LocalVar("x", BitVecType(32), 2), Some("phi")))
+    )
+
+    assert(transforms.rdDSAProperty(tightLoop.mainProcedure))
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/UQ-PAC/BASIL/issues/378

The offending function was `errorFn_1848`, which was a single empty block jumping to itself, after param anslysis we got the following:

```
proc errorFn_1848(R0_in:bv64, R10_in:bv64, R11_in:bv64, R12_in:bv64, R13_in:bv64, R14_in:bv64, R15_in:bv64, R16_in:bv64, R17_in:bv64, R18_in:bv64, R1_in:bv64, R29_in:bv64, R2_in:bv64, R30_in:bv64, R31_in:bv64, R3_in:bv64, R4_in:bv64, R5_in:bv64, R6_in:bv64, R7_in:bv64, R8_in:bv64, R9_in:bv64) -> ()
{
  name = "errorFn";
  address = 0x738;
  entry_block = "errorFn_1848__0__b8tsihT4Q6a_SWPo4w8HoA";
  blocks = [
    block errorFn_1848__0__b8tsihT4Q6a_SWPo4w8HoA {address = 0x738} [
      var R0: bv64 := R0_in:bv64;
      var R10: bv64 := R10_in:bv64;
      var R11: bv64 := R11_in:bv64;
      var R12: bv64 := R12_in:bv64;
      var R13: bv64 := R13_in:bv64;
      var R14: bv64 := R14_in:bv64;
      var R15: bv64 := R15_in:bv64;
      var R16: bv64 := R16_in:bv64;
      var R17: bv64 := R17_in:bv64;
      var R18: bv64 := R18_in:bv64;
      var R1: bv64 := R1_in:bv64;
      var R29: bv64 := R29_in:bv64;
      var R2: bv64 := R2_in:bv64;
      var R30: bv64 := R30_in:bv64;
      var R31: bv64 := R31_in:bv64;
      var R3: bv64 := R3_in:bv64;
      var R4: bv64 := R4_in:bv64;
      var R5: bv64 := R5_in:bv64;
      var R6: bv64 := R6_in:bv64;
      var R7: bv64 := R7_in:bv64;
      var R8: bv64 := R8_in:bv64;
      var R9: bv64 := R9_in:bv64;
      var R30_begin: bv64 := R30:bv64;
      goto(errorFn_1848__0__b8tsihT4Q6a_SWPo4w8HoA)
    ]
  ];
};
```

These generated register var <- param assignments don't make sense because they are part of this self-loop.

We fix this by

1. Ensure the procedure entry node does not participate in a loop (has no incoming edge) with an early transform (this alone is enough to fix the assertion because the param analysis was creating nonsense, but the DSA analysis was also not really behaving correctly with respect to that nonsense:
2. Make DSA also increment SSA count if a variable use is encountered which is not a parameter and has not been renamed, add both parameters and these renames to the DSA state so that it performs the correct renaming for block self-loops containing variables not defined earlier in the program. Examples of this can be seen in SingleAssignmentTest.scala.
