### PR TITLE
ci: use scalatest runner directly (again)

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -173,7 +173,7 @@ jobs:
           AnalysisSystemTest3,
           AnalysisSystemTest4,
         ]
-    fail-fast: false
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -173,6 +173,7 @@ jobs:
           AnalysisSystemTest3,
           AnalysisSystemTest4,
         ]
+    fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -163,10 +163,16 @@ jobs:
   AnalysisSystemTests:
     runs-on: ubuntu-latest
 
-
+    # run 4 AnalysisSystemTests in 4 parallel github jobs.
+    # the first job captures all AnalysisSystemTest and excludes all tests numbered with a different tag.
     strategy:
       matrix:
-        test: [AnalysisSystemTest1, AnalysisSystemTest2, AnalysisSystemTest3, AnalysisSystemTest4]
+        test: [
+          "AnalysisSystemTest -l test_util.tags.AnalysisSystemTest2 -l test_util.tags.AnalysisSystemTest3 -l test_util.tags.AnalysisSystemTest4",
+          AnalysisSystemTest2,
+          AnalysisSystemTest3,
+          AnalysisSystemTest4,
+        ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Compile docs
         run: ./mill allDocs
 
-  # INFO: Scalatest runner arguments (i.e., arguments to ./mill -j3 test.test) can be
+  # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner
 
   # useful scalatest arguments
@@ -80,8 +80,8 @@ jobs:
       - run: sudo apt-get install -y z3='4.8.12-*'
       - run: dotnet tool install --global boogie --version '3.4.3'
 
-      - run: ./mill compile
-      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.StandardSystemTest
+      - run: ./mill test.compile
+      - run: ./scripts/scalatest.sh -PS3 -oGD -T 1000000 -n test_util.tags.StandardSystemTest
 
       - uses: actions/upload-artifact@v4
         with:
@@ -132,6 +132,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
+        # XXX: scalatest.sh doesn't work on windows
       - run: ./mill test.test -oGD -T 1000000 -n test_util.tags.UnitTest
 
   UnitTests:
@@ -154,7 +155,7 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.UnitTest
+      - run: ./scripts/scalatest.sh -PS3 -oGD -T 1000000 -n test_util.tags.UnitTest
 
         # every test with package prefix:
         # sbt "show test:definedTests"
@@ -179,4 +180,4 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./scripts/scalatest.sh -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2
+      - run: ./scripts/scalatest.sh -PS3 -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -163,6 +163,11 @@ jobs:
   AnalysisSystemTests:
     runs-on: ubuntu-latest
 
+
+    strategy:
+      matrix:
+        test: [AnalysisSystemTest1, AnalysisSystemTest2, AnalysisSystemTest3, AnalysisSystemTest4]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -180,4 +185,4 @@ jobs:
       - run: dotnet tool install --global boogie --version '3.4.3'
 
       - run: ./mill test.compile
-      - run: ./scripts/scalatest.sh -PS3 -oGD -T 1000000 -n test_util.tags.AnalysisSystemTest -F 2
+      - run: "./scripts/scalatest.sh -PS3 -oGD -T 1000000 -n test_util.tags.${{ matrix.test }} -F 2"

--- a/scripts/scalatest.sh
+++ b/scripts/scalatest.sh
@@ -22,7 +22,7 @@
 # - to print a summary of failing tests at the end of the output, pass I to -o.
 #
 
-classes="$(./mill show test.compile | grep '"classes"' | cut -d'"' -f4 | cut -d: -f4)"
+classes="$(./mill --ticker false show test.compile | grep '"classes"' | cut -d'"' -f4 | cut -d: -f4)"
 
 if ! [[ -d "$classes" ]]; then
   echo "unable to determine mill class output directory: $classes" >&2

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -113,7 +113,7 @@ abstract class DifferentialTest extends AnyFunSuite, CaptureOutput, TestCustomis
 }
 
 /**
- * Disable analysis differential test because it makes no 
+ * Disable analysis differential test because it makes no
  * IR transforms, these examples contain no indirect calls.
  */
 @test_util.tags.DisabledTest
@@ -150,6 +150,7 @@ class DifferentialAnalysisTest extends DifferentialTest {
   runSystemTests()
 }
 
+@test_util.tags.AnalysisSystemTest2
 @test_util.tags.AnalysisSystemTest
 class DifferentialAnalysisTestSimplification extends DifferentialTest {
 

--- a/src/test/scala/IntervalDSATest.scala
+++ b/src/test/scala/IntervalDSATest.scala
@@ -11,6 +11,7 @@ import analysis.data_structure_analysis
 import test_util.{BASILTest, CaptureOutput}
 import util.DSAConfig.Checks
 
+@test_util.tags.AnalysisSystemTest3
 @test_util.tags.AnalysisSystemTest
 class IntervalDSATest extends AnyFunSuite with CaptureOutput {
   def runAnalysis(program: Program): StaticAnalysisContext = {

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -343,6 +343,7 @@ class NoSimplifySystemTests extends SystemTests {
   }
 }
 
+@test_util.tags.AnalysisSystemTest2
 @test_util.tags.AnalysisSystemTest
 class SimplifySystemTests extends SystemTests {
   runTests("correct", TestConfig(simplify = true, useBAPFrontend = true, expectVerify = true, logResults = true))
@@ -354,6 +355,7 @@ class SimplifySystemTests extends SystemTests {
   }
 }
 
+@test_util.tags.AnalysisSystemTest4
 @test_util.tags.AnalysisSystemTest
 class SimplifyMemorySystemTests extends SystemTests {
 
@@ -587,6 +589,7 @@ class UnimplementedTests extends SystemTests {
   runTests("unimplemented", TestConfig(useBAPFrontend = true, expectVerify = false))
 }
 
+@test_util.tags.AnalysisSystemTest4
 @test_util.tags.AnalysisSystemTest
 class IntervalDSASystemTests extends SystemTests {
   runTests("correct", TestConfig(useBAPFrontend = true, expectVerify = true, simplify = true, dsa = Some(Checks)))

--- a/src/test/scala/test_util/BASILTest.scala
+++ b/src/test/scala/test_util/BASILTest.scala
@@ -111,14 +111,9 @@ trait BASILTest {
 }
 
 object BASILTest {
-  lazy val rootDirectory: String = {
-    val millRoot = System.getenv("MILL_WORKSPACE_ROOT")
-    if (millRoot == null) {
-      System.getProperty("user.dir")
-    } else {
-      millRoot
-    }
-  }
+  lazy val rootDirectory: String =
+    Option(System.getenv("MILL_WORKSPACE_ROOT"))
+      .getOrElse(System.getProperty("user.dir"))
 
   def writeToFile(text: String, path: String): Unit = {
     val writer = BufferedWriter(FileWriter(path, false))

--- a/src/test/scala/test_util/tags/AnalysisSystemTest2.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest2.java
@@ -1,0 +1,9 @@
+package test_util.tags;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation;
+
+@Inherited
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnalysisSystemTest2 {}

--- a/src/test/scala/test_util/tags/AnalysisSystemTest3.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest3.java
@@ -1,0 +1,9 @@
+package test_util.tags;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation;
+
+@Inherited
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnalysisSystemTest3 {}

--- a/src/test/scala/test_util/tags/AnalysisSystemTest4.java
+++ b/src/test/scala/test_util/tags/AnalysisSystemTest4.java
@@ -1,0 +1,9 @@
+package test_util.tags;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation;
+
+@Inherited
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnalysisSystemTest4 {}


### PR DESCRIPTION
this brings back the old scalatest.sh which directly invokes scalatest's runner. now that there's a case fallback if MILL_WORKSPACE_ROOT is unset, this seems to work fine and leads to the best behaviour:

tests are run all in one thread, allowing for the best runtime performance and correctly-sorted output.

for reference:
- commit before mill 12.10 and scalatest.sh removal https://github.com/UQ-PAC/BASIL/commit/55587f08f4f90ecd35e86c14c8729669f67ca0b3
- my unfortunate suggestion to use `./mill test` directly https://github.com/UQ-PAC/BASIL/pull/421#issuecomment-2861915997
- hacky band-aid by re-sorting output. this worked but it was slow. https://github.com/UQ-PAC/BASIL/pull/429

i'm sorry for the trouble lol