### PR TITLE
computeDomain non-determinism

### DIFF
--- a/src/main/scala/ir/IRCursor.scala
+++ b/src/main/scala/ir/IRCursor.scala
@@ -184,14 +184,17 @@ object CallGraph extends CallGraph
   */
 def computeDomain[T <: CFGPosition, O <: T](walker: IRWalk[T, O], initial: IterableOnce[O]): mutable.Set[O] = {
   val domain: mutable.Set[O] = mutable.Set.from(initial)
+  val added: mutable.Set[O] = mutable.Set()
 
   var sizeBefore = 0
   var sizeAfter = domain.size
   while (sizeBefore != sizeAfter) {
     for (i <- domain) {
-      domain.addAll(walker.succ(i))
-      domain.addAll(walker.pred(i))
+      added.addAll(walker.succ(i))
+      added.addAll(walker.pred(i))
     }
+    domain.addAll(added)
+    added.clear()
     sizeBefore = sizeAfter
     sizeAfter = domain.size
   }


### PR DESCRIPTION
This hopefully prevents the non-determinism in computeDomain in IRCursor, which seems to have been caused by iterating over a set while modifying it, which is undefined behaviour (and in practice seems to be non-deterministic).

computeDomain is used everywhere in the analyses so this is likely the source of most of the non-determinism issues we've been having.