### PR TITLE
parallelise tests using testForkGrouping and post-processing the output

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -79,7 +79,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.StandardSystemTest
+      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.StandardSystemTest
 
       - uses: actions/upload-artifact@v4
         with:
@@ -152,7 +152,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.UnitTest
+      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.UnitTest
 
         # every test with package prefix:
         # sbt "show test:definedTests"
@@ -177,70 +177,4 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2
-
-  AnalysisSystemTests2:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '6.0.x'
-
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y z3='4.8.12-*'
-      - run: dotnet tool install --global boogie --version '3.4.3'
-
-      - run: ./mill test.compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest2 -F 2
-
-  AnalysisSystemTests3:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '6.0.x'
-
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y z3='4.8.12-*'
-      - run: dotnet tool install --global boogie --version '3.4.3'
-
-      - run: ./mill test.compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest3 -F 2
-
-  AnalysisSystemTests4:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '6.0.x'
-
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y z3='4.8.12-*'
-      - run: dotnet tool install --global boogie --version '3.4.3'
-
-      - run: ./mill test.compile
-      - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest4 -F 2
+      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2

--- a/build.mill
+++ b/build.mill
@@ -53,6 +53,7 @@ object `package` extends RootModule with ScalaModule with antlr.AntlrModule with
     def sources = Task.Sources {
       Seq(PathRef(this.millSourcePath / "scala"))
     }
+    def testForkGrouping = discoveredTestClasses().grouped(1).toSeq
   }
 
   /** Updates the expected

--- a/scripts/scalatest.sh
+++ b/scripts/scalatest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -u
+
+set -o pipefail
+
+# Executes the Mill Scalatest runner (https://www.scalatest.org/user_guide/using_the_runner),
+# while collating its output. When testForkGrouping is used, the output would usually be
+# interspersed due to the multiple concurrent processes (as opposed to threads).
+#
+# This script will re-group each process's output, making use of the "[001]" prefix which Mill
+# inserts on each line.
+
+out=$(mktemp)
+red=$(tput setaf 1)
+
+set -x
+
+./mill test.compile
+
+./mill --ticker true -j3 test "$@" &> $out
+code=$?
+
+sort --key=1,1 --stable $out
+echo
+grep -F "$red" $out
+
+exit $code

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -150,7 +150,7 @@ class DifferentialAnalysisTest extends DifferentialTest {
   runSystemTests()
 }
 
-@test_util.tags.AnalysisSystemTest2
+@test_util.tags.AnalysisSystemTest
 class DifferentialAnalysisTestSimplification extends DifferentialTest {
 
   def runSystemTests(): Unit = {

--- a/src/test/scala/IntervalDSATest.scala
+++ b/src/test/scala/IntervalDSATest.scala
@@ -11,7 +11,7 @@ import analysis.data_structure_analysis
 import test_util.{BASILTest, CaptureOutput}
 import util.DSAConfig.Checks
 
-@test_util.tags.AnalysisSystemTest3
+@test_util.tags.AnalysisSystemTest
 class IntervalDSATest extends AnyFunSuite with CaptureOutput {
   def runAnalysis(program: Program): StaticAnalysisContext = {
     cilvisitor.visit_prog(transforms.ReplaceReturns(), program)

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -343,7 +343,7 @@ class NoSimplifySystemTests extends SystemTests {
   }
 }
 
-@test_util.tags.AnalysisSystemTest2
+@test_util.tags.AnalysisSystemTest
 class SimplifySystemTests extends SystemTests {
   runTests("correct", TestConfig(simplify = true, useBAPFrontend = true, expectVerify = true, logResults = true))
   runTests("incorrect", TestConfig(simplify = true, useBAPFrontend = true, expectVerify = false, logResults = true))
@@ -354,7 +354,7 @@ class SimplifySystemTests extends SystemTests {
   }
 }
 
-@test_util.tags.AnalysisSystemTest4
+@test_util.tags.AnalysisSystemTest
 class SimplifyMemorySystemTests extends SystemTests {
 
   override def customiseTestsByName(name: String) = super.customiseTestsByName(name).orElse {
@@ -587,7 +587,7 @@ class UnimplementedTests extends SystemTests {
   runTests("unimplemented", TestConfig(useBAPFrontend = true, expectVerify = false))
 }
 
-@test_util.tags.AnalysisSystemTest4
+@test_util.tags.AnalysisSystemTest
 class IntervalDSASystemTests extends SystemTests {
   runTests("correct", TestConfig(useBAPFrontend = true, expectVerify = true, simplify = true, dsa = Some(Checks)))
 

--- a/src/test/scala/test_util/tags/AnalysisSystemTest2.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest2.java
@@ -1,9 +1,0 @@
-package test_util.tags;
-
-import java.lang.annotation.*;
-import org.scalatest.TagAnnotation;
-
-@Inherited
-@TagAnnotation
-@Retention(RetentionPolicy.RUNTIME)
-public @interface AnalysisSystemTest2 {}

--- a/src/test/scala/test_util/tags/AnalysisSystemTest3.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest3.java
@@ -1,9 +1,0 @@
-package test_util.tags;
-
-import java.lang.annotation.*;
-import org.scalatest.TagAnnotation;
-
-@Inherited
-@TagAnnotation
-@Retention(RetentionPolicy.RUNTIME)
-public @interface AnalysisSystemTest3 {}

--- a/src/test/scala/test_util/tags/AnalysisSystemTest4.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest4.java
@@ -1,9 +1,0 @@
-package test_util.tags;
-
-import java.lang.annotation.*;
-import org.scalatest.TagAnnotation;
-
-@Inherited
-@TagAnnotation
-@Retention(RetentionPolicy.RUNTIME)
-public @interface AnalysisSystemTest4 {}


### PR DESCRIPTION
this uses testForkGrouping and solves the problem of interespersed output by re-introducing scalatest.sh (i'm sorry)
and collating test suite output based on the `[001]` prefix in front of each line.

the output looks something like this. to make errors easier to find, any red text is re-printed after all the tests are run.
![image](https://github.com/user-attachments/assets/8e1ff0b3-3004-4891-b2a6-273a421a7f87)

this pr changes the linux github actions to use the scalatest.sh. i don't have much confidence it'll work on windows.

**pros**:
- no AnalysisTest2,3,4
- allows configuration of parallelism level with the `-j` flag (though not exposed to command line)

**cons:**
- script probably wont work on windows
- probably wont work on macos either (uses GNU sort's --stable option)
- running `./mill test` without the script will have interspersed output
