### PR TITLE
add label to dsl directCall

### DIFF
--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -189,10 +189,17 @@ def ret(params: (String, Expr)*): EventuallyReturn = EventuallyReturn(params)
 
 def unreachable: EventuallyUnreachable = EventuallyUnreachable()
 
-def directCall(lhs: Iterable[(String, Variable)], tgt: String, actualParams: (String, Expr)*): EventuallyCall =
-  EventuallyCall(DelayNameResolve(tgt), lhs.to(ArraySeq), actualParams)
+def directCall(
+  lhs: Iterable[(String, Variable)],
+  tgt: String,
+  actualParams: Iterable[(String, Expr)],
+  label: Option[String] = None
+): EventuallyCall =
+  EventuallyCall(DelayNameResolve(tgt), lhs.to(ArraySeq), actualParams, label)
 
-def directCall(tgt: String): EventuallyCall = directCall(Nil, tgt)
+def directCall(tgt: String): EventuallyCall = directCall(Nil, tgt, Nil)
+
+def directCall(tgt: String, label: Option[String]): EventuallyCall = directCall(Nil, tgt, Nil)
 
 def indirectCall(tgt: Variable): EventuallyIndirectCall = EventuallyIndirectCall(tgt)
 

--- a/src/main/scala/ir/dsl/IRToDSL.scala
+++ b/src/main/scala/ir/dsl/IRToDSL.scala
@@ -29,7 +29,7 @@ object IRToDSL {
   def convertCallStatement(x: Call): EventuallyStatement = x match {
     case DirectCall(targ, outs, actuals, label) =>
       // XXX: be aware of ordering, .map() on a SortedMap may return a HashMap.
-      directCall(outs.to(ArraySeq).map(keyToString), targ.name, actuals.to(ArraySeq).map(keyToString): _*)
+      directCall(outs.to(ArraySeq).map(keyToString), targ.name, actuals.to(ArraySeq).map(keyToString), label)
     case IndirectCall(targ, label) => indirectCall(targ)
   }
 

--- a/src/main/scala/ir/transforms/Inline.scala
+++ b/src/main/scala/ir/transforms/Inline.scala
@@ -76,7 +76,8 @@ def convertStatementRenaming(varRenamer: CILVisitor)(x: Statement): EventuallySt
     directCall(
       outs.to(ArraySeq).map(v => (v(0).name, visit_rvar(varRenamer, v(1)))),
       targ.name,
-      actuals.to(ArraySeq).map(keyToString(varRenamer)): _*
+      actuals.to(ArraySeq).map(keyToString(varRenamer)),
+      label
     )
   case IndirectCall(targ, label) => indirectCall(visit_rvar(varRenamer, targ))
   case x: NonCallStatement =>

--- a/src/test/scala/ir/IRTest.scala
+++ b/src/test/scala/ir/IRTest.scala
@@ -342,7 +342,7 @@ class IRTest extends AnyFunSuite {
         block("l_main", indirectCall(R1), goto("returntarget")),
         block(
           "block2",
-          directCall(Seq(("R0_out" -> R0)), "p1", "R0_in" -> BitVecLiteral(150, 64)),
+          directCall(Seq(("R0_out" -> R0)), "p1", Set("R0_in" -> BitVecLiteral(150, 64))),
           goto("returntarget")
         ),
         block("returntarget", ret("R0_out" -> BitVecLiteral(1, 64)))

--- a/src/test/scala/ir/IRToDSLTestData.scala
+++ b/src/test/scala/ir/IRToDSLTestData.scala
@@ -88,6 +88,7 @@ object IRToDSLTestData {
             "R31_out" -> LocalVar("R31", BitVecType(64), 0)
           ),
           "get_two_1876",
+          Seq(
           "R0_in" -> LocalVar("R0", BitVecType(64), 0),
           "R10_in" -> LocalVar("R10", BitVecType(64), 0),
           "R11_in" -> LocalVar("R11", BitVecType(64), 0),
@@ -109,6 +110,7 @@ object IRToDSLTestData {
           "R7_in" -> LocalVar("R7", BitVecType(64), 0),
           "R8_in" -> LocalVar("R8", BitVecType(64), 0),
           "R9_in" -> LocalVar("R9", BitVecType(64), 0)
+          )
         ),
         goto("l000003ec")
       ),
@@ -150,6 +152,7 @@ object IRToDSLTestData {
             "R9_out" -> LocalVar("R9", BitVecType(64), 0)
           ),
           "printf_1584",
+          Seq(
           "R0_in" -> LocalVar("R0", BitVecType(64), 0),
           "R10_in" -> LocalVar("R10", BitVecType(64), 0),
           "R11_in" -> LocalVar("R11", BitVecType(64), 0),
@@ -171,6 +174,7 @@ object IRToDSLTestData {
           "R7_in" -> LocalVar("R7", BitVecType(64), 0),
           "R8_in" -> LocalVar("R8", BitVecType(64), 0),
           "R9_in" -> LocalVar("R9", BitVecType(64), 0)
+          )
         ),
         goto("l00000430")
       ),

--- a/src/test/scala/ir/ToScalaTest.scala
+++ b/src/test/scala/ir/ToScalaTest.scala
@@ -237,7 +237,7 @@ prog(
         Seq("R0_out" -> BitVecType(64), "R1_out" -> BitVecType(64), "R31_out" -> BitVecType(64)),
         block(
           "get_two_1876_basil_return",
-          directCall(Seq("out" -> R0), "printf", "in" -> LocalVar("R0", BitVecType(64), 0)),
+          directCall(Seq("out" -> R0), "printf", Seq("in" -> LocalVar("R0", BitVecType(64), 0))),
           ret(
             "R0_out" -> LocalVar("R0", BitVecType(64), 0),
             "R1_out" -> LocalVar("R1", BitVecType(64), 0),


### PR DESCRIPTION
directCall takes an additional label argument allowing it to specify the label of EventuallyCall instances