### PR TITLE
add: dominator tree computation

### DIFF
--- a/src/main/scala/analysis/Dominators.scala
+++ b/src/main/scala/analysis/Dominators.scala
@@ -1,0 +1,150 @@
+package analysis
+
+/**
+ * This implements an intra-procedural dominator algorithm.
+ *
+ * A block b1 "dominates" another block b2 iff every path
+ * from the entry to b2 passes through b1.
+ *
+ */
+
+import ir.*
+import scala.collection.immutable
+import scala.collection.mutable
+import scala.annotation.tailrec
+
+/**
+ * Dominator analysis using the "improved iterative" algorithm (figure 3)
+ * presented in:
+ *
+ *     Cooper, Keith D., Harvey, Timothy J. and Kennedy, Ken.
+ *     "A simple, fast dominance algorithm." (2006) https://hdl.handle.net/1911/96345.
+ *
+ */
+object Dominators {
+
+  /** Internal-use mutable map of dominators. */
+  protected type Doms = mutable.Map[Block, Node]
+
+  type Node = Undefined.type | Block
+  case object Undefined
+
+  /**
+   * The result of the dominator analysis is a map representing
+   * the dominator *tree*. Each block is mapped to its
+   * unique *immediate* dominator - that is, the dominator
+   * which dominates all other dominators.
+   *
+   * A block's value may be the special Undefined value if it
+   * is unreachable from the start block.
+   */
+  type Result = immutable.Map[Block, Node]
+
+  /**
+   * Computes the dominator tree for the given procedure.
+   * The given procedure must have at least an entry block.
+   */
+  def computeDominatorTree(p: Procedure): Result = {
+    val entry = p.entryBlock.getOrElse(throw Exception("attempt to compute dominators with no entry block"))
+
+    ir.transforms.reversePostOrder(p)
+
+    val doms: Doms = mutable.Map.from(p.blocks.map(_ -> Undefined))
+    doms(entry) = entry
+
+    val allBlocksRPO = Array.from(p.blocks).sortBy(_.rpoOrder)
+
+    var changed = true
+    while (changed) {
+      // println("iteration")
+      changed = false
+      for (b <- allBlocksRPO) {
+        if (b != entry) {
+          val new_idom = b.prevBlocks
+            .to(mutable.ArraySeq)
+            .sortBy(_.rpoOrder)
+            .foldLeft(Undefined: Node)((a, b) => intersect(doms, a, b))
+
+          val old = doms.put(b, new_idom)
+          if (old != Some(new_idom)) {
+            changed = true
+          }
+        }
+
+      }
+    }
+
+    doms.toMap
+  }
+
+  /**
+   * Returns a function which to determine whether block b1 dominates block b2,
+   * given a pre-computed dominator tree.
+   */
+  def dominates(doms: Result | Doms): (Block, Block) => Boolean = {
+
+    @tailrec
+    def go(b1: Block, b2: Block): Boolean = {
+      if (b1 == b2) then {
+        true
+      } else {
+        doms(b2) match {
+          // NOTE: should every block dominate an unreachable block? currently, we say
+          // nothing dominates an unreachable block.
+          case Undefined => false
+          case nextb2: Block if nextb2 != b2 => go(b1, nextb2)
+          case _: Block => false
+        }
+      }
+    }
+
+    go
+  }
+
+  def nodeToString(x: Node) =
+    x match {
+      case b: Block => b.label
+      case _ => x.toString
+    }
+
+  def printDoms(doms: Doms | Result) = {
+    doms.foreach((k, v) => {
+      println(k.label + " -> " + nodeToString(v))
+    })
+  }
+
+  /**
+   * Computes a kind of set intersection of the dominators of the given blocks.
+   */
+  protected def intersect(doms: Doms, b1: Node, b2: Block): Node = {
+    b1 match {
+      // NOTE: the paper explicitly filters out Undefined values.
+      // but we keep them and handle them here in the intersect function.
+      // if b2 is not yet processed, then ignore it.
+      case _ if doms(b2) == Undefined => b1
+
+      // this will only be encountered in the first iteration, as
+      // Undefined is the base case for the fold and all other fold elements
+      // are blocks.
+      case Undefined => b2
+
+      // the following is the intersect algorithm from the paper.
+      case b1: Block => {
+        var finger1 = b1
+        var finger2 = b2
+        while (finger1 != finger2) {
+          // paper uses "finger1 < finger2", with an implicit numbering which is RPO???
+          while (finger1.rpoOrder < finger2.rpoOrder) {
+            // casting should be guaranteed by rpoorder and ensuring that
+            // b2 has been processed.
+            finger1 = doms(finger1).asInstanceOf[Block]
+          }
+          while (finger2.rpoOrder < finger1.rpoOrder) {
+            finger2 = doms(finger2).asInstanceOf[Block]
+          }
+        }
+        finger1
+      }
+    }
+  }
+}

--- a/src/test/scala/DominatorsTest.scala
+++ b/src/test/scala/DominatorsTest.scala
@@ -1,0 +1,112 @@
+import org.scalatest.*
+import org.scalatest.funsuite.*
+
+import ir.*
+import ir.dsl.*
+import scala.collection.immutable
+
+@test_util.tags.UnitTest
+class DominatorsTest extends AnyFunSuite {
+  import analysis.Dominators.*
+
+  def domsToStringMap(doms: Result) =
+    doms.map((k, v) => k.label -> nodeToString(v)).toMap
+
+  test("figure 4 in paper") {
+    val p = prog(
+      proc(
+        "main",
+        block("6", goto("5", "4")),
+        block("5", goto("1")),
+        block("4", goto("2", "3")),
+        block("3", goto("2")),
+        block("2", goto("1", "3")),
+        block("1", goto("2"))
+      )
+    )
+
+    val expected = Seq("1", "2", "3", "4", "5", "6").map(_ -> "6").toMap
+    val doms = computeDominatorTree(p.mainProcedure)
+    assertResult(expected) {
+      doms.map((k, v) => k.label -> nodeToString(v)).toMap
+    }
+    val b = p.labelToBlock
+    assertResult(true)(dominates(doms)(b("6"), b("1")))
+    assertResult(false)(dominates(doms)(b("1"), b("6")))
+    assertResult(true)(dominates(doms)(b("6"), b("6")))
+    assertResult(true)(dominates(doms)(b("1"), b("1")))
+    assertResult(false)(dominates(doms)(b("5"), b("1")))
+  }
+
+  test("figure 2 in paper") {
+    val p = prog(
+      proc(
+        "main",
+        block("5", goto("4", "3")),
+        block("4", goto("1")),
+        block("3", goto("2")),
+        block("2", goto("1")),
+        block("1", goto("2"))
+      )
+    )
+
+    val expected = Seq("1", "2", "3", "4", "5").map(_ -> "5").toMap
+    val doms = computeDominatorTree(p.mainProcedure)
+    assertResult(expected) {
+      domsToStringMap(doms)
+    }
+  }
+
+  test("straight line") {
+    val p = prog(
+      proc(
+        "main",
+        block("5", goto("4")),
+        block("4", goto("3")),
+        block("3", goto("2")),
+        block("2", goto("1")),
+        block("1", goto("0")),
+        block("0", goto("0"))
+      )
+    )
+
+    val expected = Map("4" -> "5", "5" -> "5", "1" -> "2", "0" -> "1", "2" -> "3", "3" -> "4")
+    val doms = computeDominatorTree(p.mainProcedure)
+    assertResult(expected) {
+      domsToStringMap(doms)
+    }
+  }
+
+  test("irreducible2.c") {
+    // from the diagram of
+    // src/test/irreducible_loops/irreducible_loop_2/irreducible2.c
+    val p = prog(
+      proc(
+        "main",
+        block("start", goto("a", "g")),
+        block("a", goto("b")),
+        block("b", goto("c")),
+        block("c", goto("d")),
+        block("d", goto("f")),
+        block("f", goto("e", "b")),
+        block("g", goto("d")),
+        block("e", goto("e"))
+      )
+    )
+
+    val expected = Map(
+      "e" -> "f",
+      "f" -> "d",
+      "a" -> "start",
+      "b" -> "start",
+      "g" -> "start",
+      "c" -> "b",
+      "start" -> "start",
+      "d" -> "start"
+    )
+    val doms = computeDominatorTree(p.mainProcedure)
+    assertResult(expected) {
+      domsToStringMap(doms)
+    }
+  }
+}


### PR DESCRIPTION
This implements a simple function to compute dominators of a block. A dominator of a block `b` is a block `b'` such that every path from the entry (of a procedure) to `b` first passes through `b'`.

To determine whether two arbitrary blocks dominate each other, you should first compute the dominator tree. Then, pass this to `Dominator.dominates` to obtain a binary predicate on blocks.

This follows the algorithm in https://hdl.handle.net/1911/96345. Although this runs in quadratic time, the paper notes that it is simpler and empirically faster than asymptotically faster algorithms for realistic sizes of programs.