### PR TITLE
Memtransform fixups

### DIFF
--- a/src/main/scala/analysis/CommonDefinitionVariableRenaming.scala
+++ b/src/main/scala/analysis/CommonDefinitionVariableRenaming.scala
@@ -103,6 +103,7 @@ def getCommonDefinitionVariableRenaming(
 
   toVisit.foreach {
     case a: LocalAssign => unifyVarsUses(a.rhs.variables, a)
+    case a: MemoryAssign => unifyVarsUses(a.rhs.variables, a)
     case l: MemoryLoad => unifyVarsUses(l.index.variables, l)
     case a: MemoryStore => unifyVarsUses(a.index.variables ++ a.value.variables, a)
     case a: Assert => unifyVarsUses(a.body.variables, a)

--- a/src/main/scala/analysis/IntraLiveVarsAnalysis.scala
+++ b/src/main/scala/analysis/IntraLiveVarsAnalysis.scala
@@ -12,6 +12,7 @@ abstract class LivenessAnalysis(program: Program, addExternals: Boolean = true) 
       case p: Procedure => s
       case b: Block => s
       case a: LocalAssign => (s - a.lhs) ++ a.rhs.variables
+      case a: MemoryAssign => (s - a.lhs) ++ a.rhs.variables
       case m: MemoryStore => s ++ m.index.variables ++ m.value.variables
       case m: MemoryLoad => (s - m.lhs) ++ m.index.variables
       case a: Assume => s ++ a.body.variables

--- a/src/main/scala/analysis/MemoryRegionAnalysis.scala
+++ b/src/main/scala/analysis/MemoryRegionAnalysis.scala
@@ -145,6 +145,7 @@ trait MemoryRegionAnalysis(
             val ctx = getUse(variable, n, reachingDefs)
             val stackRegions = ctx.flatMap {
               case l: LocalAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
+              case l: MemoryAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
               case _: MemoryLoad => Set()
               case unhandled: DirectCall =>
                 throw Exception(
@@ -181,6 +182,7 @@ trait MemoryRegionAnalysis(
     val regions = ctx.flatMap { i =>
       if (i != n) {
         i match {
+          case l: MemoryAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
           case l: LocalAssign => eval(l.rhs, stackPointerVariables, l, subAccess)
           case m: MemoryLoad => eval(m.index, stackPointerVariables, m, m.size)
           case d: DirectCall =>

--- a/src/main/scala/ir/IRCursor.scala
+++ b/src/main/scala/ir/IRCursor.scala
@@ -387,6 +387,7 @@ def toDot[T <: CFGPosition](
  */
 def freeVarsPos(s: CFGPosition): Set[Variable] = s match {
   case a: LocalAssign => a.rhs.variables
+  case a: MemoryAssign => a.rhs.variables
   case l: MemoryLoad => l.index.variables
   case a: MemoryStore => a.index.variables ++ a.value.variables
   case a: Assert => a.body.variables

--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -63,6 +63,7 @@ type NonCallStatement =
 
 def cloneStatement(x: NonCallStatement): NonCallStatement = x match {
   case LocalAssign(a, b, c) => LocalAssign(a, b, c)
+  case MemoryAssign(a, b, c) => MemoryAssign(a, b, c)
   case MemoryStore(a, b, c, d, e, f) => MemoryStore(a, b, c, d, e, f)
   case MemoryLoad(a, b, c, d, e, f) => MemoryLoad(a, b, c, d, e, f)
   case x: NOP => NOP(x.label) // FIXME: no unapply for NOP atm

--- a/src/main/scala/ir/eval/InterpretBasilIR.scala
+++ b/src/main/scala/ir/eval/InterpretBasilIR.scala
@@ -386,6 +386,13 @@ object InterpFuns {
 
   def interpretStatement[S, T <: Effects[S, InterpreterError]](f: T)(s: Statement): State[S, Unit, InterpreterError] = {
     s match {
+      case assign: MemoryAssign => {
+        for {
+          rhs <- Eval.evalLiteral(f)(assign.rhs)
+          st <- f.storeVar(assign.lhs.name, assign.lhs.toBoogie.scope, Scalar(rhs))
+          n <- f.setNext(Run(s.successor))
+        } yield (st)
+      }
       case assign: LocalAssign => {
         for {
           rhs <- Eval.evalLiteral(f)(assign.rhs)

--- a/src/main/scala/ir/transforms/ProcedureParameters.scala
+++ b/src/main/scala/ir/transforms/ProcedureParameters.scala
@@ -304,6 +304,10 @@ object ReadWriteAnalysis {
           ir.map(addWrites(Seq(s.lhs)))
             .map(addReads(s.rhs.variables))
         }
+        case s: MemoryAssign => {
+          ir.map(addWrites(Seq(s.lhs)))
+            .map(addReads(s.rhs.variables))
+        }
         case s: MemoryLoad => {
           ir.map(addWrites(Seq(s.lhs)))
             .map(addReads(s.index.variables))

--- a/src/main/scala/translating/IRExpToSMT2.scala
+++ b/src/main/scala/translating/IRExpToSMT2.scala
@@ -12,7 +12,7 @@ trait BasilIR[Repr[+_]] extends BasilIRExp[Repr] {
   def vstmt(s: Statement): Repr[Statement] = {
     s match {
       case a: LocalAssign => vassign(vlvar(a.lhs), vexpr(a.rhs))
-      case m: MemoryAssign => vassign(vlvar(m.lhs), vexpr(m.rhs))
+      case m: MemoryAssign => vmemassign(vlvar(m.lhs), vexpr(m.rhs))
       case m: MemoryLoad => vload(vlvar(m.lhs), m.mem.name, vexpr(m.index), m.endian, m.size)
       case m: MemoryStore => vstore(m.mem.name, vexpr(m.index), vexpr(m.value), m.endian, m.size)
       case c: DirectCall =>
@@ -83,6 +83,7 @@ trait BasilIR[Repr[+_]] extends BasilIRExp[Repr] {
   ): Repr[Procedure]
 
   def vassign(lhs: Repr[Variable], rhs: Repr[Expr]): Repr[LocalAssign]
+  def vmemassign(lhs: Repr[Variable], rhs: Repr[Expr]): Repr[LocalAssign]
   def vload(lhs: Repr[Variable], mem: String, index: Repr[Expr], endian: Endian, size: Int): Repr[MemoryLoad]
   def vstore(mem: String, index: Repr[Expr], value: Repr[Expr], endian: Endian, size: Int): Repr[MemoryStore]
   def vcall(

--- a/src/main/scala/translating/IRToBoogieNoVC.scala
+++ b/src/main/scala/translating/IRToBoogieNoVC.scala
@@ -43,6 +43,10 @@ object BoogieTranslator {
       val lhs: BVar = translateVar(l.lhs)
       val rhs = translateExpr(l.rhs)
       AssignCmd(List(lhs), List(rhs))
+    case l: MemoryAssign =>
+      val lhs: BVar = translateVar(l.lhs)
+      val rhs = translateExpr(l.rhs)
+      AssignCmd(List(lhs), List(rhs))
     case a: Assert =>
       val body = translateExpr(a.body)
       BAssert(body, a.comment)

--- a/src/main/scala/translating/PrettyPrinter.scala
+++ b/src/main/scala/translating/PrettyPrinter.scala
@@ -331,6 +331,7 @@ class BasilIRPrettyPrinter(
   ): PPProg[Procedure] = ???
 
   override def vassign(lhs: PPProg[Variable], rhs: PPProg[Expr]): PPProg[LocalAssign] = BST(s"${lhs} := ${rhs}")
+  override def vmemassign(lhs: PPProg[Variable], rhs: PPProg[Expr]): PPProg[LocalAssign] = BST(s"${lhs} mem:= ${rhs}")
 
   override def vstore(
     mem: String,

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -949,9 +949,11 @@ object RunUtils {
         DSATimer.checkPoint("Finished DSA Invariant Check")
         dsaContext = Some(dsaContext.get.copy(local = DSA, bottomUp = DSABU, topDown = DSATD))
 
-        if q.memoryTransform then
+        if q.memoryTransform then {
           visit_prog(MemoryTransform(DSATD, globalMapping), ctx.program)
           DSATimer.checkPoint("Performed Memory Transform")
+          // doSimplify(ctx, None)
+        }
     }
 
     if (q.runInterpret) {


### PR DESCRIPTION
Updates the various transforms to handle the new `MemoryAssign` sensibly, at least as long as they produced match exhaustivity warnings. 

Also fixes the substitution loop in https://github.com/UQ-PAC/BASIL/issues/401 