### PR TITLE
Add unsigned division to GTIRB loader

### DIFF
--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -366,6 +366,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
       case "sub_bits.0" => resolveBinaryOp(BVSUB, function, 1, typeArgs, args, ctx.getText)
       case "mul_bits.0" => resolveBinaryOp(BVMUL, function, 1, typeArgs, args, ctx.getText)
       case "sdiv_bits.0" => resolveBinaryOp(BVSDIV, function, 1, typeArgs, args, ctx.getText)
+      case "udiv_bits.0" => resolveBinaryOp(BVUDIV, function, 1, typeArgs, args, ctx.getText)
       case "slt_bits.0" => resolveBinaryOp(BVSLT, function, 1, typeArgs, args, ctx.getText)
       case "sle_bits.0" => resolveBinaryOp(BVSLE, function, 1, typeArgs, args, ctx.getText)
 


### PR DESCRIPTION
ASLp will begin producing unsigned division operations as `udiv_bits` once the following is merged: https://github.com/UQ-PAC/aslp/pull/136

This PR adds support for the primitive ahead of time.