### PR TITLE
add an assertion to check consistent reachable sets

### DIFF
--- a/src/main/scala/analysis/data_structure_analysis/Constraints.scala
+++ b/src/main/scala/analysis/data_structure_analysis/Constraints.scala
@@ -107,10 +107,9 @@ case class IndirectCallConstraint(call: IndirectCall) extends CallConstraint[Ind
 
 def generateConstraints(proc: Procedure): Set[Constraint] = {
   ConstGenLogger.info(s"Generating Constraints for ${proc.name}")
-  val domain = computeDomain(IntraProcIRCursor, Set(proc))
   var constraints: Set[Constraint] = Set.empty
 
-  domain.foreach {
+  proc.foreach {
     case load: MemoryLoad =>
       constraints += MemoryReadConstraint(load)
     case write: MemoryStore =>

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -819,6 +819,12 @@ class IntervalCell(val node: IntervalNode, val interval: DSInterval) {
 
 class IntervalDSA(irContext: IRContext) {
   def pre(): (Map[Procedure, SymValues[DSInterval]], Map[Procedure, Set[Constraint]]) = {
+    val reachable = computeDomain(IntraProcIRCursor, irContext.program.procedures).toSet
+    val alt = irContext.program.procedures.flatMap(p => computeDomain(IntraProcIRCursor, Set(p))).toSet
+    assert(
+      reachable == alt,
+      s"different reachable sets ${reachable.diff(alt).map(p => (p, IRWalk.procedure(p))).mkString("\n")}"
+    )
     var sva: Map[Procedure, SymValues[DSInterval]] = Map.empty
     var cons: Map[Procedure, Set[Constraint]] = Map.empty
     computeDSADomain(irContext.program.mainProcedure, irContext).toSeq

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -1054,7 +1054,7 @@ object IntervalDSA {
             )
             assert(pointers.forall(_.hasPointee), "expected all of the pointers to have pointee")
             val distinctPointees = pointers.map(_.getPointee).map(dsg.get).toSet
-            assert(distinctPointees.size == 1, s"Expected index cells to have unified pointer ${distinctPointees.size}")
+            assert(distinctPointees.size <= 1, s"Expected index cells to have unified pointee ${distinctPointees.size}")
           case store: MemoryStore =>
             val pointers = dsg.exprToCells(store.index).map(dsg.find)
             assert(
@@ -1063,8 +1063,8 @@ object IntervalDSA {
             )
             assert(pointers.forall(_.hasPointee), "expected all of the pointers to have pointee")
             val distinctPointees = pointers.map(_.getPointee).map(dsg.get).toSet
-            assert(distinctPointees.size == 1, s"Expected index cells to have unified pointer ${distinctPointees.size}")
-            
+            assert(distinctPointees.size <= 1, s"Expected index cells to have unified pointee ${distinctPointees.size}")
+
           case _ =>
     }
   }

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -970,7 +970,7 @@ object IntervalDSA {
           else {
             assert(base != Global)
             DSALogger.warn(
-              s"hit this case, $base, $off, source: ${source.proc.procName}, Source Expr: $sourceExpr,  target: ${target.proc.procName}, targetExpr: $targetExpr "
+              s"Duplicate offsets for base, $base, $off, source: ${source.proc.procName}, Source Expr: $sourceExpr,  target: ${target.proc.procName}, targetExpr: $targetExpr "
             )
             target.mergeCells(node.collapse(), t)
           }

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -895,6 +895,16 @@ class IntervalDSA(irContext: IRContext) {
 
 object IntervalDSA {
 
+  type MemoryAccess = MemoryLoad | MemoryStore
+
+  extension (ma: MemoryAccess)
+    def index = {
+      ma match {
+        case load: MemoryLoad => load.index
+        case store: MemoryStore => store.index
+      }
+    }
+
   def checksGlobalMaintained(graph: IntervalGraph): Unit = {
     assert(!graph.find(graph.nodes(Global)).isCollapsed, s"${graph.proc.procName} had it's global node collapsed}")
   }

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -1053,7 +1053,8 @@ object IntervalDSA {
               "Expected cells for indices used in reachable memory access to have corresponding DSA cells"
             )
             assert(pointers.forall(_.hasPointee), "expected all of the pointers to have pointee")
-            assert(pointers.map(_.getPointee).map(dsg.get).size == 1, s"Expected index cells to have unified pointer}")
+            val distinctPointees = pointers.map(_.getPointee).map(dsg.get).toSet
+            assert(distinctPointees.size == 1, s"Expected index cells to have unified pointer ${distinctPointees.size}")
           case store: MemoryStore =>
             val pointers = dsg.exprToCells(store.index).map(dsg.find)
             assert(
@@ -1061,7 +1062,9 @@ object IntervalDSA {
               s"Expected cells for indices used in reachable memory access to have corresponding DSA cells"
             )
             assert(pointers.forall(_.hasPointee), "expected all of the pointers to have pointee")
-            assert(pointers.map(_.getPointee).map(dsg.get).size == 1, s"Expected index cells to have unified pointer")
+            val distinctPointees = pointers.map(_.getPointee).map(dsg.get).toSet
+            assert(distinctPointees.size == 1, s"Expected index cells to have unified pointer ${distinctPointees.size}")
+            
           case _ =>
     }
   }

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -821,6 +821,12 @@ class IntervalDSA(irContext: IRContext) {
   def pre(): (Map[Procedure, SymValues[DSInterval]], Map[Procedure, Set[Constraint]]) = {
     var sva: Map[Procedure, SymValues[DSInterval]] = Map.empty
     var cons: Map[Procedure, Set[Constraint]] = Map.empty
+    assert(
+      irContext.program
+        .filter(_.isInstanceOf[MemoryAccess])
+        .toSet == irContext.program.procedures.flatMap(_.iterator).filter(_.isInstanceOf[MemoryAccess]).toSet,
+      "Inconsistent domain for constraints and invariants"
+    )
     computeDSADomain(irContext.program.mainProcedure, irContext).toSeq
       .sortBy(_.name)
       .foreach(proc =>
@@ -892,7 +898,6 @@ class IntervalDSA(irContext: IRContext) {
   }
 
 }
-
 
 type MemoryAccess = MemoryLoad | MemoryStore
 

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -899,16 +899,6 @@ class IntervalDSA(irContext: IRContext) {
 
 }
 
-type MemoryAccess = MemoryLoad | MemoryStore
-
-extension (ma: MemoryAccess)
-  def index = {
-    ma match {
-      case load: MemoryLoad => load.index
-      case store: MemoryStore => store.index
-    }
-  }
-
 object IntervalDSA {
 
   def checksGlobalMaintained(graph: IntervalGraph): Unit = {

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -819,12 +819,6 @@ class IntervalCell(val node: IntervalNode, val interval: DSInterval) {
 
 class IntervalDSA(irContext: IRContext) {
   def pre(): (Map[Procedure, SymValues[DSInterval]], Map[Procedure, Set[Constraint]]) = {
-    val reachable = computeDomain(IntraProcIRCursor, irContext.program.procedures).toSet
-    val alt = irContext.program.procedures.flatMap(p => computeDomain(IntraProcIRCursor, Set(p))).toSet
-    assert(
-      reachable == alt,
-      s"different reachable sets ${reachable.diff(alt).map(p => (p, IRWalk.procedure(p))).mkString("\n")}"
-    )
     var sva: Map[Procedure, SymValues[DSInterval]] = Map.empty
     var cons: Map[Procedure, Set[Constraint]] = Map.empty
     computeDSADomain(irContext.program.mainProcedure, irContext).toSeq

--- a/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
+++ b/src/main/scala/analysis/data_structure_analysis/IntervalDSA.scala
@@ -893,17 +893,18 @@ class IntervalDSA(irContext: IRContext) {
 
 }
 
-object IntervalDSA {
 
-  type MemoryAccess = MemoryLoad | MemoryStore
+type MemoryAccess = MemoryLoad | MemoryStore
 
-  extension (ma: MemoryAccess)
-    def index = {
-      ma match {
-        case load: MemoryLoad => load.index
-        case store: MemoryStore => store.index
-      }
+extension (ma: MemoryAccess)
+  def index = {
+    ma match {
+      case load: MemoryLoad => load.index
+      case store: MemoryStore => store.index
     }
+  }
+
+object IntervalDSA {
 
   def checksGlobalMaintained(graph: IntervalGraph): Unit = {
     assert(!graph.find(graph.nodes(Global)).isCollapsed, s"${graph.proc.procName} had it's global node collapsed}")

--- a/src/main/scala/ir/Statement.scala
+++ b/src/main/scala/ir/Statement.scala
@@ -67,6 +67,10 @@ object LocalAssign {
   def unapply(l: LocalAssign): Some[(Variable, Expr, Option[String])] = Some(l.lhs, l.rhs, l.label)
 }
 
+sealed trait MemoryAccess {
+  def index: Expr
+}
+
 class MemoryStore(
   var mem: Memory,
   var index: Expr,
@@ -74,7 +78,8 @@ class MemoryStore(
   var endian: Endian,
   var size: Int,
   override val label: Option[String] = None
-) extends Statement {
+) extends Statement,
+      MemoryAccess {
   override def modifies: Set[Global] = Set(mem)
   override def toString: String = s"$labelStr$mem[$index] := MemoryStore($value, $endian, $size)"
   override def acceptVisit(visitor: Visitor): Statement = visitor.visitMemoryStore(this)
@@ -92,7 +97,8 @@ class MemoryLoad(
   var endian: Endian,
   var size: Int,
   override val label: Option[String] = None
-) extends SingleAssign {
+) extends SingleAssign,
+      MemoryAccess {
   override def modifies: Set[Global] = lhs match {
     case r: Register => Set(r)
     case _ => Set()


### PR DESCRIPTION
As the title says

I had a non-deterministic dsa test failure occur locally and found that the local graph for from_base64 procedure in CNTLM is very different in the failed case than usual

This is the dsg for the procedure 
![fromBaseDSG](https://github.com/user-attachments/assets/13d8238a-f14f-4622-95a3-978cd0f5102a)


This is the dsg when the test fails 
![error](https://github.com/user-attachments/assets/c1acccfc-887c-432f-97e9-af12edb4d8ad)

What occurs is that not all reachable memory accesses in the procedure are converted to constraints.
So want to add an assertion to act as a guard ensuring consistent reachable cfgpositions between the assertion that fails in the test cases and the constraint generator to help narrow down the causes for the nondeterministic test failure
