### PR TITLE
set ammoniteVersion in build.sc

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -7,6 +7,8 @@ import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
 import contrib.scalapblib._
 
 object basil extends RootModule with ScalaModule with antlr.AntlrModule with ScalaPBModule {
+  // ammoniteVersion should be updated whenever scalaVersion is changed. see, for example,
+  // https://mvnrepository.com/artifact/com.lihaoyi/ammonite_3.4.3 to list valid versions.
   def scalaVersion = "3.3.4"
   override def ammoniteVersion = "3.0.2"
 
@@ -38,7 +40,7 @@ object basil extends RootModule with ScalaModule with antlr.AntlrModule with Sca
   }
 
   object test extends ScalaTests with TestModule.ScalaTest {
-    override def ammoniteVersion = "3.0.2"
+    override def ammoniteVersion = basil.ammoniteVersion
     def ivyDeps = Agg(scalaTests, javaTests)
     def sources = T.sources { Seq(PathRef(this.millSourcePath / "scala")) }
   }

--- a/build.sc
+++ b/build.sc
@@ -8,6 +8,7 @@ import contrib.scalapblib._
 
 object basil extends RootModule with ScalaModule with antlr.AntlrModule with ScalaPBModule {
   def scalaVersion = "3.3.4"
+  override def ammoniteVersion = "3.0.2"
 
   def scalacOptions: T[Seq[String]] = Seq("-deprecation")
 
@@ -37,6 +38,7 @@ object basil extends RootModule with ScalaModule with antlr.AntlrModule with Sca
   }
 
   object test extends ScalaTests with TestModule.ScalaTest {
+    override def ammoniteVersion = "3.0.2"
     def ivyDeps = Agg(scalaTests, javaTests)
     def sources = T.sources { Seq(PathRef(this.millSourcePath / "scala")) }
   }


### PR DESCRIPTION
I'm working on migrating the Nix package to use mill. This version number will need to be updated manually whenever the Scala version is changed.

Without this change, it fails with this error:
```
basil-sbt-dependencies.tar.zst> Preparing Java 17.0.13 runtime; this may take a minute or two ...
basil-sbt-dependencies.tar.zst> [info] compiling 2 Scala sources to /build/source/out/mill-build/compile.dest/classes ...
basil-sbt-dependencies.tar.zst> [info] done compiling
basil-sbt-dependencies.tar.zst> Resolving Ammonite Repl 3.0.0-M0-53-084f7f4e for Scala 3.3.4 ...
basil-sbt-dependencies.tar.zst> If you encounter dependency resolution failures, please review/override `def ammoniteVersion` to select a compatible release.
basil-sbt-dependencies.tar.zst> 1 targets failed
basil-sbt-dependencies.tar.zst> resolvedAmmoniteReplIvyDeps
basil-sbt-dependencies.tar.zst> Resolution failed for 1 modules:
basil-sbt-dependencies.tar.zst> --------------------------------------------
basil-sbt-dependencies.tar.zst>   com.lihaoyi:ammonite_3.3.4:3.0.0-M0-53-084f7f4e
basil-sbt-dependencies.tar.zst>         not found: /build/.ivy2/local/com.lihaoyi/ammonite_3.3.4/3.0.0-M0-53-084f7f4e/ivys/ivy.xml
basil-sbt-dependencies.tar.zst>         not found: https://repo1.maven.org/maven2/com/lihaoyi/ammonite_3.3.4/3.0.0-M0-53-084f7f4e/ammonite_3.3.4-3.0.0-M0-53-084f7f4e.pom
basil-sbt-dependencies.tar.zst> --------------------------------------------
basil-sbt-dependencies.tar.zst> For additional information on library dependencies, see the docs at
basil-sbt-dependencies.tar.zst> https://mill-build.com/mill/Library_Dependencies.html
```

The available ammonite versions for Scala 3.3.4 seem to be these ones: https://mvnrepository.com/artifact/com.lihaoyi/ammonite_3.4.3

Idk which version we're all using locally and why it works locally but not in nix.