### PR TITLE
remove duplicate eq ops

### DIFF
--- a/src/main/scala/analysis/IrreducibleLoops.scala
+++ b/src/main/scala/analysis/IrreducibleLoops.scala
@@ -2,7 +2,7 @@ package analysis
 
 import scala.annotation.tailrec
 import ir.{Block, Command, IntraProcIRCursor, Program, Procedure, GoTo, IRWalk}
-import ir.{LocalAssign, Assume, IntLiteral, IntType, IntEQ, BoolOR, LocalVar, BinaryExpr}
+import ir.{LocalAssign, Assume, IntLiteral, IntType, EQ, BoolOR, LocalVar, BinaryExpr}
 import util.intrusive_list.IntrusiveList
 import util.StaticAnalysisLogger
 
@@ -376,7 +376,7 @@ object LoopTransform {
 
     P_e.groupBy(_.to).map { (destBlock, origins) =>
       val idexs = origins.map { b =>
-        BinaryExpr(IntEQ, LocalVar("FromEntryIdx", IntType), IntLiteral(BigInt(entryids(b.from))))
+        BinaryExpr(EQ, LocalVar("FromEntryIdx", IntType), IntLiteral(BigInt(entryids(b.from))))
       }
       idexs.toList match {
         case Nil => ()

--- a/src/main/scala/analysis/KnownBits.scala
+++ b/src/main/scala/analysis/KnownBits.scala
@@ -613,16 +613,12 @@ class TNumDomain extends AbstractDomain[Map[Variable, TNum]] {
       case BVSLE => tn1.TSLE(tn2)
       case BVSGT => tn1.TSGT(tn2)
       case BVSGE => tn1.TSGE(tn2)
-      case BVEQ => tn1.TEQ(tn2)
-      case BVNEQ => tn1.TNEQ(tn2)
       case BVCONCAT => tn1.TCONCAT(tn2)
       case IntADD => tn1.TADD(tn2)
       case IntMUL => tn1.TMUL(tn2)
       case IntSUB => tn1.TSUB(tn2)
       case IntDIV => tn1.TSDIV(tn2)
       case IntMOD => tn1.TSMOD(tn2)
-      case IntEQ => tn1.TEQ(tn2)
-      case IntNEQ => tn1.TNEQ(tn2)
       case IntLT => tn1.TSLT(tn2)
       case IntLE => tn1.TSLE(tn2)
       case IntGT => tn1.TSGT(tn2)
@@ -632,12 +628,9 @@ class TNumDomain extends AbstractDomain[Map[Variable, TNum]] {
 
   def evaluateBoolBinOp(op: BoolBinOp, tn1: TNum, tn2: TNum): TNum = {
     op match {
-      case BoolEQ => tn1.TEQ(tn2)
-      case BoolNEQ => tn1.TNEQ(tn2)
       case BoolAND => tn1.TAND(tn2)
       case BoolOR => tn1.TOR(tn2)
       case BoolIMPLIES => (tn1.TOR(tn2.TNOT()))
-      case BoolEQUIV => tn1.TEQ(tn2)
     }
   }
 
@@ -679,6 +672,8 @@ class TNumDomain extends AbstractDomain[Map[Variable, TNum]] {
         val arg2TNum = evaluateExprToTNum(s, arg2)
 
         (op, arg1TNum, arg2TNum) match {
+          case (EQ, tn1, tn2) => tn1.TEQ(tn2)
+          case (NEQ, tn1, tn2) => tn1.TNEQ(tn2)
           case (opVal: BVBinOp, tnum1: TNum, tnum2: TNum) => evaluateValueBinOp(opVal, tnum1, tnum2)
           case (opVal: IntBinOp, tnum1: TNum, tnum2: TNum) => evaluateValueBinOp(opVal, tnum1, tnum2)
           case (opVal: BoolBinOp, tnum1: TNum, tnum2: TNum) => evaluateBoolBinOp(opVal, tnum1, tnum2)

--- a/src/main/scala/analysis/Lattice.scala
+++ b/src/main/scala/analysis/Lattice.scala
@@ -312,6 +312,8 @@ class ValueSetLattice[T] extends Lattice[ValueSet[T]] {
 
   def applyOp(op: BinOp, lhs: ValueSet[T], rhs: Either[ValueSet[T], BitVecLiteral]): ValueSet[T] = {
     op match
+      case EQ => applyOp(EQ, lhs, rhs)
+      case NEQ => applyOp(NEQ, lhs, rhs)
       case bvOp: BVBinOp =>
         bvOp match
           case BVAND => ???
@@ -346,17 +348,12 @@ class ValueSetLattice[T] extends Lattice[ValueSet[T]] {
           case BVSLE => ???
           case BVSGT => ???
           case BVSGE => ???
-          case BVEQ => ???
-          case BVNEQ => ???
           case BVCONCAT => ???
       case boolOp: BoolBinOp =>
         boolOp match
-          case BoolEQ => applyOp(BVEQ, lhs, rhs)
-          case BoolNEQ => applyOp(BVNEQ, lhs, rhs)
           case BoolAND => applyOp(BVAND, lhs, rhs)
           case BoolOR => applyOp(BVOR, lhs, rhs)
           case BoolIMPLIES => ???
-          case BoolEQUIV => ???
       case intOp: IntBinOp =>
         applyOp(intOp.toBV, lhs, rhs)
   }

--- a/src/main/scala/analysis/NumericalDomains.scala
+++ b/src/main/scala/analysis/NumericalDomains.scala
@@ -184,8 +184,8 @@ class IntervalDomain(
         else if s.size == 1 then fromPred(s.head)
         else s.tail.foldLeft(fromPred(s.head)) { (i, p) => i.join(fromPred(p)) }
 
-      case BVCmp(BVEQ, BVTerm.Lit(x), BVTerm.Var(v)) => top + (v -> ConcreteInterval(bvto(x), bvto(x), x.size))
-      case BVCmp(BVEQ, BVTerm.Var(v), BVTerm.Lit(x)) => top + (v -> ConcreteInterval(bvto(x), bvto(x), x.size))
+      case BVCmp(EQ, BVTerm.Lit(x), BVTerm.Var(v)) => top + (v -> ConcreteInterval(bvto(x), bvto(x), x.size))
+      case BVCmp(EQ, BVTerm.Var(v), BVTerm.Lit(x)) => top + (v -> ConcreteInterval(bvto(x), bvto(x), x.size))
 
       case BVCmp(BVSLE, BVTerm.Lit(x), BVTerm.Var(v)) if signed =>
         top + (v -> ConcreteInterval(bvto(x), inf(x.size), x.size))

--- a/src/main/scala/analysis/procedure_summaries/Predicate.scala
+++ b/src/main/scala/analysis/procedure_summaries/Predicate.scala
@@ -803,10 +803,22 @@ def exprToGammaTerm(e: Expr): Option[GammaTerm] = e match {
 def exprToPredicate(e: Expr): Option[Predicate] = e match {
   case b: BoolLit => Some(Predicate.Lit(b))
   case UnaryExpr(BoolNOT, arg) => exprToPredicate(arg).map(p => Predicate.not(p))
-  case BinaryExpr(op: (BoolBinOp | PolyCmp), arg1, arg2) =>
-    exprToPredicate(arg1).flatMap(p => exprToPredicate(arg2).map(q => Predicate.bop(op, p, q)))
-  case BinaryExpr(op: BVCmpOp, arg1, arg2) =>
-    exprToBVTerm(arg1).flatMap(p => exprToBVTerm(arg2).map(q => Predicate.BVCmp(op, p, q)))
+  case BinaryExpr(op: (PolyCmp | BVCmpOp | BoolCmpOp), arg1, arg2) =>
+    (
+      List(arg1, arg2).map(e =>
+        e.getType match {
+          case BoolType => exprToPredicate(e)
+          case _: BitVecType => exprToBVTerm(e)
+          case _ => None
+        }
+      ),
+      op
+    ) match {
+      case (Some(l: Predicate) :: Some(r: Predicate) :: Nil, op: (BoolCmpOp | PolyCmp)) => Some(Predicate.bop(op, l, r))
+      case (Some(l: BVTerm) :: Some(r: BVTerm) :: Nil, op: (BVCmpOp | PolyCmp)) => Some(Predicate.BVCmp(op, l, r))
+      case _ => None
+    }
+
   case _ => None
 }
 

--- a/src/main/scala/analysis/procedure_summaries/Predicate.scala
+++ b/src/main/scala/analysis/procedure_summaries/Predicate.scala
@@ -273,8 +273,8 @@ enum Predicate {
   case Not(p: Atomic & Predicate) extends Predicate with Atomic
   case Conj(s: Set[Predicate])
   case Disj(s: Set[Predicate])
-  case BVCmp(op: BVCmpOp, x: BVTerm, y: BVTerm) extends Predicate with Atomic
-  case GammaCmp(op: BoolCmpOp, x: GammaTerm, y: GammaTerm) extends Predicate with Atomic
+  case BVCmp(op: BVCmpOp | PolyCmp, x: BVTerm, y: BVTerm) extends Predicate with Atomic
+  case GammaCmp(op: BoolCmpOp | PolyCmp, x: GammaTerm, y: GammaTerm) extends Predicate with Atomic
 
   private var simplified: Boolean = false
 
@@ -578,19 +578,19 @@ enum Predicate {
               case Conj(s2) => cur - p ++ s2
               case Not(p) if cur.contains(p) => Set(False)
               case BVCmp(BVSLE, a, b) if cur.contains(BVCmp(BVSLE, b, a)) =>
-                cur - p - BVCmp(BVSLE, b, a) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVSLE, b, a) + BVCmp(EQ, a, b).simplify
               case BVCmp(BVSLE, a, b) if cur.contains(BVCmp(BVSGE, a, b)) =>
-                cur - p - BVCmp(BVSGE, a, b) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVSGE, a, b) + BVCmp(EQ, a, b).simplify
               case BVCmp(BVSGE, a, b) if cur.contains(BVCmp(BVSGE, b, a)) =>
-                cur - p - BVCmp(BVSGE, b, a) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVSGE, b, a) + BVCmp(EQ, a, b).simplify
               case BVCmp(BVULE, a, b) if cur.contains(BVCmp(BVULE, b, a)) =>
-                cur - p - BVCmp(BVULE, b, a) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVULE, b, a) + BVCmp(EQ, a, b).simplify
               case BVCmp(BVULE, a, b) if cur.contains(BVCmp(BVUGE, a, b)) =>
-                cur - p - BVCmp(BVUGE, a, b) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVUGE, a, b) + BVCmp(EQ, a, b).simplify
               case BVCmp(BVUGE, a, b) if cur.contains(BVCmp(BVUGE, b, a)) =>
-                cur - p - BVCmp(BVUGE, b, a) + BVCmp(BVEQ, a, b).simplify
+                cur - p - BVCmp(BVUGE, b, a) + BVCmp(EQ, a, b).simplify
               case GammaCmp(BoolIMPLIES, a, b) if cur.contains(GammaCmp(BoolIMPLIES, b, a)) =>
-                cur - p - GammaCmp(BoolIMPLIES, b, a) + GammaCmp(BoolEQ, a, b).simplify
+                cur - p - GammaCmp(BoolIMPLIES, b, a) + GammaCmp(EQ, a, b).simplify
               case Disj(s2) if s.intersect(s2).nonEmpty => cur - p
               case _ => cur
             }
@@ -662,22 +662,22 @@ enum Predicate {
               case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(BVUGE, b, a)) => cur - p - BVCmp(BVUGE, b, a) + True
               case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(BVULE, a, b)) => cur - p - BVCmp(BVULE, a, b) + True
 
-              case BVCmp(BVSLT, a, b) if cur.contains(BVCmp(BVEQ, a, b)) =>
-                cur - p - BVCmp(BVEQ, a, b) + BVCmp(BVSLE, a, b).simplify
-              case BVCmp(BVSLT, a, b) if cur.contains(BVCmp(BVEQ, b, a)) =>
-                cur - p - BVCmp(BVEQ, b, a) + BVCmp(BVSLE, a, b).simplify
-              case BVCmp(BVSGT, a, b) if cur.contains(BVCmp(BVEQ, a, b)) =>
-                cur - p - BVCmp(BVEQ, a, b) + BVCmp(BVSGE, a, b).simplify
-              case BVCmp(BVSGT, a, b) if cur.contains(BVCmp(BVEQ, b, a)) =>
-                cur - p - BVCmp(BVEQ, b, a) + BVCmp(BVSGE, a, b).simplify
-              case BVCmp(BVULT, a, b) if cur.contains(BVCmp(BVEQ, a, b)) =>
-                cur - p - BVCmp(BVEQ, a, b) + BVCmp(BVULE, a, b).simplify
-              case BVCmp(BVULT, a, b) if cur.contains(BVCmp(BVEQ, b, a)) =>
-                cur - p - BVCmp(BVEQ, b, a) + BVCmp(BVULE, a, b).simplify
-              case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(BVEQ, a, b)) =>
-                cur - p - BVCmp(BVEQ, a, b) + BVCmp(BVUGE, a, b).simplify
-              case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(BVEQ, b, a)) =>
-                cur - p - BVCmp(BVEQ, b, a) + BVCmp(BVUGE, a, b).simplify
+              case BVCmp(BVSLT, a, b) if cur.contains(BVCmp(EQ, a, b)) =>
+                cur - p - BVCmp(EQ, a, b) + BVCmp(BVSLE, a, b).simplify
+              case BVCmp(BVSLT, a, b) if cur.contains(BVCmp(EQ, b, a)) =>
+                cur - p - BVCmp(EQ, b, a) + BVCmp(BVSLE, a, b).simplify
+              case BVCmp(BVSGT, a, b) if cur.contains(BVCmp(EQ, a, b)) =>
+                cur - p - BVCmp(EQ, a, b) + BVCmp(BVSGE, a, b).simplify
+              case BVCmp(BVSGT, a, b) if cur.contains(BVCmp(EQ, b, a)) =>
+                cur - p - BVCmp(EQ, b, a) + BVCmp(BVSGE, a, b).simplify
+              case BVCmp(BVULT, a, b) if cur.contains(BVCmp(EQ, a, b)) =>
+                cur - p - BVCmp(EQ, a, b) + BVCmp(BVULE, a, b).simplify
+              case BVCmp(BVULT, a, b) if cur.contains(BVCmp(EQ, b, a)) =>
+                cur - p - BVCmp(EQ, b, a) + BVCmp(BVULE, a, b).simplify
+              case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(EQ, a, b)) =>
+                cur - p - BVCmp(EQ, a, b) + BVCmp(BVUGE, a, b).simplify
+              case BVCmp(BVUGT, a, b) if cur.contains(BVCmp(EQ, b, a)) =>
+                cur - p - BVCmp(EQ, b, a) + BVCmp(BVUGE, a, b).simplify
 
               case Conj(s2) if s.intersect(s2).nonEmpty => cur - p
               case _ => cur
@@ -695,15 +695,15 @@ enum Predicate {
         import BVTerm.*
         (op, a.simplify, b.simplify) match {
           case (op, BVTerm.Lit(a), BVTerm.Lit(b)) => if evalBVLogBinExpr(op, a, b) then True else False
-          case (BVEQ, a, b) if a == b => True
-          case (BVEQ, a, Uop(BVNEG, b)) => BVCmp(BVEQ, Bop(BVADD, a, b), BVTerm.Lit(BitVecLiteral(0, a.size))).simplify
-          case (BVEQ, l: BVTerm.Lit, v: Var) => BVCmp(BVEQ, v, l) // Canonical form-ish (to remove duplicate terms
+          case (EQ, a, b) if a == b => True
+          case (EQ, a, Uop(BVNEG, b)) => BVCmp(EQ, Bop(BVADD, a, b), BVTerm.Lit(BitVecLiteral(0, a.size))).simplify
+          case (EQ, l: BVTerm.Lit, v: Var) => BVCmp(EQ, v, l) // Canonical form-ish (to remove duplicate terms
           case (op, a, b) => BVCmp(op, a, b)
         }
       case GammaCmp(op, a, b) =>
         (op, a.simplify, b.simplify) match {
           case (BoolIMPLIES, a, b) if a == b => True
-          case (BoolEQ, a, b) if a == b => True
+          case (EQ, a, b) if a == b => True
           case (op, a, b) => GammaCmp(op, a, b)
         }
       case _ => this
@@ -748,14 +748,13 @@ object Predicate {
 
   def or(ps: Predicate*): Predicate = Disj(ps.toSet).flatten
 
-  def bop(op: BoolBinOp, a: Predicate, b: Predicate): Predicate = {
+  def bop(op: (BoolBinOp | PolyCmp), a: Predicate, b: Predicate): Predicate = {
     op match {
-      case BoolEQ => or(and(not(a), not(b)), and(a, b))
-      case BoolNEQ => or(and(not(a), b), and(a, not(b)))
+      case EQ => or(and(not(a), not(b)), and(a, b))
+      case NEQ => or(and(not(a), b), and(a, not(b)))
       case BoolAND => and(a, b)
       case BoolOR => or(a, b)
       case BoolIMPLIES => or(not(a), b)
-      case BoolEQUIV => bop(BoolEQ, a, b)
     }
   }
 
@@ -763,7 +762,7 @@ object Predicate {
 
   def gammaLeq(a: GammaTerm, b: GammaTerm) = GammaCmp(BoolIMPLIES, b, a)
   def gammaGeq(a: GammaTerm, b: GammaTerm) = GammaCmp(BoolIMPLIES, a, b)
-  def gammaEq(a: GammaTerm, b: GammaTerm) = GammaCmp(BoolEQ, a, b)
+  def gammaEq(a: GammaTerm, b: GammaTerm) = GammaCmp(EQ, a, b)
 }
 
 /**
@@ -804,7 +803,7 @@ def exprToGammaTerm(e: Expr): Option[GammaTerm] = e match {
 def exprToPredicate(e: Expr): Option[Predicate] = e match {
   case b: BoolLit => Some(Predicate.Lit(b))
   case UnaryExpr(BoolNOT, arg) => exprToPredicate(arg).map(p => Predicate.not(p))
-  case BinaryExpr(op: BoolBinOp, arg1, arg2) =>
+  case BinaryExpr(op: (BoolBinOp | PolyCmp), arg1, arg2) =>
     exprToPredicate(arg1).flatMap(p => exprToPredicate(arg2).map(q => Predicate.bop(op, p, q)))
   case BinaryExpr(op: BVCmpOp, arg1, arg2) =>
     exprToBVTerm(arg1).flatMap(p => exprToBVTerm(arg2).map(q => Predicate.BVCmp(op, p, q)))

--- a/src/main/scala/analysis/rely_guarantee_generation/InterferenceDomains.scala
+++ b/src/main/scala/analysis/rely_guarantee_generation/InterferenceDomains.scala
@@ -242,7 +242,7 @@ class MonotonicityDomain[S](stateLattice: InterferenceCompatibleLattice[S], stat
       // apply assume statement to add constraints to y
       val yConstraints = d match {
         case Direction.Bot =>
-          stateTransfer(postState, Assume(BinaryExpr(IntEQ, y, v)))
+          stateTransfer(postState, Assume(BinaryExpr(EQ, y, v)))
         case Direction.Increasing =>
           stateTransfer(postState, Assume(BinaryExpr(BVSGE, y, v)))
         case Direction.Decreasing =>

--- a/src/main/scala/boogie/BExpr.scala
+++ b/src/main/scala/boogie/BExpr.scala
@@ -316,7 +316,7 @@ case class UnaryBExpr(op: UnOp, arg: BExpr) extends BExpr {
 case class BinaryBExpr(op: BinOp, arg1: BExpr, arg2: BExpr) extends BExpr {
   override def getType: BType = (op, arg1.getType, arg2.getType) match {
     case (_: BoolBinOp, BoolBType, BoolBType) => BoolBType
-    case (EQ | NEQ , _ , _) => BoolBType
+    case (EQ | NEQ, _, _) => BoolBType
     case (binOp: BVBinOp, bv1: BitVecBType, bv2: BitVecBType) =>
       binOp match {
         case BVCONCAT =>
@@ -387,7 +387,7 @@ case class BinaryBExpr(op: BinOp, arg1: BExpr, arg2: BExpr) extends BExpr {
 
   override def toString: String = op match {
     case bOp: BoolBinOp => s"($arg1 $bOp $arg2)"
-    case EQ | NEQ  => s"($arg1 $op $arg2)"
+    case EQ | NEQ => s"($arg1 $op $arg2)"
     case bOp: BVBinOp =>
       bOp match {
         case BVCONCAT =>
@@ -400,7 +400,7 @@ case class BinaryBExpr(op: BinOp, arg1: BExpr, arg2: BExpr) extends BExpr {
 
   override def functionOps: Set[FunctionOp] = {
     val thisFn = op match {
-      case EQ | NEQ  => Set()
+      case EQ | NEQ => Set()
       case b: BVBinOp =>
         b match {
           case BVCONCAT => Set()

--- a/src/main/scala/ir/Expr.scala
+++ b/src/main/scala/ir/Expr.scala
@@ -226,12 +226,8 @@ case class BinaryExpr(op: BinOp, arg1: Expr, arg2: Expr) extends Expr with Cache
 
   override def toString: String = op match {
     case bOp: BoolBinOp => s"($arg1 $bOp $arg2)"
-    case EQ | NEQ => s"($arg1 $op $arg2)"
-    case bOp: BVBinOp =>
-      bOp match {
-        case _ =>
-          s"bv$bOp$inSize($arg1, $arg2)"
-      }
+    case BVCONCAT | EQ | NEQ => s"($arg1 $op $arg2)"
+    case bOp: BVBinOp => s"bv$bOp$inSize($arg1, $arg2)"
     case bOp: IntBinOp => s"($arg1 $bOp $arg2)"
   }
 

--- a/src/main/scala/ir/Expr.scala
+++ b/src/main/scala/ir/Expr.scala
@@ -180,6 +180,8 @@ case class BinaryExpr(op: BinOp, arg1: Expr, arg2: Expr) extends Expr with Cache
   override def variables: Set[Variable] = arg1.variables ++ arg2.variables
   override def getType: IRType = (op, arg1.getType, arg2.getType) match {
     case (_: BoolBinOp, BoolType, BoolType) => BoolType
+    case (EQ, _, _) => BoolType
+    case (NEQ, _, _) => BoolType
     case (binOp: BVBinOp, bv1: BitVecType, bv2: BitVecType) =>
       binOp match {
         case BVCONCAT =>
@@ -205,13 +207,11 @@ case class BinaryExpr(op: BinOp, arg1: Expr, arg2: Expr) extends Expr with Cache
             println(this)
             throw new Exception("bitvector size mismatch")
           }
-        case BVEQ | BVNEQ =>
-          BoolType
       }
     case (intOp: IntBinOp, IntType, IntType) =>
       intOp match {
         case IntADD | IntSUB | IntMUL | IntDIV | IntMOD => IntType
-        case IntEQ | IntNEQ | IntLT | IntLE | IntGT | IntGE => BoolType
+        case IntLT | IntLE | IntGT | IntGE => BoolType
       }
     case _ =>
       throw new Exception(
@@ -226,10 +226,9 @@ case class BinaryExpr(op: BinOp, arg1: Expr, arg2: Expr) extends Expr with Cache
 
   override def toString: String = op match {
     case bOp: BoolBinOp => s"($arg1 $bOp $arg2)"
+    case EQ | NEQ => s"($arg1 $op $arg2)"
     case bOp: BVBinOp =>
       bOp match {
-        case BVEQ | BVNEQ | BVCONCAT =>
-          s"($arg1 $bOp $arg2)"
         case _ =>
           s"bv$bOp$inSize($arg1, $arg2)"
       }
@@ -249,14 +248,22 @@ sealed trait BoolBinOp(op: String) extends BinOp {
   def opName = op
 }
 
-sealed trait BoolCmpOp extends BoolBinOp
+sealed trait PolyCmp extends BinOp
 
-case object BoolEQ extends BoolBinOp("==") with BoolCmpOp
-case object BoolNEQ extends BoolBinOp("!=")
+case object EQ extends PolyCmp {
+  override def opName = "=="
+  override def toString = opName
+}
+
+case object NEQ extends PolyCmp {
+  override def opName = "!="
+  override def toString = opName
+}
+
+sealed trait BoolCmpOp extends BoolBinOp
 case object BoolAND extends BoolBinOp("&&")
 case object BoolOR extends BoolBinOp("||")
 case object BoolIMPLIES extends BoolBinOp("==>") with BoolCmpOp
-case object BoolEQUIV extends BoolBinOp("<==>")
 
 sealed trait BVBinOp(op: String) extends BinOp {
   override def toString: String = op
@@ -291,8 +298,6 @@ case object BVSLT extends BVBinOp("slt") with BVCmpOp
 case object BVSLE extends BVBinOp("sle") with BVCmpOp
 case object BVSGT extends BVBinOp("sgt") with BVCmpOp
 case object BVSGE extends BVBinOp("sge") with BVCmpOp
-case object BVEQ extends BVBinOp("==") with BVCmpOp
-case object BVNEQ extends BVBinOp("!=") with BVCmpOp
 case object BVCONCAT extends BVBinOp("++")
 
 sealed trait IntBinOp(op: String) extends BinOp {
@@ -304,8 +309,6 @@ sealed trait IntBinOp(op: String) extends BinOp {
     case IntSUB => BVSUB
     case IntDIV => BVSDIV
     case IntMOD => BVSMOD
-    case IntEQ => BVEQ
-    case IntNEQ => BVNEQ
     case IntLT => BVSLT
     case IntLE => BVSLE
     case IntGT => BVSGT
@@ -318,8 +321,6 @@ case object IntMUL extends IntBinOp("*")
 case object IntSUB extends IntBinOp("-")
 case object IntDIV extends IntBinOp("div")
 case object IntMOD extends IntBinOp("mod")
-case object IntEQ extends IntBinOp("==")
-case object IntNEQ extends IntBinOp("!=")
 case object IntLT extends IntBinOp("<")
 case object IntLE extends IntBinOp("<=")
 case object IntGT extends IntBinOp(">")

--- a/src/main/scala/ir/IRType.scala
+++ b/src/main/scala/ir/IRType.scala
@@ -37,8 +37,8 @@ def curryFunctionType(t: IRType, acc: List[IRType] = List()): (List[IRType], IRT
 
 def coerceToBool(e: Expr): Expr = {
   e.getType match {
-    case BitVecType(s) => BinaryExpr(BVNEQ, e, BitVecLiteral(0, s))
-    case IntType => BinaryExpr(IntNEQ, e, IntLiteral(0))
+    case BitVecType(s) => BinaryExpr(NEQ, e, BitVecLiteral(0, s))
+    case IntType => BinaryExpr(NEQ, e, IntLiteral(0))
     case BoolType => e
     case MapType(_, _) => ???
   }

--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -86,14 +86,6 @@ val R29: Register = Register("R29", 64)
 val R30: Register = Register("R30", 64)
 val R31: Register = Register("R31", 64)
 
-def exprEq(l: Expr, r: Expr): Expr = (l, r) match {
-  case (l, r) if l.getType != r.getType => FalseLiteral
-  case (l, r) if l.getType == BoolType => BinaryExpr(BoolEQ, l, r)
-  case (l, r) if l.getType.isInstanceOf[BitVecType] => BinaryExpr(BVEQ, l, r)
-  case (l, r) if l.getType == IntType => BinaryExpr(IntEQ, l, r)
-  case _ => FalseLiteral
-}
-
 def R(i: Int): Register = Register(s"R$i", 64)
 
 def bv_t(i: Int) = BitVecType(i)

--- a/src/main/scala/ir/dsl/InfixConstructors.scala
+++ b/src/main/scala/ir/dsl/InfixConstructors.scala
@@ -55,18 +55,8 @@ private def panic(op: String, i: Expr, j: Expr) = throw Exception(s"$op not defi
 
 extension (i: Expr)
 
-  infix def ===(j: Expr): Expr = i.getType match {
-    case IntType => BinaryExpr(IntEQ, i, j)
-    case b: BitVecType => BinaryExpr(BVEQ, i, j)
-    case BoolType => BinaryExpr(BoolEQ, i, j)
-    case _ => panic("Equal", i, j)
-  }
-  infix def !==(j: Expr): Expr = i.getType match {
-    case IntType => BinaryExpr(IntNEQ, i, j)
-    case b: BitVecType => BinaryExpr(BVNEQ, i, j)
-    case BoolType => BinaryExpr(BoolNEQ, i, j)
-    case _ => panic("Not Equal", i, j)
-  }
+  infix def ===(j: Expr): Expr = BinaryExpr(EQ, i, j)
+  infix def !==(j: Expr): Expr = BinaryExpr(NEQ, i, j)
   infix def +(j: Expr): Expr = i.getType match {
     case IntType => BinaryExpr(IntADD, i, j)
     case b: BitVecType => BinaryExpr(BVADD, i, j)

--- a/src/main/scala/ir/eval/BitVectorEval.scala
+++ b/src/main/scala/ir/eval/BitVectorEval.scala
@@ -167,15 +167,15 @@ object BitVectorEval {
     if s == t then BitVecLiteral(1, 1)
     else BitVecLiteral(0, 1)
 
-  /** (bvneq (_ BitVec m) (_ BitVec m))
-    *   - not equal too
+  /** (bveq (_ BitVec m) (_ BitVec m))
+    *   - equal to
     */
   def smt_bveq(s: BitVecLiteral, t: BitVecLiteral): Boolean = {
     s == t
   }
 
   /** (bvneq (_ BitVec m) (_ BitVec m))
-    *   - not equal too
+    *   - not equal to
     */
   def smt_bvneq(s: BitVecLiteral, t: BitVecLiteral): Boolean = {
     s != t

--- a/src/main/scala/ir/eval/ExprEval.scala
+++ b/src/main/scala/ir/eval/ExprEval.scala
@@ -78,7 +78,7 @@ def evalBoolLogBinExpr(b: BoolBinOp | PolyCmp, l: Boolean, r: Boolean): Boolean 
   case BoolAND => l && r
   case BoolOR => l || r
   case BoolIMPLIES => l || (!r)
-  case EQ => l  == r
+  case EQ => l == r
   case NEQ => l != r
 }
 

--- a/src/main/scala/ir/eval/ExprEval.scala
+++ b/src/main/scala/ir/eval/ExprEval.scala
@@ -34,12 +34,12 @@ def evalBVBinExpr(b: BVBinOp, l: BitVecLiteral, r: BitVecLiteral): BitVecLiteral
     case BVASHR => BitVectorEval.smt_bvashr(l, r)
     case BVCOMP => BitVectorEval.smt_bvcomp(l, r)
     case BVCONCAT => BitVectorEval.smt_concat(l, r)
-    case BVULE | BVULT | BVUGT | BVUGE | BVSLT | BVSLE | BVSGT | BVSGE | BVEQ | BVNEQ =>
+    case BVULE | BVULT | BVUGT | BVUGE | BVSLT | BVSLE | BVSGT | BVSGE =>
       throw IllegalArgumentException("Did not expect logical op")
   }
 }
 
-def evalBVLogBinExpr(b: BVBinOp, l: BitVecLiteral, r: BitVecLiteral): Boolean = b match {
+def evalBVLogBinExpr(b: BVBinOp | PolyCmp, l: BitVecLiteral, r: BitVecLiteral): Boolean = b match {
   case BVULE => BitVectorEval.smt_bvule(l, r)
   case BVUGT => BitVectorEval.smt_bvugt(l, r)
   case BVUGE => BitVectorEval.smt_bvuge(l, r)
@@ -48,16 +48,16 @@ def evalBVLogBinExpr(b: BVBinOp, l: BitVecLiteral, r: BitVecLiteral): Boolean = 
   case BVSLE => BitVectorEval.smt_bvsle(l, r)
   case BVSGT => BitVectorEval.smt_bvsgt(l, r)
   case BVSGE => BitVectorEval.smt_bvsge(l, r)
-  case BVEQ => BitVectorEval.smt_bveq(l, r)
-  case BVNEQ => BitVectorEval.smt_bvneq(l, r)
+  case EQ => BitVectorEval.smt_bveq(l, r)
+  case NEQ => BitVectorEval.smt_bvneq(l, r)
   case BVADD | BVSUB | BVMUL | BVUDIV | BVSDIV | BVSREM | BVUREM | BVSMOD | BVAND | BVOR | BVXOR | BVNAND | BVNOR |
       BVXNOR | BVSHL | BVLSHR | BVASHR | BVCOMP | BVCONCAT =>
     throw IllegalArgumentException("Did not expect non-logical op")
 }
 
-def evalIntLogBinExpr(b: IntBinOp, l: BigInt, r: BigInt): Boolean = b match {
-  case IntEQ => l == r
-  case IntNEQ => l != r
+def evalIntLogBinExpr(b: IntBinOp | PolyCmp, l: BigInt, r: BigInt): Boolean = b match {
+  case EQ => l == r
+  case NEQ => l != r
   case IntLT => l < r
   case IntLE => l <= r
   case IntGT => l > r
@@ -71,16 +71,15 @@ def evalIntBinExpr(b: IntBinOp, l: BigInt, r: BigInt): BigInt = b match {
   case IntMUL => l * r
   case IntDIV => l / r
   case IntMOD => l % r
-  case IntEQ | IntNEQ | IntLT | IntLE | IntGT | IntGE => throw IllegalArgumentException("Did not expect logical op")
+  case IntLT | IntLE | IntGT | IntGE => throw IllegalArgumentException("Did not expect logical op")
 }
 
-def evalBoolLogBinExpr(b: BoolBinOp, l: Boolean, r: Boolean): Boolean = b match {
-  case BoolEQ => l == r
-  case BoolEQUIV => l == r
-  case BoolNEQ => l != r
+def evalBoolLogBinExpr(b: BoolBinOp | PolyCmp, l: Boolean, r: Boolean): Boolean = b match {
   case BoolAND => l && r
   case BoolOR => l || r
   case BoolIMPLIES => l || (!r)
+  case EQ => l  == r
+  case NEQ => l != r
 }
 
 def evalUnOp(op: UnOp, body: Literal): Literal = {
@@ -176,6 +175,8 @@ def fastPartialEvalExprTopLevel(exp: Expr): (Expr, Boolean) = {
   var didAnything = true
   val r = exp match {
     case UnaryExpr(op, l: Literal) => logSimp(exp, evalUnOp(op, l))
+    case BinaryExpr(EQ, l: Literal, r: Literal) => if (l == r) then TrueLiteral else FalseLiteral
+    case BinaryExpr(NEQ, l: Literal, r: Literal) => if (l != r) then TrueLiteral else FalseLiteral
     case BinaryExpr(op: BVBinOp, l: BitVecLiteral, r: BitVecLiteral) if exp.getType.isInstanceOf[BitVecType] =>
       logSimp(exp, evalBVBinExpr(op, l, r))
     case BinaryExpr(op: IntBinOp, l: IntLiteral, r: IntLiteral) if exp.getType == IntType =>
@@ -233,6 +234,8 @@ def statePartialEvalExpr[S](l: Loader[S, InterpreterError])(exp: Expr): State[S,
         case BoolType => {
           def bool2lit(b: Boolean) = if b then TrueLiteral else FalseLiteral
           (binOp.op, lhs, rhs) match {
+            case (EQ, l: Literal, r: Literal) => bool2lit(l == r)
+            case (NEQ, l: Literal, r: Literal) => bool2lit(l != r)
             case (o: BVBinOp, l: BitVecLiteral, r: BitVecLiteral) => bool2lit(evalBVLogBinExpr(o, l, r))
             case (o: IntBinOp, l: IntLiteral, r: IntLiteral) => bool2lit(evalIntLogBinExpr(o, l.value, r.value))
             case (o: BoolBinOp, l: BoolLit, r: BoolLit) => bool2lit(evalBoolLogBinExpr(o, l.value, r.value))

--- a/src/main/scala/ir/eval/SimplifyExpr.scala
+++ b/src/main/scala/ir/eval/SimplifyExpr.scala
@@ -139,7 +139,7 @@ def simpFixedPoint(s: Simplifier)(e: Expr): (Expr, Boolean) = {
 
 /** Perform general-purpose expression simplifications and partial evaluation to remove redundant operations.
   *   - Normalises predicate calculations to boolean form rather than bitvector form.
-  *   - Normalises BinaryExpr(BVNEQ, a, b) to unaryExpr(BoolNOT, BinaryExpr(BVEQ, a, b))
+  *   - Normalises BinaryExpr(NEQ, a, b) to unaryExpr(BoolNOT, BinaryExpr(EQ, a, b))
   *   - Normalises BinaryExpr(BVSUB, a, b) to BinaryExpr(BVADD, a, UnaryExpr(BVNEG, b))
   *
   * @see
@@ -243,12 +243,7 @@ object SimplifyValidation {
 
     def makeEQ(a: Expr, b: Expr) = {
       require(a.getType == b.getType)
-      a.getType match {
-        case BitVecType(sz) => BinaryExpr(BVEQ, a, b)
-        case IntType => BinaryExpr(IntEQ, a, b)
-        case BoolType => BinaryExpr(BoolEQ, a, b)
-        case m: MapType => ???
-      }
+      BinaryExpr(EQ, a, b)
     }
 
     var ind = 0
@@ -360,8 +355,8 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
 
     /** canonicalising to boolean operations */
     /* remove bool2bv in boolean context */
-    case BinaryExpr(BVEQ, UnaryExpr(BoolToBV1, body), BitVecLiteral(1, 1)) => logSimp(e, body)
-    case BinaryExpr(BVEQ, UnaryExpr(BoolToBV1, l), UnaryExpr(BoolToBV1, r)) => logSimp(e, BinaryExpr(BoolEQ, (l), (r)))
+    case BinaryExpr(EQ, UnaryExpr(BoolToBV1, body), BitVecLiteral(1, 1)) => logSimp(e, body)
+    case BinaryExpr(EQ, UnaryExpr(BoolToBV1, l), UnaryExpr(BoolToBV1, r)) => logSimp(e, BinaryExpr(EQ, (l), (r)))
 
     case BinaryExpr(BVADD, l @ UnaryExpr(BVNEG, x), r) if !r.isInstanceOf[Literal] && ! {
           r match {
@@ -371,17 +366,17 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
         } =>
       logSimp(e, BinaryExpr(BVADD, r, l))
 
-    case BinaryExpr(BoolAND, l @ BinaryExpr(BVEQ, _, _), r @ BinaryExpr(relop, _, _))
+    case BinaryExpr(BoolAND, l @ BinaryExpr(EQ, _, _), r @ BinaryExpr(relop, _, _))
         if ineqToStrict.contains(relop) || strictIneq.contains(relop) => {
       logSimp(e, BinaryExpr(BoolAND, r, l))
     }
-    case BinaryExpr(BoolAND, l @ UnaryExpr(BoolNOT, BinaryExpr(BVEQ, _, _)), r @ BinaryExpr(relop, _, _))
+    case BinaryExpr(BoolAND, l @ UnaryExpr(BoolNOT, BinaryExpr(EQ, _, _)), r @ BinaryExpr(relop, _, _))
         if ineqToStrict.contains(relop) || strictIneq.contains(relop) => {
       logSimp(e, BinaryExpr(BoolAND, r, l))
     }
 
     case BinaryExpr(BVCOMP, l, r) => {
-      logSimp(e, bool2bv1(BinaryExpr(BVEQ, l, r)))
+      logSimp(e, bool2bv1(BinaryExpr(EQ, l, r)))
     }
     /* push bool2bv upwards */
     case BinaryExpr(bop, BitVecLiteral(x, 1), UnaryExpr(BoolToBV1, r)) if bvLogOpToBoolOp.contains(bop) => {
@@ -406,37 +401,37 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(BVULT, x, BitVecLiteral(0, s)) => logSimp(e, FalseLiteral)
 
     // subsume constant bound
-    case BinaryExpr(BoolOR, l @ BinaryExpr(BVUGE, x, y: BitVecLiteral), BinaryExpr(BVEQ, x2, y2: BitVecLiteral))
+    case BinaryExpr(BoolOR, l @ BinaryExpr(BVUGE, x, y: BitVecLiteral), BinaryExpr(EQ, x2, y2: BitVecLiteral))
         if x == x2 && y2.value >= y.value => {
       logSimp(e, l)
     }
-    case BinaryExpr(BoolOR, l @ BinaryExpr(BVULE, x, y: BitVecLiteral), BinaryExpr(BVEQ, x2, y2: BitVecLiteral))
+    case BinaryExpr(BoolOR, l @ BinaryExpr(BVULE, x, y: BitVecLiteral), BinaryExpr(EQ, x2, y2: BitVecLiteral))
         if x == x2 && y2.value <= y.value => {
       logSimp(e, l)
     }
-    case BinaryExpr(BoolOR, l @ BinaryExpr(BVUGT, x, y: BitVecLiteral), BinaryExpr(BVEQ, x2, y2: BitVecLiteral))
+    case BinaryExpr(BoolOR, l @ BinaryExpr(BVUGT, x, y: BitVecLiteral), BinaryExpr(EQ, x2, y2: BitVecLiteral))
         if x == x2 && y2.value > y.value => {
       logSimp(e, l)
     }
-    case BinaryExpr(BoolOR, l @ BinaryExpr(BVULT, x, y: BitVecLiteral), BinaryExpr(BVEQ, x2, y2: BitVecLiteral))
+    case BinaryExpr(BoolOR, l @ BinaryExpr(BVULT, x, y: BitVecLiteral), BinaryExpr(EQ, x2, y2: BitVecLiteral))
         if x == x2 && y2.value < y.value => {
       logSimp(e, l)
     }
 
     // relax bound by 1
-    case BinaryExpr(BoolOR, BinaryExpr(BVULE, x, y: BitVecLiteral), (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+    case BinaryExpr(BoolOR, BinaryExpr(BVULE, x, y: BitVecLiteral), (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         if x == x2 && ((y.value + 1) == z.value) => {
       logSimp(e, BinaryExpr(BVULE, x, z))
     }
-    case BinaryExpr(BoolOR, BinaryExpr(BVULT, x, y: BitVecLiteral), (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+    case BinaryExpr(BoolOR, BinaryExpr(BVULT, x, y: BitVecLiteral), (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         if x == x2 && y.value == z.value => {
       logSimp(e, BinaryExpr(BVULE, x, z))
     }
-    case BinaryExpr(BoolOR, BinaryExpr(BVUGT, x, y: BitVecLiteral), (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+    case BinaryExpr(BoolOR, BinaryExpr(BVUGT, x, y: BitVecLiteral), (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         if x == x2 && y.value == z.value => {
       logSimp(e, BinaryExpr(BVUGE, x, z))
     }
-    case BinaryExpr(BoolOR, BinaryExpr(BVUGE, x, y: BitVecLiteral), (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+    case BinaryExpr(BoolOR, BinaryExpr(BVUGE, x, y: BitVecLiteral), (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         if x == x2 && y.value - 1 == z.value => {
       logSimp(e, BinaryExpr(BVULE, x, z))
     }
@@ -463,38 +458,38 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGE, e1, BitVecLiteral(x1, _)),
-          r @ UnaryExpr(BoolNOT, BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _)))
+          r @ UnaryExpr(BoolNOT, BinaryExpr(EQ, e2, BitVecLiteral(x2, _)))
         ) if e1 == e2 && (x1 > x2) =>
       logSimp(e, l)
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGT, e1, BitVecLiteral(x1, _)),
-          r @ UnaryExpr(BoolNOT, BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _)))
+          r @ UnaryExpr(BoolNOT, BinaryExpr(EQ, e2, BitVecLiteral(x2, _)))
         ) if e1 == e2 && (x1 >= x2) =>
       logSimp(e, l)
 
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGE, e1, BitVecLiteral(x1, _)),
-          r @ BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _))
+          r @ BinaryExpr(EQ, e2, BitVecLiteral(x2, _))
         ) if e1 == e2 && (x1 <= x2) =>
       logSimp(e, r)
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGT, e1, BitVecLiteral(x1, _)),
-          r @ BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _))
+          r @ BinaryExpr(EQ, e2, BitVecLiteral(x2, _))
         ) if e1 == e2 && (x1 > x2) =>
       logSimp(e, r)
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGE, e1, BitVecLiteral(x1, _)),
-          r @ BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _))
+          r @ BinaryExpr(EQ, e2, BitVecLiteral(x2, _))
         ) if e1 == e2 && (x1 > x2) =>
       logSimp(e, FalseLiteral)
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGT, e1, BitVecLiteral(x1, _)),
-          r @ BinaryExpr(BVEQ, e2, BitVecLiteral(x2, _))
+          r @ BinaryExpr(EQ, e2, BitVecLiteral(x2, _))
         ) if e1 == e2 && (x2 <= x1) =>
       logSimp(e, FalseLiteral)
 
@@ -502,33 +497,33 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           BinaryExpr(BVUGT, x, y: BitVecLiteral),
-          UnaryExpr(BoolNOT, (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+          UnaryExpr(BoolNOT, (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         ) if x == x2 && z.value == y.value + 1 => {
       logSimp(e, BinaryExpr(BVUGT, x, z))
     }
     case BinaryExpr(
           BoolAND,
           BinaryExpr(BVULT, x, y: BitVecLiteral),
-          UnaryExpr(BoolNOT, (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+          UnaryExpr(BoolNOT, (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         ) if x == x2 && z.value == y.value - 1 => {
       logSimp(e, BinaryExpr(BVULT, x, z))
     }
     case BinaryExpr(
           BoolAND,
           BinaryExpr(BVUGE, x, y: BitVecLiteral),
-          UnaryExpr(BoolNOT, (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+          UnaryExpr(BoolNOT, (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         ) if x == x2 && z.value == y.value + 1 => {
       logSimp(e, BinaryExpr(BVUGT, x, z))
     }
     case BinaryExpr(
           BoolAND,
           BinaryExpr(BVULE, x, y: BitVecLiteral),
-          UnaryExpr(BoolNOT, (BinaryExpr(BVEQ, x2, z: BitVecLiteral)))
+          UnaryExpr(BoolNOT, (BinaryExpr(EQ, x2, z: BitVecLiteral)))
         ) if x == x2 && z.value == y.value - 1 => {
       logSimp(e, BinaryExpr(BVULT, x, z))
     }
-    case BinaryExpr(BVEQ, BinaryExpr(BVADD, x, y), BitVecLiteral(0, _)) =>
-      logSimp(e, BinaryExpr(BVEQ, x, UnaryExpr(BVNEG, y)))
+    case BinaryExpr(EQ, BinaryExpr(BVADD, x, y), BitVecLiteral(0, _)) =>
+      logSimp(e, BinaryExpr(EQ, x, UnaryExpr(BVNEG, y)))
 
     case UnaryExpr(BVNOT, UnaryExpr(BoolToBV1, arg)) => {
       logSimp(e, bool2bv1(UnaryExpr(BoolNOT, arg)))
@@ -561,14 +556,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
       */
     case BinaryExpr(
           // add case
-          BoolEQ,
+          EQ,
           // N set
           (BinaryExpr(BVSLT, lhs, BitVecLiteral(0, sz))),
           // V set
           UnaryExpr(
             BoolNOT,
             BinaryExpr(
-              BVEQ,
+              EQ,
               SignExtend(exts, orig @ BinaryExpr(BVADD, x1, y1)),
               compar @ BinaryExpr(BVADD, x2, y2)
             ) // high precision op
@@ -581,14 +576,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
     case BinaryExpr(
           // add case
-          BoolEQ,
+          EQ,
           // N set
           (BinaryExpr(BVSLT, BinaryExpr(BVADD, UnaryExpr(BVNEG, x0), y0), BitVecLiteral(0, sz))),
           // V set
           UnaryExpr(
             BoolNOT,
             BinaryExpr(
-              BVEQ,
+              EQ,
               SignExtend(exts, orig @ BinaryExpr(BVADD, UnaryExpr(BVNEG, x1), y1)),
               compar @ BinaryExpr(BVADD, UnaryExpr(BVNEG, x2), y2)
             ) // high precision op
@@ -604,14 +599,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     // special case for collapsed cmp 0 x
     case BinaryExpr(
           // add case
-          BoolEQ,
+          EQ,
           // N set
           (BinaryExpr(BVSLT, lhs @ UnaryExpr(BVNOT, _), BitVecLiteral(0, sz))),
           // V set
           UnaryExpr(
             BoolNOT,
             BinaryExpr(
-              BVEQ,
+              EQ,
               SignExtend(exts, orig @ UnaryExpr(BVNOT, x2)),
               compar @ BinaryExpr(BVADD, SignExtend(_, UnaryExpr(BVNOT, x3)), BitVecLiteral(2, _))
             ) // high precision op
@@ -622,14 +617,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
 
     case BinaryExpr(
           // sub case (with two args)
-          BoolEQ,
+          EQ,
           // N set
           (BinaryExpr(BVSLT, lhs, BitVecLiteral(0, sz))),
           // V set
           UnaryExpr(
             BoolNOT,
             BinaryExpr(
-              BVEQ,
+              EQ,
               SignExtend(exts, orig @ BinaryExpr(o1, x1, UnaryExpr(BVNEG, y1))),
               compar @ BinaryExpr(o2, SignExtend(ext1, x2), UnaryExpr(BVNEG, SignExtend(ext2, y2)))
             ) // high precision op
@@ -646,14 +641,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     // NF == VF
     case BinaryExpr(
           // this matches sub case a - b ===> (x1 + (bvneg y1)) + 1
-          BoolEQ,
+          EQ,
           // N set
           (BinaryExpr(BVSLT, lhs, BitVecLiteral(0, sz))),
           // V set
           UnaryExpr(
             BoolNOT,
             BinaryExpr(
-              BVEQ,
+              EQ,
               SignExtend(exts, orig @ BinaryExpr(o1, BinaryExpr(o3, x1, y1), z1)),
               BinaryExpr(o2, compar @ BinaryExpr(o4, x2, y2), z2) // high precision op
             )
@@ -666,7 +661,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
       logSimp(e, BinaryExpr(BVSGE, x1, UnaryExpr(BVNEG, BinaryExpr(BVADD, y1, z1))))
     }
 
-    case BinaryExpr(BVEQ, ZeroExtend(exts, orig @ BinaryExpr(o1, x1, y1)), compar @ BinaryExpr(o2, x2, y2))
+    case BinaryExpr(EQ, ZeroExtend(exts, orig @ BinaryExpr(o1, x1, y1)), compar @ BinaryExpr(o2, x2, y2))
         if size(x1).get > 1 && (o1 == o2) && o1 == BVADD
           && simplifyCond(x2) == simplifyCond(ZeroExtend(exts, x1))
           && simplifyCond(y2) == simplifyCond(ZeroExtend(exts, y1)) => {
@@ -675,7 +670,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
 
     case BinaryExpr(
-          BVEQ,
+          EQ,
           ZeroExtend(exts, BinaryExpr(BVADD, UnaryExpr(BVNEG, x1), y1)),
           BinaryExpr(BVADD, ZeroExtend(sz, UnaryExpr(BVNOT, x2)), z2)
         )
@@ -688,14 +683,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
       logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(BVUGE, y1, x1)), true)
     }
 
-    case BinaryExpr(BVEQ, ZeroExtend(sz, v), BinaryExpr(BVADD, ZeroExtend(sz2, v2), BitVecLiteral(mv, _)))
+    case BinaryExpr(EQ, ZeroExtend(sz, v), BinaryExpr(BVADD, ZeroExtend(sz2, v2), BitVecLiteral(mv, _)))
         if sz == sz2 && v == v2 && mv == BigInt(2).pow(size(v).get) => {
       // special case for comparison collapsed cmp 0 - v
       logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(BVUGT, v, UnaryExpr(BVNEG, BitVecLiteral(1, size(v).get)))))
     }
 
     case BinaryExpr(
-          BVEQ,
+          EQ,
           ZeroExtend(exts, orig @ BinaryExpr(o1, BinaryExpr(o3, x1, y1), z1)),
           BinaryExpr(o2, compar @ BinaryExpr(o4, x2, y2), z2) // high precision op
         )
@@ -710,7 +705,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
 
     case BinaryExpr(
-          BVEQ,
+          EQ,
           extended @ ZeroExtend(exts, orig @ BinaryExpr(o1, x1, z1)),
           BinaryExpr(o2, compar @ ZeroExtend(ext2, BinaryExpr(o4, x2, y2)), z2)
         )
@@ -722,7 +717,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
 
     case BinaryExpr(
-          BVEQ,
+          EQ,
           ZeroExtend(exts, orig @ BinaryExpr(o1, x1, UnaryExpr(BVNEG, y1))),
           BinaryExpr(
             o2,
@@ -738,7 +733,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
 
     case BinaryExpr(
-          BVEQ,
+          EQ,
           ZeroExtend(exts, orig @ BinaryExpr(BVADD, x1, y1: BitVecLiteral)),
           BinaryExpr(BVADD, ZeroExtend(ext1, BinaryExpr(BVADD, x2, y3neg: BitVecLiteral)), y4neg: BitVecLiteral)
         )
@@ -768,7 +763,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BoolAND, _, BinaryExpr(op, lhs, rhs: BitVecLiteral)),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, rhs2: BitVecLiteral))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, rhs2: BitVecLiteral))
         )
         if (ineqToStrict.contains(op) || strictIneq
           .contains(op)) && rhs.getType == rhs2.getType && simplifyCond(
@@ -780,7 +775,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BoolAND, _, BinaryExpr(op, lhs, rhs)),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, rhs2))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, rhs2))
         ) if strictIneq.contains(op) && rhs == rhs2 && lhs == lhs2 => {
       logSimp(e, l)
     }
@@ -788,14 +783,14 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVUGT, lhs, UnaryExpr(BVNOT, rhs)),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, nrhs @ UnaryExpr(BVNEG, rhs2)))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, nrhs @ UnaryExpr(BVNEG, rhs2)))
         ) if rhs == rhs2 && lhs == lhs2 => {
       logSimp(e, BinaryExpr(BVUGT, lhs, nrhs))
     }
     case BinaryExpr(
           BoolAND,
           l @ BinaryExpr(BVULT, lhs, UnaryExpr(BVNEG, rhs)),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, nrhs @ UnaryExpr(BVNOT, rhs2)))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, nrhs @ UnaryExpr(BVNOT, rhs2)))
         ) if rhs == rhs2 && lhs == lhs2 => {
       logSimp(e, BinaryExpr(BVULT, lhs, nrhs))
     }
@@ -804,18 +799,18 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     // x >= 0 && x != 0 ===> x > 0
     case BinaryExpr(BoolAND, BinaryExpr(op, lhs, BitVecLiteral(0, sz)), UnaryExpr(BoolNOT, rhs))
         if ineqToStrict.contains(op) &&
-          size(lhs).isDefined && (simplifyCond(BinaryExpr(BVEQ, lhs, BitVecLiteral(0, size(lhs).get))) == rhs) => {
+          size(lhs).isDefined && (simplifyCond(BinaryExpr(EQ, lhs, BitVecLiteral(0, size(lhs).get))) == rhs) => {
       logSimp(e, BinaryExpr(ineqToStrict(op), lhs, BitVecLiteral(0, size(lhs).get)))
     }
-    case BinaryExpr(BoolAND, BinaryExpr(op, lhs, rhs), UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, rhs2)))
+    case BinaryExpr(BoolAND, BinaryExpr(op, lhs, rhs), UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, rhs2)))
         if ineqToStrict.contains(op) &&
           lhs == lhs2 && (simplifyCond(UnaryExpr(BVNEG, rhs)) == simplifyCond(rhs2)) => {
       logSimp(e, BinaryExpr(ineqToStrict(op), lhs, rhs))
     }
 
-    case BinaryExpr(BoolEQ, UnaryExpr(BoolNOT, x), UnaryExpr(BoolNOT, y)) => logSimp(e, BinaryExpr(BoolEQ, x, y))
+    case BinaryExpr(EQ, UnaryExpr(BoolNOT, x), UnaryExpr(BoolNOT, y)) => logSimp(e, BinaryExpr(EQ, x, y))
 
-    case BinaryExpr(BoolOR, BinaryExpr(strictOp, x, y), r @ BinaryExpr(BVEQ, a, b))
+    case BinaryExpr(BoolOR, BinaryExpr(strictOp, x, y), r @ BinaryExpr(EQ, a, b))
         if x == a && y == b && strictToNonStrict.contains(strictOp) => {
       logSimp(e, BinaryExpr(strictToNonStrict(strictOp), x, y))
     }
@@ -823,21 +818,21 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolOR,
           BinaryExpr(strictOp, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)), BitVecLiteral(0, _)),
-          r @ BinaryExpr(BVEQ, a, b)
+          r @ BinaryExpr(EQ, a, b)
         ) if x == a && y == b && strictToNonStrict.contains(strictOp) => {
       logSimp(e, BinaryExpr(strictToNonStrict(strictOp), x, y))
     }
 
-    case BinaryExpr(BoolAND, BinaryExpr(BoolAND, x, y), r @ UnaryExpr(BoolNOT, BinaryExpr(BVEQ, a, b))) => {
+    case BinaryExpr(BoolAND, BinaryExpr(BoolAND, x, y), r @ UnaryExpr(BoolNOT, BinaryExpr(EQ, a, b))) => {
       logSimp(e, BinaryExpr(BoolAND, BinaryExpr(BoolAND, x, r), BinaryExpr(BoolAND, y, r)))
     }
 
-    case BinaryExpr(BoolOR, BinaryExpr(op, lhs, rhs), BinaryExpr(BVEQ, lhs2, rhs2))
+    case BinaryExpr(BoolOR, BinaryExpr(op, lhs, rhs), BinaryExpr(EQ, lhs2, rhs2))
         if strictToNonStrict.contains(op) && rhs == rhs2 && lhs == lhs2 => {
       logSimp(e, BinaryExpr(strictToNonStrict(op), lhs, rhs))
     }
 
-    case BinaryExpr(BoolAND, lhs @ BinaryExpr(op, l, r), UnaryExpr(BoolNOT, BinaryExpr(BVEQ, l2, r2)))
+    case BinaryExpr(BoolAND, lhs @ BinaryExpr(op, l, r), UnaryExpr(BoolNOT, BinaryExpr(EQ, l2, r2)))
         if strictIneq.contains(op) && l == l2 && r == r2 => {
       logSimp(e, lhs)
     }
@@ -873,7 +868,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolOR,
           BinaryExpr(BoolAND, l @ BinaryExpr(op1, lhs1, lb: Literal), r @ BinaryExpr(op2, lhs3, rb: Literal)),
-          d @ BinaryExpr(BVEQ, lhs2, rhs2: Literal)
+          d @ BinaryExpr(EQ, lhs2, rhs2: Literal)
         )
         if isIneq(op1) && isIneq(op2) && lhs1 == lhs2 && lhs3 == lhs2
           && {
@@ -890,7 +885,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           BinaryExpr(op, lhs, rhs),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, BinaryExpr(BVADD, lhs2, rhs2), BitVecLiteral(0, _)))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, BinaryExpr(BVADD, lhs2, rhs2), BitVecLiteral(0, _)))
         )
         if ineqToStrict.contains(op) &&
           rhs == rhs2 && (simplifyCond(lhs) == simplifyCond(UnaryExpr(BVNEG, lhs2))) => {
@@ -898,7 +893,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     }
 
     // TODO: below are possibly redundant due to changed canonical form
-    case BinaryExpr(BoolAND, BinaryExpr(op, lhs, rhs), UnaryExpr(BoolNOT, BinaryExpr(BVEQ, lhs2, rhs2)))
+    case BinaryExpr(BoolAND, BinaryExpr(op, lhs, rhs), UnaryExpr(BoolNOT, BinaryExpr(EQ, lhs2, rhs2)))
         if ineqToStrict.contains(op) &&
           lhs == lhs2 && rhs == rhs2 => {
       logSimp(e, BinaryExpr(ineqToStrict(op), lhs, rhs))
@@ -906,7 +901,7 @@ def simplifyCmpInequalities(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(
           BoolAND,
           BinaryExpr(op, lhs, rhs),
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, BinaryExpr(BVADD, lhs2, rhs2), BitVecLiteral(0, _)))
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, BinaryExpr(BVADD, lhs2, rhs2), BitVecLiteral(0, _)))
         )
         if ineqToStrict.contains(op) &&
           lhs == lhs2 && simplifyCond(rhs) == simplifyCond(UnaryExpr(BVNEG, rhs2)) => {
@@ -961,7 +956,7 @@ def bool2bv1(e: Expr) = {
 }
 
 def isRel(b: BinOp) = {
-  isIneq(b) || b == BVEQ || b == BoolEQ
+  isIneq(b) || b == NEQ || b == EQ
 }
 
 def isIneq(b: BinOp) = {
@@ -994,11 +989,11 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
     case Extract(ed, 0, ZeroExtend(exts, body)) if exts + size(body).get >= ed && ed > size(body).get =>
       logSimp(e, ZeroExtend(ed - size(body).get, body))
 
-    case BinaryExpr(BVEQ, ZeroExtend(x, body), y: BitVecLiteral) if y.value <= BigInt(2).pow(size(body).get) - 1 =>
-      logSimp(e, BinaryExpr(BVEQ, body, BitVecLiteral(y.value, size(body).get)))
+    case BinaryExpr(EQ, ZeroExtend(x, body), y: BitVecLiteral) if y.value <= BigInt(2).pow(size(body).get) - 1 =>
+      logSimp(e, BinaryExpr(EQ, body, BitVecLiteral(y.value, size(body).get)))
 
-    case BinaryExpr(BVEQ, ZeroExtend(sz, expr), BitVecLiteral(0, sz2)) =>
-      logSimp(e, BinaryExpr(BVEQ, expr, BitVecLiteral(0, size(expr).get)))
+    case BinaryExpr(EQ, ZeroExtend(sz, expr), BitVecLiteral(0, sz2)) =>
+      logSimp(e, BinaryExpr(EQ, expr, BitVecLiteral(0, size(expr).get)))
 
     // compose slices
     case Extract(ed1, be1, Extract(ed2, be2, body)) => logSimp(e, Extract(ed1 + be2, be1 + be2, (body)))
@@ -1036,34 +1031,34 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
       logSimp(e, BitVecLiteral(0, size(body).get))
 
     // simplify convoluted bit test
-    case BinaryExpr(BVEQ, BinaryExpr(BVSHL, ZeroExtend(n1, body), BitVecLiteral(n, _)), BitVecLiteral(0, _))
+    case BinaryExpr(EQ, BinaryExpr(BVSHL, ZeroExtend(n1, body), BitVecLiteral(n, _)), BitVecLiteral(0, _))
         if n1 == n => {
-      logSimp(e, BinaryExpr(BVEQ, body, BitVecLiteral(0, size(body).get)))
+      logSimp(e, BinaryExpr(EQ, body, BitVecLiteral(0, size(body).get)))
     }
     //     assume (!(bvshl8(zero_extend6_2(R3_19[8:6]), 6bv8) == 128bv8));
     case BinaryExpr(
-          BVEQ,
+          EQ,
           BinaryExpr(BVSHL, ZeroExtend(n1, body @ Extract(hi, lo, v)), BitVecLiteral(n, _)),
           c @ BitVecLiteral(cval, _)
         ) if lo == n && cval >= BigInt(2).pow(lo + n.toInt) => {
-      logSimp(e, BinaryExpr(BVEQ, body, Extract(hi + n.toInt, lo + n.toInt, c)))
+      logSimp(e, BinaryExpr(EQ, body, Extract(hi + n.toInt, lo + n.toInt, c)))
     }
-    case BinaryExpr(BVEQ, BinaryExpr(BVSHL, b, BitVecLiteral(n, _)), c @ BitVecLiteral(0, _)) => {
+    case BinaryExpr(EQ, BinaryExpr(BVSHL, b, BitVecLiteral(n, _)), c @ BitVecLiteral(0, _)) => {
       // b low bits are all zero due to shift
-      logSimp(e, BinaryExpr(BVEQ, b, BitVecLiteral(0, size(b).get)))
+      logSimp(e, BinaryExpr(EQ, b, BitVecLiteral(0, size(b).get)))
     }
-    case BinaryExpr(BVEQ, BinaryExpr(BVSHL, b, BitVecLiteral(n, _)), c @ BitVecLiteral(cval, _))
+    case BinaryExpr(EQ, BinaryExpr(BVSHL, b, BitVecLiteral(n, _)), c @ BitVecLiteral(cval, _))
         if cval != 0 && cval < BigInt(2).pow(n.toInt) => {
       // low bits are all zero due to shift, and cval low bits are not zero
       logSimp(e, FalseLiteral)
     }
     case BinaryExpr(
-          BVEQ,
+          EQ,
           BinaryExpr(BVSHL, ZeroExtend(n1, body @ Extract(hi, lo, v)), BitVecLiteral(n, _)),
           c @ BitVecLiteral(cval, _)
         ) if lo == n && cval >= BigInt(2).pow(n.toInt) => {
       // extract the part of cval we are testing and remove the shift on the lhs operand
-      logSimp(e, BinaryExpr(BVEQ, body, Extract((hi - lo) + n.toInt, n.toInt, c)))
+      logSimp(e, BinaryExpr(EQ, body, Extract((hi - lo) + n.toInt, n.toInt, c)))
     }
 
     // bvnot to bvneg
@@ -1079,12 +1074,12 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
 }
 
 private val assocOps: Set[BinOp] =
-  Set(BVADD, BVMUL, BVOR, BVAND, BVEQ, BoolAND, BoolEQ, BoolOR, BoolEQUIV, BoolEQ, IntADD, IntMUL, IntEQ)
+  Set(BVADD, BVMUL, BVOR, BVAND, EQ, BoolAND, BoolOR, NEQ, IntADD, IntMUL)
 
 /** Simplifier implementing basic canonicalisation and simplifications of experssions without changing them too much.
   *
   *   - Normalises predicate calculations to boolean form rather than bitvector form.
-  *   - Normalises BinaryExpr(BVNEQ, a, b) to unaryExpr(BoolNOT, BinaryExpr(BVEQ, a, b))
+  *   - Normalises BinaryExpr(NEQ, a, b) to unaryExpr(BoolNOT, BinaryExpr(EQ, a, b))
   *   - Normalises BinaryExpr(BVSUB, a, b) to BinaryExpr(BVADD, a, UnaryExpr(BVNEG, b))
   *   - Removes redundant expressions
   */
@@ -1102,20 +1097,20 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
     //
     //
     // (comp (comp x y) 1) = (comp x y)
-    case BinaryExpr(BVEQ, UnaryExpr(BoolToBV1, body), BitVecLiteral(1, 1)) => logSimp(e, body)
+    case BinaryExpr(EQ, UnaryExpr(BoolToBV1, body), BitVecLiteral(1, 1)) => logSimp(e, body)
     case BinaryExpr(
-          BVEQ,
+          EQ,
           BinaryExpr(BVCOMP, body @ BinaryExpr(BVCOMP, _, _), BitVecLiteral(0, 1)),
           BitVecLiteral(1, 1)
         ) =>
-      logSimp(e, BinaryExpr(BVEQ, (body), BitVecLiteral(0, 1)))
-    case BinaryExpr(BVEQ, ZeroExtend(hi, Extract(ehi, 0, expr)), BitVecLiteral(0, _)) => {
-      val x = BinaryExpr(BVEQ, Extract(ehi, 0, expr), BitVecLiteral(0, ehi))
+      logSimp(e, BinaryExpr(EQ, (body), BitVecLiteral(0, 1)))
+    case BinaryExpr(EQ, ZeroExtend(hi, Extract(ehi, 0, expr)), BitVecLiteral(0, _)) => {
+      val x = BinaryExpr(EQ, Extract(ehi, 0, expr), BitVecLiteral(0, ehi))
       logSimp(e, x)
     }
 
-    case BinaryExpr(BVEQ, BinaryExpr(BVCOMP, e1: Expr, e2: Expr), BitVecLiteral(0, 1)) =>
-      logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(BVEQ, (e1), (e2))))
+    case BinaryExpr(EQ, BinaryExpr(BVCOMP, e1: Expr, e2: Expr), BitVecLiteral(0, 1)) =>
+      logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(EQ, (e1), (e2))))
 
     case BinaryExpr(BVADD, BinaryExpr(BVADD, body, l: BitVecLiteral), r: BitVecLiteral)
         if !body.isInstanceOf[Literal] =>
@@ -1136,10 +1131,10 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
     // normalise
     // make all comparisons positive so double negatives can be cleaned up
 
-    case BinaryExpr(BVEQ, BinaryExpr(BVCOMP, e1: Expr, e2: Expr), BitVecLiteral(1, 1)) =>
-      logSimp(e, BinaryExpr(BVEQ, (e1), (e2)))
+    case BinaryExpr(EQ, BinaryExpr(BVCOMP, e1: Expr, e2: Expr), BitVecLiteral(1, 1)) =>
+      logSimp(e, BinaryExpr(EQ, (e1), (e2)))
 
-    case BinaryExpr(BVNEQ, e1, e2) => logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(BVEQ, (e1), (e2))))
+    case BinaryExpr(NEQ, e1, e2) => logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(EQ, (e1), (e2))))
 
     case BinaryExpr(op, BinaryExpr(op1, a, b: Literal), BinaryExpr(op2, c, d: Literal))
         if !a.isInstanceOf[Literal] && !c.isInstanceOf[Literal]
@@ -1178,9 +1173,9 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
 
     case BinaryExpr(BVADD, UnaryExpr(BVNOT, x), BitVecLiteral(1, _)) => logSimp(e, UnaryExpr(BVNEG, x))
 
-    // case BinaryExpr(BVEQ, BinaryExpr(BVADD, x, y: BitVecLiteral), BitVecLiteral(0, _))
+    // case BinaryExpr(EQ, BinaryExpr(BVADD, x, y: BitVecLiteral), BitVecLiteral(0, _))
     //    if (eval.BitVectorEval.isNegative(y)) =>
-    //  logSimp(e, BinaryExpr(BVEQ, x, eval.BitVectorEval.smt_bvneg(y)))
+    //  logSimp(e, BinaryExpr(EQ, x, eval.BitVectorEval.smt_bvneg(y)))
 
     /*
      * Simplify BVop to Bool ops in a boolean context.
@@ -1189,8 +1184,8 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(BVCOMP, body @ BinaryExpr(BVCOMP, _, _), BitVecLiteral(1, 1)) => logSimp(e, body)
     case BinaryExpr(BVCOMP, body @ BinaryExpr(BVCOMP, _, _), BitVecLiteral(0, 1)) =>
       logSimp(e, UnaryExpr(BVNOT, (body)))
-    case BinaryExpr(BVEQ, l, BitVecLiteral(0, 1)) =>
-      logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(BVEQ, l, BitVecLiteral(1, 1))))
+    case BinaryExpr(EQ, l, BitVecLiteral(0, 1)) =>
+      logSimp(e, UnaryExpr(BoolNOT, BinaryExpr(EQ, l, BitVecLiteral(1, 1))))
 
     case BinaryExpr(BoolAND, x, TrueLiteral) => logSimp(e, x)
     case BinaryExpr(BoolAND, x, FalseLiteral) => logSimp(e, FalseLiteral)
@@ -1210,7 +1205,7 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
           case _ => throw Exception("Type error (should be unreachable)")
         }
       )
-    case BinaryExpr(BoolEQ, x, FalseLiteral) => logSimp(e, UnaryExpr(BoolNOT, x))
+    case BinaryExpr(EQ, x, FalseLiteral) => logSimp(e, UnaryExpr(BoolNOT, x))
     case BinaryExpr(BVADD, x, BitVecLiteral(0, _)) => logSimp(e, x)
 
     case BinaryExpr(BoolIMPLIES, FalseLiteral, _) => logSimp(e, TrueLiteral)
@@ -1226,19 +1221,19 @@ def simplifyExpr(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(BoolIMPLIES, UnaryExpr(BoolNOT, a), b) => logSimp(e, BinaryExpr(BoolOR, a, b))
 
     // syntactic equality
-    case BinaryExpr(BVEQ, a, b) if a == b => logSimp(e, TrueLiteral)
+    case BinaryExpr(EQ, a, b) if a == b => logSimp(e, TrueLiteral)
 
     case BinaryExpr(BVADD, BinaryExpr(BVADD, y, UnaryExpr(BVNOT, x)), BitVecLiteral(1, _))
         if !(y.isInstanceOf[BitVecLiteral]) =>
       logSimp(e, BinaryExpr(BVADD, y, UnaryExpr(BVNEG, x)))
 
-    // case BinaryExpr(BVEQ, BinaryExpr(BVADD, x, y: BitVecLiteral), BitVecLiteral(0, s)) =>
-    //  logSimp(e, BinaryExpr(BVEQ, x, UnaryExpr(BVNEG, y)))
+    // case BinaryExpr(EQ, BinaryExpr(BVADD, x, y: BitVecLiteral), BitVecLiteral(0, s)) =>
+    //  logSimp(e, BinaryExpr(EQ, x, UnaryExpr(BVNEG, y)))
     //
-    // case BinaryExpr(BVEQ, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)), BitVecLiteral(0, _)) =>
-    //  logSimp(e, BinaryExpr(BVEQ, x, y))
+    // case BinaryExpr(EQ, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)), BitVecLiteral(0, _)) =>
+    //  logSimp(e, BinaryExpr(EQ, x, y))
 
-    // case BinaryExpr(op, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)), BitVecLiteral(0, _)) if strictIneq.contains(op) || op == BVEQ || ineqToStrict.contains(op) =>
+    // case BinaryExpr(op, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)), BitVecLiteral(0, _)) if strictIneq.contains(op) || op == EQ || ineqToStrict.contains(op) =>
     //  logSimp(e, BinaryExpr(op, x, y))
 
     case BinaryExpr(BVSUB, x: Expr, y: BitVecLiteral) => logSimp(e, BinaryExpr(BVADD, x, UnaryExpr(BVNEG, y)))

--- a/src/main/scala/ir/transforms/IndirectCallResolution.scala
+++ b/src/main/scala/ir/transforms/IndirectCallResolution.scala
@@ -182,7 +182,7 @@ trait IndirectCallResolution {
             case None =>
               throw Exception(s"resolved indirect call $indirectCall to procedure which does not have address: $t")
           }
-          val assume = Assume(BinaryExpr(BVEQ, indirectCall.target, BitVecLiteral(address, 64)))
+          val assume = Assume(BinaryExpr(EQ, indirectCall.target, BitVecLiteral(address, 64)))
           val newLabel: String = block.label + t.name
           val directCall = t.makeCall()
 

--- a/src/main/scala/ir/transforms/LinuxAssertFail.scala
+++ b/src/main/scala/ir/transforms/LinuxAssertFail.scala
@@ -140,15 +140,11 @@ def liftSVComp(p: Program) = {
       }
       case d: DirectCall if d.target.procName == "__VERIFIER_assert" => {
         val arg = d.actualParams(LocalVar("R0_in", BitVecType(64)))
-        ChangeTo(
-          List(Assert(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assert")))
-        )
+        ChangeTo(List(Assert(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assert"))))
       }
       case d: DirectCall if d.target.procName == "__VERIFIER_assume" => {
         val arg = d.actualParams(LocalVar("R0_in", BitVecType(64)))
-        ChangeTo(
-          List(Assume(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assume")))
-        )
+        ChangeTo(List(Assume(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assume"))))
       }
       case _ => SkipChildren()
     }

--- a/src/main/scala/ir/transforms/LinuxAssertFail.scala
+++ b/src/main/scala/ir/transforms/LinuxAssertFail.scala
@@ -141,13 +141,13 @@ def liftSVComp(p: Program) = {
       case d: DirectCall if d.target.procName == "__VERIFIER_assert" => {
         val arg = d.actualParams(LocalVar("R0_in", BitVecType(64)))
         ChangeTo(
-          List(Assert(UnaryExpr(BoolNOT, BinaryExpr(BVEQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assert")))
+          List(Assert(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assert")))
         )
       }
       case d: DirectCall if d.target.procName == "__VERIFIER_assume" => {
         val arg = d.actualParams(LocalVar("R0_in", BitVecType(64)))
         ChangeTo(
-          List(Assume(UnaryExpr(BoolNOT, BinaryExpr(BVEQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assume")))
+          List(Assume(UnaryExpr(BoolNOT, BinaryExpr(EQ, arg, BitVecLiteral(0, 64))), Some("__VERIFIER_assume")))
         )
       }
       case _ => SkipChildren()

--- a/src/main/scala/ir/transforms/ReplaceReturn.scala
+++ b/src/main/scala/ir/transforms/ReplaceReturn.scala
@@ -18,7 +18,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
           j.parent.replaceJump(Return())
           val R30Begin = LocalVar("R30_begin", BitVecType(64))
           if (assertR30Addr) {
-            ChangeTo(List(Assert(BinaryExpr(BVEQ, r30, R30Begin), Some("is returning to caller-set R30"))))
+            ChangeTo(List(Assert(BinaryExpr(EQ, r30, R30Begin), Some("is returning to caller-set R30"))))
           } else {
             ChangeTo(List())
           }
@@ -33,7 +33,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             i.parent.replaceJump(Return())
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), i))
+              ChangeTo(List(Assert(BinaryExpr(EQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), i))
             } else {
               SkipChildren()
             }
@@ -51,7 +51,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             d.parent.replaceJump(GoTo((d.parent.parent.entryBlock.get)))
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
+              ChangeTo(List(Assert(BinaryExpr(EQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
             } else {
               SkipChildren()
             }
@@ -60,7 +60,7 @@ class ReplaceReturns(insertR30InvariantAssertion: Procedure => Boolean = (_ => t
             val R30Begin = LocalVar("R30_begin", BitVecType(64))
             d.parent.replaceJump(Return())
             if (assertR30Addr) {
-              ChangeTo(List(Assert(BinaryExpr(BVEQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
+              ChangeTo(List(Assert(BinaryExpr(EQ, Register("R30", 64), R30Begin), Some("R30 = R30_in")), d))
             } else {
               SkipChildren()
             }

--- a/src/main/scala/translating/BAPToIR.scala
+++ b/src/main/scala/translating/BAPToIR.scala
@@ -537,7 +537,7 @@ class BAPToIR(var program: BAPProgram, mainAddress: BigInt) {
         if (negative) {
           BinaryExpr(ir.EQ, e, BitVecLiteral(0, s))
         } else {
-          UnaryExpr(BoolNOT, BinaryExpr(ir.EQ, e, BitVecLiteral(0, s)))
+          BinaryExpr(ir.NEQ, e, BitVecLiteral(0, s))
         }
       case BoolType =>
         if (negative) {

--- a/src/main/scala/translating/BAPToIR.scala
+++ b/src/main/scala/translating/BAPToIR.scala
@@ -335,8 +335,8 @@ class BAPToIR(var program: BAPProgram, mainAddress: BigInt) {
         case AND => (BinaryExpr(BVAND, lhsIR, rhsIR), load)
         case OR => (BinaryExpr(BVOR, lhsIR, rhsIR), load)
         case XOR => (BinaryExpr(BVXOR, lhsIR, rhsIR), load)
-        case EQ => (BinaryExpr(BVCOMP, lhsIR, rhsIR), load)
-        case NEQ => (UnaryExpr(BVNOT, BinaryExpr(BVCOMP, lhsIR, rhsIR)), load)
+        case bap.EQ => (BinaryExpr(BVCOMP, lhsIR, rhsIR), load)
+        case bap.NEQ => (UnaryExpr(BVNOT, BinaryExpr(BVCOMP, lhsIR, rhsIR)), load)
         case LT => (BinaryExpr(BVULT, lhsIR, rhsIR), load)
         case LE => (BinaryExpr(BVULE, lhsIR, rhsIR), load)
         case SLT => (BinaryExpr(BVSLT, lhsIR, rhsIR), load)
@@ -535,9 +535,9 @@ class BAPToIR(var program: BAPProgram, mainAddress: BigInt) {
     e.getType match {
       case BitVecType(s) =>
         if (negative) {
-          BinaryExpr(BVEQ, e, BitVecLiteral(0, s))
+          BinaryExpr(ir.EQ, e, BitVecLiteral(0, s))
         } else {
-          BinaryExpr(BVNEQ, e, BitVecLiteral(0, s))
+          UnaryExpr(BoolNOT, BinaryExpr(ir.EQ, e, BitVecLiteral(0, s)))
         }
       case BoolType =>
         if (negative) {

--- a/src/main/scala/translating/GTIRBLoader.scala
+++ b/src/main/scala/translating/GTIRBLoader.scala
@@ -346,7 +346,7 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         checkArgs(function, 0, 1, typeArgs.size, args.size, ctx.getText)
         val (expr, load) = visitExpr(args.head)
         val result: Option[Expr] = expr.map {
-          case b: BinaryExpr if b.op == BVEQ => BinaryExpr(BVCOMP, b.arg1, b.arg2)
+          case b: BinaryExpr if b.op == EQ => BinaryExpr(BVCOMP, b.arg1, b.arg2)
           case FalseLiteral => BitVecLiteral(0, 1)
           case TrueLiteral => BitVecLiteral(1, 1)
           case o => UnaryExpr(BoolToBV1, o)
@@ -354,14 +354,14 @@ class GTIRBLoader(parserMap: immutable.Map[String, List[InsnSemantics]]) {
         (result, load)
 
       case "not_bool.0" => (resolveUnaryOp(BoolNOT, function, 0, typeArgs, args, ctx.getText), None)
-      case "eq_enum.0" => resolveBinaryOp(BoolEQ, function, 0, typeArgs, args, ctx.getText)
+      case "eq_enum.0" => resolveBinaryOp(EQ, function, 0, typeArgs, args, ctx.getText)
       case "or_bool.0" => resolveBinaryOp(BoolOR, function, 0, typeArgs, args, ctx.getText)
       case "and_bool.0" => resolveBinaryOp(BoolAND, function, 0, typeArgs, args, ctx.getText)
 
       case "or_bits.0" => resolveBinaryOp(BVOR, function, 1, typeArgs, args, ctx.getText)
       case "and_bits.0" => resolveBinaryOp(BVAND, function, 1, typeArgs, args, ctx.getText)
       case "eor_bits.0" => resolveBinaryOp(BVXOR, function, 1, typeArgs, args, ctx.getText)
-      case "eq_bits.0" => resolveBinaryOp(BVEQ, function, 1, typeArgs, args, ctx.getText)
+      case "eq_bits.0" => resolveBinaryOp(EQ, function, 1, typeArgs, args, ctx.getText)
       case "add_bits.0" => resolveBinaryOp(BVADD, function, 1, typeArgs, args, ctx.getText)
       case "sub_bits.0" => resolveBinaryOp(BVSUB, function, 1, typeArgs, args, ctx.getText)
       case "mul_bits.0" => resolveBinaryOp(BVMUL, function, 1, typeArgs, args, ctx.getText)

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -707,7 +707,7 @@ class GTIRBToIR(
       val target = entranceUUIDtoProcedure(call.targetUuid)
       val resolvedCall = DirectCall(target)
 
-      val assume = Assume(BinaryExpr(BVEQ, targetRegister, BitVecLiteral(target.address.get, 64)))
+      val assume = Assume(BinaryExpr(EQ, targetRegister, BitVecLiteral(target.address.get, 64)))
       val label = block.label + "_" + target.name
       newBlocks.append(Block(label, None, ArrayBuffer(assume, resolvedCall), GoTo(returnTarget)))
     }

--- a/src/main/scala/translating/IRExpToSMT2.scala
+++ b/src/main/scala/translating/IRExpToSMT2.scala
@@ -233,7 +233,7 @@ object BasilIRToSMT2 extends BasilIRExpWithVis[Sexp] {
   def opnameToFun(b: BinOp) = {
     b match {
       case EQ => "="
-      case NEQ => ??? 
+      case NEQ => ???
       case BoolOR => "or"
       case BVCONCAT => "concat"
       case b: BVBinOp => "bv" + b.opName

--- a/src/main/scala/translating/IRExpToSMT2.scala
+++ b/src/main/scala/translating/IRExpToSMT2.scala
@@ -147,9 +147,7 @@ trait BasilIRExpWithVis[Repr[+_]] extends BasilIRExp[Repr] {
         vexpr(BinaryExpr(BVCONCAT, Repeat(bits, Extract(size(arg).get, size(arg).get - 1, arg)), arg))
       case BinaryExpr(op, arg, arg2) =>
         op match {
-          case BVNEQ => vunary_expr(BoolNOT, vbinary_expr(BVEQ, vexpr(arg), vexpr(arg2)))
-          case IntNEQ => vunary_expr(BoolNOT, vbinary_expr(IntEQ, vexpr(arg), vexpr(arg2)))
-          case BoolNEQ => vunary_expr(BoolNOT, vbinary_expr(BoolEQ, vexpr(arg), vexpr(arg2)))
+          case NEQ => vunary_expr(BoolNOT, vbinary_expr(EQ, vexpr(arg), vexpr(arg2)))
           case _ => vbinary_expr(op, vexpr(arg), vexpr(arg2))
         }
       case UnaryExpr(op, arg) => vunary_expr(op, vexpr(arg))
@@ -234,12 +232,8 @@ object BasilIRToSMT2 extends BasilIRExpWithVis[Sexp] {
 
   def opnameToFun(b: BinOp) = {
     b match {
-      case IntEQ => "="
-      case BoolEQ => "="
-      case BVEQ => "="
-      case BVNEQ => ???
-      case IntNEQ => ???
-      case BoolNEQ => ???
+      case EQ => "="
+      case NEQ => ??? 
       case BoolOR => "or"
       case BVCONCAT => "concat"
       case b: BVBinOp => "bv" + b.opName

--- a/src/main/scala/translating/IRToBoogie.scala
+++ b/src/main/scala/translating/IRToBoogie.scala
@@ -31,7 +31,7 @@ def memoryToConditionCoalesced(memorySections: Iterable[MemorySection]): List[BE
         val bits = s.bytes.size * 8
         Seq(
           BinaryBExpr(
-            BVEQ,
+            EQ,
             BMemoryLoad(memory, BitVecBLiteral(s.address, 64), Endian.LittleEndian, bits),
             BitVecBLiteral(combined, bits)
           )
@@ -49,7 +49,7 @@ def memoryToConditionCoalesced(memorySections: Iterable[MemorySection]): List[BE
           val combined: BigInt =
             (0 until 8).foldLeft(BigInt(0))((x, y) => x + (s.bytes(b + y).value * BigInt(2).pow(y * 8)))
           BinaryBExpr(
-            BVEQ,
+            EQ,
             BMemoryLoad(memory, BitVecBLiteral(s.address + b, 64), Endian.LittleEndian, 64),
             BitVecBLiteral(combined, 64)
           )
@@ -62,7 +62,7 @@ def memoryToConditionCoalesced(memorySections: Iterable[MemorySection]): List[BE
         } else {
           for (b <- 0 until aligned) yield {
             BinaryBExpr(
-              BVEQ,
+              EQ,
               BMemoryLoad(memory, BitVecBLiteral(s.address + b, 64), Endian.LittleEndian, 8),
               s.bytes(b).toBoogie
             )
@@ -80,7 +80,7 @@ def memoryToConditionCoalesced(memorySections: Iterable[MemorySection]): List[BE
         } else {
           for (b <- alignedEnd until s.bytes.size) yield {
             BinaryBExpr(
-              BVEQ,
+              EQ,
               BMemoryLoad(memory, BitVecBLiteral(s.address + b, 64), Endian.LittleEndian, 8),
               s.bytes(b).toBoogie
             )
@@ -101,7 +101,7 @@ def memoryToConditionBytes(memorySections: Iterable[MemorySection]): List[BExpr]
     }
     for (b <- s.bytes.indices) yield {
       BinaryBExpr(
-        BVEQ,
+        EQ,
         BMemoryLoad(memory, BitVecBLiteral(s.address + b, 64), Endian.LittleEndian, 8),
         s.bytes(b).toBoogie
       )
@@ -274,7 +274,7 @@ class IRToBoogie(
       relies
     } else {
       // default case where no rely is given - rely on no external changes
-      memoriesAndGammas.toList.sorted.map(m => BinaryBExpr(BVEQ, m, Old(m)))
+      memoriesAndGammas.toList.sorted.map(m => BinaryBExpr(EQ, m, Old(m)))
     }
     val relyEnsures = if (relies.nonEmpty) {
       val i = BVariable("i", BitVecBType(64), Scope.Local)
@@ -285,8 +285,8 @@ class IRToBoogie(
           List(i),
           BinaryBExpr(
             BoolIMPLIES,
-            BinaryBExpr(BVEQ, MapAccess(memory, i), Old(MapAccess(memory, i))),
-            BinaryBExpr(BVEQ, MapAccess(gamma, i), Old(MapAccess(gamma, i)))
+            BinaryBExpr(EQ, MapAccess(memory, i), Old(MapAccess(memory, i))),
+            BinaryBExpr(EQ, MapAccess(gamma, i), Old(MapAccess(gamma, i)))
           )
         )
       }
@@ -318,7 +318,7 @@ class IRToBoogie(
       reliesParam
     } else {
       // default case where no rely is given - rely on no external changes
-      List(BinaryBExpr(BVEQ, mem_out, mem_in), BinaryBExpr(BVEQ, Gamma_mem_out, Gamma_mem_in))
+      List(BinaryBExpr(EQ, mem_out, mem_in), BinaryBExpr(EQ, Gamma_mem_out, Gamma_mem_in))
     }
     val relyEnsures = if (reliesParam.nonEmpty) {
       val i = BVariable("i", BitVecBType(64), Scope.Local)
@@ -326,8 +326,8 @@ class IRToBoogie(
         List(i),
         BinaryBExpr(
           BoolIMPLIES,
-          BinaryBExpr(BVEQ, MapAccess(mem_out, i), MapAccess(mem_in, i)),
-          BinaryBExpr(BVEQ, MapAccess(Gamma_mem_out, i), MapAccess(Gamma_mem_in, i))
+          BinaryBExpr(EQ, MapAccess(mem_out, i), MapAccess(mem_in, i)),
+          BinaryBExpr(EQ, MapAccess(Gamma_mem_out, i), MapAccess(Gamma_mem_in, i))
         )
       )
       List(rely2) ++ reliesUsed
@@ -350,7 +350,7 @@ class IRToBoogie(
       reliesParam
     } else {
       // default case where no rely is given - rely on no external changes
-      List(BinaryBExpr(BVEQ, mem_out, mem_in), BinaryBExpr(BVEQ, Gamma_mem_out, Gamma_mem_in))
+      List(BinaryBExpr(EQ, mem_out, mem_in), BinaryBExpr(EQ, Gamma_mem_out, Gamma_mem_in))
     }
     val relyEnsures = if (reliesParam.nonEmpty) {
       val i = BVariable("i", BitVecBType(64), Scope.Local)
@@ -358,8 +358,8 @@ class IRToBoogie(
         List(i),
         BinaryBExpr(
           BoolIMPLIES,
-          BinaryBExpr(BVEQ, MapAccess(mem_out, i), MapAccess(mem_in, i)),
-          BinaryBExpr(BVEQ, MapAccess(Gamma_mem_out, i), MapAccess(Gamma_mem_in, i))
+          BinaryBExpr(EQ, MapAccess(mem_out, i), MapAccess(mem_in, i)),
+          BinaryBExpr(EQ, MapAccess(Gamma_mem_out, i), MapAccess(Gamma_mem_in, i))
         )
       )
       List(rely2) ++ reliesUsed
@@ -512,13 +512,13 @@ class IRToBoogie(
         val body: BExpr = LPreds.keys.foldLeft(FalseBLiteral) { (ite: BExpr, next: SpecGlobal) =>
           val guard = next.arraySize match {
             case Some(size: Int) =>
-              val initial: BExpr = BinaryBExpr(BoolEQ, indexVar, ArrayAccess(next, 0).toAddrVar)
+              val initial: BExpr = BinaryBExpr(EQ, indexVar, ArrayAccess(next, 0).toAddrVar)
               val indices = 1 until size
               indices.foldLeft(initial) { (or: BExpr, i: Int) =>
-                BinaryBExpr(BoolOR, BinaryBExpr(BoolEQ, indexVar, ArrayAccess(next, i).toAddrVar), or)
+                BinaryBExpr(BoolOR, BinaryBExpr(EQ, indexVar, ArrayAccess(next, i).toAddrVar), or)
               }
             case None =>
-              BinaryBExpr(BoolEQ, indexVar, next.toAddrVar)
+              BinaryBExpr(EQ, indexVar, next.toAddrVar)
           }
           val LPred = LPreds(next)
           /*if (controlled.contains(next)) {
@@ -575,7 +575,7 @@ class IRToBoogie(
       .sorted
 
     val modifiedPreserve = modifies.collect { case m: BVar if modifiedCheck.contains(m) => m }
-    val modifiedPreserveEnsures: List[BExpr] = modifiedPreserve.map(m => BinaryBExpr(BoolEQ, m, Old(m))).toList
+    val modifiedPreserveEnsures: List[BExpr] = modifiedPreserve.map(m => BinaryBExpr(EQ, m, Old(m))).toList
 
     val procRequires: List[BExpr] = p.requires ++ requires.getOrElse(p.procName, List())
     val procEnsures: List[BExpr] = p.ensures ++ ensures.getOrElse(p.procName, List())
@@ -985,7 +985,7 @@ class IRToBoogie(
 
     val asserts = indices.flatMap { index =>
       for (c <- controls.keys.view.toList.sorted) yield {
-        val addrCheck = BinaryBExpr(BVEQ, index, c.toAddrVar)
+        val addrCheck = BinaryBExpr(EQ, index, c.toAddrVar)
         val checks = controls(c).toList.sorted.map { v =>
           BinaryBExpr(BoolIMPLIES, L(LArgs, v.toAddrVar), v.toOldGamma)
         }

--- a/src/main/scala/translating/SpecificationLoader.scala
+++ b/src/main/scala/translating/SpecificationLoader.scala
@@ -368,7 +368,7 @@ case class SpecificationLoader(symbols: Set[SpecGlobal], program: Program) {
   // may need to make this more sophisticated and check for bool == bool
   def visitRelOp(ctx: RelOpContext): BinOp = ctx.getText match {
     case "==" => EQ
-    case "!=" => NEQ 
+    case "!=" => NEQ
     case ">" => BVSGT
     case ">=" => BVSGE
     case "<" => BVSLT

--- a/src/main/scala/translating/SpecificationLoader.scala
+++ b/src/main/scala/translating/SpecificationLoader.scala
@@ -163,7 +163,7 @@ case class SpecificationLoader(symbols: Set[SpecGlobal], program: Program) {
   def visitExpr(ctx: ExprContext, nameToGlobals: Map[String, SpecGlobal], params: Map[String, Expr] = Map()): BExpr = {
     val exprs = ctx.impliesExpr.asScala.map(e => visitImpliesExpr(e, nameToGlobals, params))
     if (exprs.size > 1) {
-      exprs.tail.foldLeft(exprs.head)((opExpr: BExpr, next: BExpr) => BinaryBExpr(BoolEQUIV, opExpr, next))
+      exprs.tail.foldLeft(exprs.head)((opExpr: BExpr, next: BExpr) => BinaryBExpr(EQ, opExpr, next))
     } else {
       exprs.head
     }
@@ -366,9 +366,9 @@ case class SpecificationLoader(symbols: Set[SpecGlobal], program: Program) {
   }
 
   // may need to make this more sophisticated and check for bool == bool
-  def visitRelOp(ctx: RelOpContext): BVBinOp = ctx.getText match {
-    case "==" => BVEQ
-    case "!=" => BVNEQ
+  def visitRelOp(ctx: RelOpContext): BinOp = ctx.getText match {
+    case "==" => EQ
+    case "!=" => NEQ 
     case ">" => BVSGT
     case ">=" => BVSGE
     case "<" => BVSLT

--- a/src/test/scala/BitVectorSMTTest.scala
+++ b/src/test/scala/BitVectorSMTTest.scala
@@ -41,8 +41,8 @@ class BitVectorEvalTest extends AnyFunSuite {
       BVSLE,
       BVSGT,
       BVSGE,
-      BVEQ,
-      BVNEQ,
+      EQ,
+      NEQ,
       BVCONCAT
     )
 
@@ -53,7 +53,7 @@ class BitVectorEvalTest extends AnyFunSuite {
         val lhs = BitVecLiteral(l, size)
         val rhs = BitVecLiteral(r, size)
         val exprs = ops.map(op => BinaryExpr(op, lhs, rhs))
-        val test = exprs.map(e => (e, BinaryExpr(BVNEQ, e, ir.eval.evaluateExpr(e).get)))
+        val test = exprs.map(e => (e, BinaryExpr(NEQ, e, ir.eval.evaluateExpr(e).get)))
         checks = checks ++ test
       }
     }

--- a/src/test/scala/ConditionLiftingTests.scala
+++ b/src/test/scala/ConditionLiftingTests.scala
@@ -715,12 +715,7 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
       ),
       block(
         "Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__3",
-        Assume(
-          UnaryExpr(BoolNOT, BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1))),
-          None,
-          None,
-          true
-        ),
+        Assume(UnaryExpr(BoolNOT, BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1))), None, None, true),
         LocalAssign(Register("R3", 64), Register("R3", 64), Some("4196540_0")),
         goto("Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__5")
       ),

--- a/src/test/scala/ConditionLiftingTests.scala
+++ b/src/test/scala/ConditionLiftingTests.scala
@@ -24,9 +24,9 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
       "main_4196096_9" ->
         BinaryExpr(BVSGT, Extract(32, 0, LocalVar("R0_in", BitVecType(64), 0)), BitVecLiteral(BigInt("1"), 32)),
       "Sqrt_4196496_15" ->
-        BinaryExpr(BVEQ, LocalVar("R1", BitVecType(64), 6), BitVecLiteral(BigInt("0"), 64)),
+        BinaryExpr(EQ, LocalVar("R1", BitVecType(64), 6), BitVecLiteral(BigInt("0"), 64)),
       "Sqrt_4196496_16" ->
-        UnaryExpr(BoolNOT, BinaryExpr(BVEQ, LocalVar("R1", BitVecType(64), 6), BitVecLiteral(BigInt("0"), 64))),
+        UnaryExpr(BoolNOT, BinaryExpr(EQ, LocalVar("R1", BitVecType(64), 6), BitVecLiteral(BigInt("0"), 64))),
       "Sqrt_4196496_12" ->
         BinaryExpr(
           BVULT,
@@ -286,8 +286,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
             BoolNOT,
             BinaryExpr(
               BoolAND,
-              BinaryExpr(BVEQ, Register("NF", 1), Register("VF", 1)),
-              BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+              BinaryExpr(EQ, Register("NF", 1), Register("VF", 1)),
+              BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
             )
           ),
           None,
@@ -305,8 +305,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
               BoolNOT,
               BinaryExpr(
                 BoolAND,
-                BinaryExpr(BVEQ, Register("NF", 1), Register("VF", 1)),
-                BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+                BinaryExpr(EQ, Register("NF", 1), Register("VF", 1)),
+                BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
               )
             )
           ),
@@ -451,8 +451,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
             BoolNOT,
             BinaryExpr(
               BoolAND,
-              BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-              BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+              BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+              BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
             )
           ),
           None,
@@ -471,8 +471,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
               BoolNOT,
               BinaryExpr(
                 BoolAND,
-                BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-                BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+                BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+                BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
               )
             )
           ),
@@ -492,8 +492,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
         Assume(
           BinaryExpr(
             BoolAND,
-            BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-            BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+            BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+            BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
           ),
           None,
           None,
@@ -508,8 +508,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
             BoolNOT,
             BinaryExpr(
               BoolAND,
-              BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-              BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+              BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+              BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
             )
           ),
           None,
@@ -595,14 +595,14 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
       ),
       block(
         "Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__0",
-        Assume(BinaryExpr(BVEQ, Register("R1", 64), BitVecLiteral(BigInt("0"), 64)), None, None, true),
+        Assume(BinaryExpr(EQ, Register("R1", 64), BitVecLiteral(BigInt("0"), 64)), None, None, true),
         LocalAssign(Register("R3", 64), BitVecLiteral(BigInt("0"), 64), Some("4196512_0")),
         goto("Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__2")
       ),
       block(
         "Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__1",
         Assume(
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, Register("R1", 64), BitVecLiteral(BigInt("0"), 64))),
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, Register("R1", 64), BitVecLiteral(BigInt("0"), 64))),
           None,
           None,
           true
@@ -716,7 +716,7 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
       block(
         "Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__3",
         Assume(
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1))),
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1))),
           None,
           None,
           true
@@ -727,7 +727,7 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
       block(
         "Sqrt_4196496__1__5jlZESzjQ4a4yO3~e1nyHQ$__4",
         Assume(
-          UnaryExpr(BoolNOT, UnaryExpr(BoolNOT, BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)))),
+          UnaryExpr(BoolNOT, UnaryExpr(BoolNOT, BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)))),
           None,
           None,
           true
@@ -744,8 +744,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
         Assume(
           BinaryExpr(
             BoolAND,
-            BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-            BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+            BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+            BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
           ),
           None,
           None,
@@ -761,8 +761,8 @@ class ConditionLiftingRegressionTest extends AnyFunSuite with test_util.CaptureO
             BoolNOT,
             BinaryExpr(
               BoolAND,
-              BinaryExpr(BVEQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
-              BinaryExpr(BVEQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
+              BinaryExpr(EQ, Register("CF", 1), BitVecLiteral(BigInt("1"), 1)),
+              BinaryExpr(EQ, Register("ZF", 1), BitVecLiteral(BigInt("0"), 1))
             )
           ),
           None,

--- a/src/test/scala/InterpretTestConstProp.scala
+++ b/src/test/scala/InterpretTestConstProp.scala
@@ -45,7 +45,7 @@ class InterpretTestConstProp
     absval match {
       case Top => TrueLiteral
       case Bottom => TrueLiteral /* deliberately don't check */
-      case FlatEl(value) => BinaryExpr(BVEQ, value, concrete)
+      case FlatEl(value) => BinaryExpr(EQ, value, concrete)
     }
   }
 

--- a/src/test/scala/SATTest.scala
+++ b/src/test/scala/SATTest.scala
@@ -8,7 +8,7 @@ import translating.BasilIRToSMT2
 class SATTest extends AnyFunSuite with CaptureOutput {
   test(" basic taut ") {
     // Logger.setLevel(LogLevel.DEBUG)
-    val e = BinaryExpr(BoolEQ, BinaryExpr(BVNEQ, R0, bv64(0)), BinaryExpr(BVEQ, bv64(0), R0))
+    val e = BinaryExpr(EQ, BinaryExpr(NEQ, R0, bv64(0)), BinaryExpr(EQ, bv64(0), R0))
     val r = BasilIRToSMT2.proveExpr(e)
     assert(r == Some(true))
   }

--- a/src/test/scala/TestKnownBitsInterpreter.scala
+++ b/src/test/scala/TestKnownBitsInterpreter.scala
@@ -111,12 +111,7 @@ class TestKnownBitsInterpreter
       ),
       block(
         "lknownBitsExample_goto_l0000026d",
-        Assume(
-          BinaryExpr(EQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64)),
-          None,
-          None,
-          true
-        ),
+        Assume(BinaryExpr(EQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64)), None, None, true),
         LocalAssign(LocalVar("R2", BitVecType(64), 9), LocalVar("R0", BitVecType(64), 3), Some("phiback")),
         goto("l00000274")
       ),

--- a/src/test/scala/TestKnownBitsInterpreter.scala
+++ b/src/test/scala/TestKnownBitsInterpreter.scala
@@ -49,9 +49,9 @@ class TestKnownBitsInterpreter
   def valueInAbstractValue(absVal: TNum, concrete: Expr) = {
     (absVal, concrete.getType) match {
       case (TNum(v, m), _: BitVecType) =>
-        BinaryExpr(BVEQ, v, BinaryExpr(BVAND, concrete, UnaryExpr(BVNOT, m)))
+        BinaryExpr(EQ, v, BinaryExpr(BVAND, concrete, UnaryExpr(BVNOT, m)))
       case (TNum(v, m), BoolType) =>
-        BinaryExpr(BVEQ, v, BinaryExpr(BVAND, UnaryExpr(BoolToBV1, concrete), UnaryExpr(BVNOT, m)))
+        BinaryExpr(EQ, v, BinaryExpr(BVAND, UnaryExpr(BoolToBV1, concrete), UnaryExpr(BVNOT, m)))
       case _ => ???
     }
   }
@@ -112,7 +112,7 @@ class TestKnownBitsInterpreter
       block(
         "lknownBitsExample_goto_l0000026d",
         Assume(
-          BinaryExpr(BVEQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64)),
+          BinaryExpr(EQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64)),
           None,
           None,
           true
@@ -123,7 +123,7 @@ class TestKnownBitsInterpreter
       block(
         "l00000274_goto_l0000029d",
         Assume(
-          BinaryExpr(BVEQ, Extract(16, 0, LocalVar("R2", BitVecType(64), 9)), BitVecLiteral(BigInt("0"), 16)),
+          BinaryExpr(EQ, Extract(16, 0, LocalVar("R2", BitVecType(64), 9)), BitVecLiteral(BigInt("0"), 16)),
           None,
           None,
           true
@@ -142,7 +142,7 @@ class TestKnownBitsInterpreter
       block(
         "lknownBitsExample_phi_lknownBitsExample_goto_l00000271",
         Assume(
-          UnaryExpr(BoolNOT, BinaryExpr(BVEQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64))),
+          UnaryExpr(BoolNOT, BinaryExpr(EQ, LocalVar("R1_in", BitVecType(64), 0), BitVecLiteral(BigInt("0"), 64))),
           None,
           None,
           true
@@ -155,7 +155,7 @@ class TestKnownBitsInterpreter
         Assume(
           UnaryExpr(
             BoolNOT,
-            BinaryExpr(BVEQ, Extract(16, 0, LocalVar("R2", BitVecType(64), 9)), BitVecLiteral(BigInt("0"), 16))
+            BinaryExpr(EQ, Extract(16, 0, LocalVar("R2", BitVecType(64), 9)), BitVecLiteral(BigInt("0"), 16))
           ),
           None,
           None,
@@ -223,7 +223,7 @@ class TestKnownBitsInterpreter
       BVSDIV // broken
     )
 
-  def arbBinComp = Gen.oneOf(BVULE, BVUGT, BVULT, BVUGE, BVSLT, BVSLE, BVSGT, BVSGE, BVEQ, BVNEQ, BVCOMP)
+  def arbBinComp = Gen.oneOf(BVULE, BVUGT, BVULT, BVUGE, BVSLT, BVSLE, BVSGT, BVSGE, EQ, NEQ, BVCOMP)
 
   def genValue(givenSize: Option[Int] = None) = for {
     genSize <- Gen.chooseNum(1, 70)

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -378,16 +378,16 @@ class InterpreterTests extends AnyFunSuite with CaptureOutput with BeforeAndAfte
       proc(
         "begin",
         block("entry", LocalAssign(R8, Register("R31", 64)), LocalAssign(R0, bv64(n)), directCall("fib"), goto("done")),
-        block("done", Assert(BinaryExpr(BVEQ, R0, bv64(fib(n)))), ret)
+        block("done", Assert(BinaryExpr(EQ, R0, bv64(fib(n)))), ret)
       ),
       proc(
         "fib",
         block("base", goto("base1", "base2", "dofib")),
-        block("base1", Assume(BinaryExpr(BVEQ, R0, bv64(0))), ret),
-        block("base2", Assume(BinaryExpr(BVEQ, R0, bv64(1))), ret),
+        block("base1", Assume(BinaryExpr(EQ, R0, bv64(0))), ret),
+        block("base2", Assume(BinaryExpr(EQ, R0, bv64(1))), ret),
         block(
           "dofib",
-          Assume(BinaryExpr(BoolAND, BinaryExpr(BVNEQ, R0, bv64(0)), BinaryExpr(BVNEQ, R0, bv64(1)))),
+          Assume(BinaryExpr(BoolAND, BinaryExpr(NEQ, R0, bv64(0)), BinaryExpr(NEQ, R0, bv64(1)))),
           // R8 stack pointer preserved across calls
           LocalAssign(R7, BinaryExpr(BVADD, R8, bv64(8))),
           MemoryStore(stack, R7, R8, Endian.LittleEndian, 64), // sp
@@ -479,7 +479,7 @@ class InterpreterTests extends AnyFunSuite with CaptureOutput with BeforeAndAfte
     val watch = IRWalk.firstInProc((fib.procedures.find(_.name == "fib")).get).get
     val bp = BreakPoint(
       "Fibentry",
-      BreakPointLoc.CMDCond(watch, BinaryExpr(BVEQ, BitVecLiteral(5, 64), Register("R0", 64))),
+      BreakPointLoc.CMDCond(watch, BinaryExpr(EQ, BitVecLiteral(5, 64), Register("R0", 64))),
       BreakPointAction(true, true, List(("R0", Register("R0", 64))), true)
     )
     val bp2 = BreakPoint(


### PR DESCRIPTION
This removes the duplicate EQ ops BVEQ, BoolEQ, IntEQ, BoolEQUIV and the NEQ equivalends and replaces them with a single `EQ` and `NEQ` operator. This generally reduces the number of cases to write and makes it possible to compare any type (as it is in boogie and smt). 