### PR TITLE
fix GenericLogger.writeToFile bug which produced empty file

### DIFF
--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -19,7 +19,7 @@ class GenericLogger(
 ) {
 
   private var _output = () => defaultOutput
-  def output = _output()
+  def output: PrintStream = _output()
 
   val children: HashSet[GenericLogger] = HashSet()
 
@@ -48,7 +48,10 @@ class GenericLogger(
   }
 
   def deriveLogger(name: String, file: File): GenericLogger = {
-    deriveLogger(name, PrintStream(file))
+    // WARN: PrintStream must be constructed outside of the "=>" param
+    // so there is a single PrintStream instance.
+    val stream = PrintStream(file)
+    deriveLogger(name, stream)
   }
 
   def deriveLogger(name: String): GenericLogger = deriveLogger(name, output)

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -41,22 +41,26 @@ class GenericLogger(
   def disableColour(setChildren: Boolean = false) = setColour(false, setChildren)
   def enableColour(setChildren: Boolean = false): Unit = setColour(true, setChildren)
 
-  def deriveLogger(sname: String, stream: => PrintStream): GenericLogger = {
+  // WARNING: if using this private method, be very aware of the by-name "=>" PrintStream parameter.
+  private def deriveLoggerInternal(sname: String, stream: => PrintStream): GenericLogger = {
     val l = GenericLogger(name + "." + sname, level, stream, ANSIColour)
     children.add(l)
     l
   }
 
-  def deriveLogger(name: String, file: File): GenericLogger = {
-    // WARN: PrintStream must be constructed outside of the "=>" param
-    // so there is a single PrintStream instance.
-    val stream = PrintStream(file)
-    deriveLogger(name, stream)
-  }
+  def deriveLogger(name: String, stream: PrintStream): GenericLogger =
+    deriveLoggerInternal(name, stream)
 
-  def deriveLogger(name: String): GenericLogger = deriveLogger(name, output)
+  def deriveLogger(name: String, stream: () => PrintStream): GenericLogger =
+    deriveLoggerInternal(name, stream())
 
-  def setOutput(stream: => PrintStream) = _output = () => stream
+  def deriveLogger(name: String, file: File): GenericLogger =
+    deriveLogger(name, PrintStream(file))
+
+  def deriveLogger(name: String): GenericLogger = deriveLoggerInternal(name, output)
+
+  def setOutput(stream: PrintStream) = _output = () => stream
+  def setOutput(streamProducer: () => PrintStream) = _output = streamProducer
 
   def writeToFile(file: File, content: => String) = {
     if (level.id < LogLevel.OFF.id) {
@@ -167,16 +171,16 @@ class GenericLogger(
 def isAConsole = System.console() != null
 
 val Logger = GenericLogger("log", LogLevel.DEBUG, Console.out, isAConsole).setLevel(LogLevel.INFO, true)
-val StaticAnalysisLogger = Logger.deriveLogger("analysis", Console.out)
-val SimplifyLogger = Logger.deriveLogger("simplify", Console.out)
+val StaticAnalysisLogger = Logger.deriveLogger("analysis")
+val SimplifyLogger = Logger.deriveLogger("simplify")
 val DebugDumpIRLogger = Logger.deriveLogger("debugdumpir").setLevel(LogLevel.OFF)
 val AnalysisResultDotLogger = Logger.deriveLogger("analysis-results-dot").setLevel(LogLevel.OFF)
 val VSALogger = StaticAnalysisLogger.deriveLogger("vsa")
 val MRALogger = StaticAnalysisLogger.deriveLogger("mra").setLevel(LogLevel.INFO)
 val SteensLogger = StaticAnalysisLogger.deriveLogger("steensgaard")
 // DSA Loggers
-val DSALogger = Logger.deriveLogger("DSA", Console.out).setLevel(LogLevel.OFF)
+val DSALogger = Logger.deriveLogger("DSA").setLevel(LogLevel.OFF)
 val ConstGenLogger = DSALogger.deriveLogger("Constraint Gen", Console.out).setLevel(LogLevel.INFO)
-val SVALogger = DSALogger.deriveLogger("SVA", Console.out)
+val SVALogger = DSALogger.deriveLogger("SVA")
 val IntervalDSALogger = DSALogger.deriveLogger("SadDSA", Console.out).setLevel(LogLevel.OFF)
-val StackLogger = Logger.deriveLogger("Stack", Console.out).setLevel(LogLevel.INFO)
+val StackLogger = Logger.deriveLogger("Stack").setLevel(LogLevel.INFO)

--- a/src/test/scala/LoggingTest.scala
+++ b/src/test/scala/LoggingTest.scala
@@ -1,0 +1,22 @@
+import org.scalatest.funsuite.AnyFunSuite
+
+@test_util.tags.UnitTest
+class LoggingTest extends AnyFunSuite, test_util.CaptureOutput {
+
+  import java.nio.file.Files
+  import java.io.File
+  import scala.jdk.CollectionConverters.*
+
+  import util.Logger
+
+  test("GenericLogger.writeToFile") {
+    val f = File.createTempFile("basil-test-logger-output", "")
+
+    val s = "jfidosajfioas"
+    Logger.writeToFile(f, s)
+
+    assertResult(List(s)) {
+      Files.readAllLines(f.toPath).asScala
+    }
+  }
+}


### PR DESCRIPTION
I'm very sorry about this one.
In my changes to GenericLogger to implement the redirection of stdout/stderr (https://github.com/UQ-PAC/BASIL/pull/372), I changed the PrintStream parameter to be a by-name (`=>`) parameter.

This means it is evaluated every time the parameter is used. This was needed to allow for the possibility that Console.out, for example, would be redirected to a new stream.

However, in this instance, it causes problems when the by-name parameter is re-evaluated on every call. Here, the `PrintStream(file)` parameter being re-evaluated means that new PrintStreams are being constructed on the same file, leading to conflicts when flushing and closing, and extremely surprising behaviour.

This was a nasty one, I'm sorry. I would support bigger changes to deriveLogger to prevent similar problems in future.