### PR TITLE
refactor: improve error messages of loadDirectory and refactor

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -22,50 +22,72 @@ object Main {
     case Bap
   }
 
+  private def replacePathExtension(p: java.nio.file.Path, newExtension: String) = {
+    val basename = p.getFileName().toString
+
+    val withoutExtension = if (basename.contains(".")) {
+      basename.split("\\.", -1).dropRight(1).mkString(".")
+    } else {
+      basename
+    }
+
+    p.resolveSibling(withoutExtension + newExtension)
+  }
+
   def loadDirectory(i: ChooseInput = ChooseInput.Gtirb, d: String): ILLoadingConfig = {
 
-    val x = d.stripSuffix(".gts").stripSuffix(".adt")
-    val p = x.split("/")
-    val tryName = Seq(x + "/" + p.last, x + "/" + p.dropRight(1).last, x, p.last, p.dropRight(1).mkString("/"))
+    // at this point, `path` is the given directory with file extensions removed (if any).
+    val path = replacePathExtension(java.nio.file.Paths.get(d), "")
 
-    tryName
+    // name of the parent directory.
+    // e.g., in "src/test/correct/TESTCASE/gcc_O2", this would be "TESTCASE".
+    val parentName = path.getParent().getFileName()
+
+    // the elements of this list are the filenames which will be tried. they will be
+    // suffixed with different extensions to get the different files needed.
+    val tryName = Seq(path.resolve(path.getFileName), path.resolve(parentName), path, path.getFileName, path.getParent)
+    // NOTE: path.resolve(subpath) acts like `path + "/" + subpath`
+
+    // helper function to locate a file adjacent to the given path, with the given extension,
+    // and ensure that it exists. returns None if file does not exist, otherwise Some(Path).
+    val findAdjacent = (x: java.nio.file.Path, ext: String) =>
+      Some(replacePathExtension(x, ext)).filter(_.toFile.exists)
+
+    val results = tryName
       .flatMap(name => {
-        val trySpec =
-          tryName.map(n => n + ".spec") ++ Seq(p.dropRight(1).mkString("/") + "/" + p.dropRight(1).last + ".spec")
-        val adt = s"$name.adt"
-        val relf = s"$name.relf"
-        val gtirb = s"$name.gts"
+        val trySpec = (tryName ++ Seq(path.getParent.resolve(parentName)))
+          .flatMap(findAdjacent(_, ".spec"))
+        val spec = trySpec.headOption
 
-        val spec = trySpec
-          .flatMap(s => {
-            if (File(s).exists) {
-              Seq(s)
-            } else {
-              Seq()
-            }
-          })
-          .headOption
+        val adt = findAdjacent(name, ".adt")
+        val relf = findAdjacent(name, ".relf")
+        val gtirb = findAdjacent(name, ".gts")
 
         val input = i match
           case ChooseInput.Gtirb => gtirb
           case ChooseInput.Bap => adt
 
-        if (File(input).exists() && File(relf).exists()) {
-          Logger.info(s"Found $input $relf ${spec.getOrElse("")}")
-          Seq(ILLoadingConfig(input, relf, spec))
-        } else {
-          Seq()
+        (input, relf) match {
+          case (Some(input), Some(relf)) => {
+            Logger.info(s"Found $input $relf ${spec.getOrElse("")}")
+            Seq(ILLoadingConfig(input.toString, relf.toString, spec.map(_.toString)))
+          }
+          case _ => Seq()
         }
       })
-      .head
 
+    results match {
+      case Nil => throw Exception(s"failed to load directory (tried: ${tryName.mkString(", ")})")
+      case Seq(x) => x
+      case more => throw Exception(s"found more than one potential input (${more.mkString(", ")})")
+    }
   }
 
   @main(name = "BASIL")
   case class Config(
     @arg(name = "load-directory-bap", doc = "Load relf, adt, and bir from directory (and spec from parent directory)")
     bapInputDirName: Option[String],
-    @arg(name = "load-directory-gtirb", doc = "Load relf, gts, and bir from directory (and spec from parent directory)")
+    @arg(name = "load-directory-gtirb", doc = "Load relf and gts from directory (and spec from parent directory)")
     gtirbInputDirName: Option[String],
     @arg(name = "input", short = 'i', doc = "BAP .adt file or GTIRB/ASLi .gts file")
     inputFileName: Option[String],


### PR DESCRIPTION
the biggest change is to use the java.nio.file.Path abstraction (https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html) instead of manually manipulating slashes. this should make it more robust on different platforms, and more reasonable in the face of paths which contain semantically equivalent but syntactically different paths (e.g., multiple slashes in a row `//` or `.` path components).

it also improves readability by using methods with path-specific names instead of manipulating lists and strings. some other changes to add more comments and use more functional programming.

in most cases, the new behaviour should be equivalent to the old one. in cases with elements like `//` or `.`, the behaviour should be more reasonable - now, it correctly treats those as insignificant.