### PR TITLE
ci: fix word regex in check-test-tagging

### DIFF
--- a/.github/workflows/check-test-tagging.sh
+++ b/.github/workflows/check-test-tagging.sh
@@ -14,19 +14,32 @@ grep --color=always '@test_util\.tags\.DisabledTest' --context=1 -R $test_dir
 echo '::endgroup::'
 echo
 
+# Locates the definition of the given test case, and prints the class definition
+# with two preceding lines of context.
+find_test_case() {
+  t="$1"
+  shift
+  # NOTE: \> matches the end of a word
+  exec grep 'class\s\+'"$t"'\>' --before-context=2 -R $test_dir "$@"
+}
+
 ok=true
 echo '::group::Test suites with no tag annotations:'
 for t in $tests; do
-  defn="$(grep 'class\s\+'"$t"'[ (]' --before-context=2 -R $test_dir)"
+  defn="$(find_test_case "$t")"
+
   # search for lines which are entirely "@test_util.tags.*Test"
   # leading - is produced by grep to mark prefixes
   if ! grep -q -- '-@test_util\.tags\..\+Test$' <<< "$defn"; then
-    echo 'test suite has no `@test_util.tags.*Test` annotation:' >&2
-    grep --color=always 'class\s\+'"$t"'[ (]' --before-context=2  -R $test_dir
+    echo 'test suite' "'$t'" 'has no `@test_util.tags.*Test` annotation:' >&2
+    find_test_case "$t" --color=always || true
     echo
     ok=false
   fi
 done
+if $ok; then
+  echo '(none - this is good!)'
+fi
 echo '::endgroup::'
 
 $ok


### PR DESCRIPTION
the previous regex would fail to find the test case definition if it appeared on multiple lines, e.g.:

```scala
@test_util.tags.UnitTest
class BitVectorAnalysisTests
  extends AnyFunSuite {
```

this led to false alarms in the ci runs.

also improves and refactors the script to make it a bit more robust, with clearer error messages and less silent failures

with this pr, i avoid having to rewrite the script. but maybe the time will come soon...

this has been tested to fix the ci failure in https://github.com/UQ-PAC/BASIL/actions/runs/14326080264/job/40151684127?pr=335