### PR TITLE
mill: avoid downloading files if a local copy exists

### DIFF
--- a/util.mill
+++ b/util.mill
@@ -20,14 +20,19 @@ trait DownloadModule extends Module {
   def local: Target[Either[String, String]]
 
   def mode = "rwxr-xr-x"
-  def remote = Task {
-    val p = Task.dest / name
+
+  // this is not a mill Task to prevent it from being eagerly run.
+  def remote(dest: Path) = {
+    val p = dest / name
     os.write(p, requests.get(url))
     ignoring(classOf[UnsupportedOperationException]) {
       os.perms.set(p, mode)
     }
     p.toString
   }
+
   def source = Task(PathRef(Path(path())))
-  def path = Task(local().getOrElse(remote()))
+  def path = Task {
+    local().getOrElse(remote(Task.dest))
+  }
 }


### PR DESCRIPTION
this was always the intention, but there was an oversight. we need to make the `remote()` into a regular function, not a Task, because mill executes dependent Tasks unconditionally.

this fixes the pac-nix build.