### PR TITLE
remove duplicate call class

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -97,6 +97,28 @@ jobs:
           echo "$pasted" > $GITHUB_STEP_SUMMARY
         shell: "bash -xe {0}"
 
+
+  UnitTestsWindows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
+      - run: choco install z3
+      - run: dotnet tool install --global boogie --version '3.4.3'
+
+      - run: ./mill test.compile
+      - run: ./scripts/scalatest.sh -oGD -PS3 -T 1000000 -n test_util.tags.UnitTest
+
   UnitTests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -149,7 +149,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./mill test.compile
 
       - uses: actions/setup-java@v4
         with:
@@ -166,5 +165,5 @@ jobs:
 
       - run: echo "All systemtest suites:" && ./mill test.testOnly '*SystemTests*' -- -z 'xxxx'
 
-      - run: ./mill compile
+      - run: ./mill test.compile
       - run: ./scripts/scalatest.sh -oGD -PS3 -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2

--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -197,9 +197,7 @@ def directCall(
 def directCall(lhs: Iterable[(String, Variable)], tgt: String, actualParams: (String, Expr)*): EventuallyCall =
   EventuallyCall(DelayNameResolve(tgt), lhs.to(ArraySeq), actualParams)
 
-case class Call(target: String, actualParams: (String, Expr)*)
-
-def directCall(lhs: Iterable[(String, Variable)], rhs: Call): EventuallyCall =
+def directCall(lhs: Iterable[(String, Variable)], rhs: call): EventuallyCall =
   EventuallyCall(DelayNameResolve(rhs.target), lhs.toArray, rhs.actualParams)
 
 def directCall(tgt: String): EventuallyCall = directCall(Nil, tgt, Nil)


### PR DESCRIPTION
Works on Linux but causes tests to fail to compile on case-insensitive filesystems.

```
[warn] -- Warning: /home/am/Documents/programming/2024/basil-fix-x/src/main/scala/ir/dsl/DSL.scala:200:11 
[warn] 200 |case class Call(target: String, actualParams: (String, Expr)*)
[warn]     |           ^
[warn]     |Generated class ir.dsl.Call differs only in case from ir.dsl.call (defined in InfixConstructors.scala).
[warn]     |  Such classes will overwrite one another on case-insensitive filesystems.
[warn] there were 2 feature warnings; re-run with -feature for details
[warn] three warnings found
```

The lowercase `ir.dsl.call` breaks capital camel case naming convention for classes but in this case its part of the DSL so obscuring that its a class is fine.

I would also set this warning to error but it seems its not been given an ID in the scala compiler so you would have to regex match the warning message, and I'm not doing that. 