### PR TITLE
Make --relf optional

### DIFF
--- a/scripts/liftmake.sh
+++ b/scripts/liftmake.sh
@@ -18,8 +18,8 @@ case "${o}" in
 done
 shift $((OPTIND-1))
 
-if [[ -z "$CFILE_NAME" ]] ; then 
-    echo "Usage: -c cfile.c [-b binaryname] [ -- make args]"
+if [[ -z "$CFILE_NAME" ]] && [[ -z "$BIN_NAME" ]] ; then 
+    echo "Usage: (-c cfile.c |-b binaryname) [ -- make args]"
     echo "Optionally variables CC, CFLAGS, DDISASM, READELF, GTIRBSEM, BAP to change the the binary path to the lifter tools"
     exit 1
 fi
@@ -48,7 +48,7 @@ $(BIN_NAME).relf: $(BIN_NAME)
 	$(READELF) -s -r -W $(BIN_NAME) > $(BIN_NAME).relf
 
 $(BIN_NAME).gts: $(BIN_NAME).gtirb
-	$(GTIRBSEM) $(BIN_NAME).gtirb $(BIN_NAME).gts
+	$(GTIRBSEM) $(GTIRBSEM_FLAGS) $(BIN_NAME).gtirb $(BIN_NAME).gts
 
 $(BIN_NAME).gtirb: $(BIN_NAME)
 	$(DDISASM) $(BIN_NAME) --ir $(BIN_NAME).gtirb

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -96,11 +96,11 @@ object Main {
     bapInputDirName: Option[String],
     @arg(name = "load-directory-gtirb", doc = "Load relf and gts from directory (and spec from parent directory)")
     gtirbInputDirName: Option[String],
-    @arg(name = "input", short = 'i', doc = "BAP .adt file or GTIRB/ASLi .gts file")
+    @arg(name = "input", short = 'i', doc = "BAP .adt file or GTIRB/ASLi .gts file (requires --relf)")
     inputFileName: Option[String],
     @arg(name = "relf", short = 'r', doc = "Name of the file containing the output of 'readelf -s -r -W'.")
     relfFileName: Option[String],
-    @arg(name = "spec", short = 's', doc = "BASIL specification file.")
+    @arg(name = "spec", short = 's', doc = "BASIL specification file (requires --relf).")
     specFileName: Option[String],
     @arg(name = "output", short = 'o', doc = "Boogie output destination file.")
     outFileName: String = "basil-out.bpl",

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -96,9 +96,13 @@ object Main {
     bapInputDirName: Option[String],
     @arg(name = "load-directory-gtirb", doc = "Load relf and gts from directory (and spec from parent directory)")
     gtirbInputDirName: Option[String],
-    @arg(name = "input", short = 'i', doc = "BAP .adt file or GTIRB/ASLi .gts file (requires --relf)")
+    @arg(name = "input", short = 'i', doc = "BAP .adt file or GTIRB/ASLi .gts file (.adt requires --relf)")
     inputFileName: Option[String],
-    @arg(name = "relf", short = 'r', doc = "Name of the file containing the output of 'readelf -s -r -W'.")
+    @arg(
+      name = "relf",
+      short = 'r',
+      doc = "Name of the file containing the output of 'readelf -s -r -W'  (required for most uses)"
+    )
     relfFileName: Option[String],
     @arg(name = "spec", short = 's', doc = "BASIL specification file (requires --relf).")
     specFileName: Option[String],
@@ -185,7 +189,7 @@ object Main {
     @arg(
       name = "dsa",
       doc =
-        "Perform Data Structure Analysis if no version is specified perform constraint generation (requires --simplify flag) (none|norm|field|set|all)"
+        "Perform Data Structure Analysis if no version is specified perform constraint generation (requires --simplify and --relf flags) (none|norm|field|set|all)"
     )
     dsaType: Option[String],
     @arg(name = "memory-transform", doc = "Transform memory access to region accesses")
@@ -295,8 +299,11 @@ object Main {
       )
     }
 
-    if (conf.specFileName.isDefined && conf.relfFileName.isEmpty) {
+    if (loadingInputs.specFile.isDefined && loadingInputs.relfFile.isEmpty) {
       throw IllegalArgumentException("--spec requires --relf")
+    }
+    if (loadingInputs.inputFile.endsWith(".adt") && loadingInputs.relfFile.isEmpty) {
+      throw IllegalArgumentException("BAP ADT input requires --relf")
     }
 
     val q = BASILConfig(

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -295,6 +295,10 @@ object Main {
       )
     }
 
+    if (conf.specFileName.isDefined && conf.relfFileName.isEmpty) {
+      throw IllegalArgumentException("--spec requires --relf")
+    }
+
     val q = BASILConfig(
       loading = loadingInputs.copy(
         dumpIL = conf.dumpIL,

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -72,7 +72,11 @@ object Main {
           case (Some(input), Some(relf)) => {
             Logger.info(s"Found $input $relf ${spec.getOrElse("")}")
             Seq(
-              ILLoadingConfig(input.normalize().toString, relf.normalize().toString, spec.map(_.normalize().toString))
+              ILLoadingConfig(
+                input.normalize().toString,
+                Some(relf.normalize().toString),
+                spec.map(_.normalize().toString)
+              )
             )
           }
           case _ => Seq()
@@ -281,12 +285,12 @@ object Main {
 
     } else if (conf.gtirbInputDirName.isDefined) then {
       loadDirectory(ChooseInput.Gtirb, conf.gtirbInputDirName.get)
-    } else if (conf.inputFileName.isDefined && conf.relfFileName.isDefined) then {
-      ILLoadingConfig(conf.inputFileName.get, conf.relfFileName.get, conf.specFileName)
+    } else if (conf.inputFileName.isDefined) then {
+      ILLoadingConfig(conf.inputFileName.get, conf.relfFileName, conf.specFileName)
 
     } else {
       throw IllegalArgumentException(
-        "\nRequires --load-directory-bap OR --load-directory-gtirb OR --input and--relf\n\n" + parser
+        "\nRequires --load-directory-gtirb, --load-directory-bap OR --input\n\n" + parser
           .helpText(sorted = false)
       )
     }

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -72,7 +72,8 @@ class GTIRBToIR(
   mods: Seq[Module],
   parserMap: immutable.Map[String, List[InsnSemantics]],
   cfg: CFG,
-  mainAddress: BigInt
+  mainAddress: Option[BigInt],
+  mainName: Option[String]
 ) {
   private val functionNames = MapDecoder.decode_uuid(mods.map(_.auxData("functionNames").data))
   private val functionEntries = MapDecoder.decode_set(mods.map(_.auxData("functionEntries").data))
@@ -243,7 +244,11 @@ class GTIRBToIR(
       initialMemory += (address -> section)
     }
 
-    val intialProc: Procedure = procedures.find(_.address.get == mainAddress).get
+    val intialProc: Procedure =
+      mainAddress
+        .map(ma => procedures.find(_.address.get == ma).get)
+        .orElse(mainName.map(n => procedures.find(_.procName == n)).get)
+        .getOrElse(procedures.head)
 
     Program(procedures, intialProc, initialMemory)
   }

--- a/src/main/scala/util/BASILConfig.scala
+++ b/src/main/scala/util/BASILConfig.scala
@@ -18,7 +18,7 @@ case class BoogieGeneratorConfig(
 
 case class ILLoadingConfig(
   inputFile: String,
-  relfFile: String,
+  relfFile: Option[String] = None,
   specFile: Option[String] = None,
   dumpIL: Option[String] = None,
   mainProcedureName: String = "main",

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -137,6 +137,7 @@ object IRLoading {
     } yield (IRContext(symbols, externalFunctions, globals, funcEntries, globalOffsets, specification, program))
 
     val ctx = withRelf.getOrElse {
+      assert(q.inputFile.endsWith(".gts"), "Only gtirb supports omitting relf")
       val prog = loadGTIRB(q.inputFile, None, Some(q.mainProcedureName))
       IRLoading.load(prog)
     }

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -147,13 +147,19 @@ object IRLoading {
 
         (Some(mainAddress), continuation)
       }
+      case None if mode == FrontendMode.Gtirb => {
+        Logger.warn("RELF not provided, recommended for GTIRB input")
+        (None, IRLoading.load: Program => IRContext)
+      }
       case None => {
         (None, IRLoading.load: Program => IRContext)
       }
     }
 
     val program: Program = (mode, mainAddress) match {
-      case (FrontendMode.Gtirb, _) => loadGTIRB(q.inputFile, mainAddress, Some(q.mainProcedureName))
+      case (FrontendMode.Gtirb, _) => {
+        loadGTIRB(q.inputFile, mainAddress, Some(q.mainProcedureName))
+      }
       case (FrontendMode.Basil, _) => ir.parsing.ParseBasilIL.loadILFile(q.inputFile)
       case (FrontendMode.Bap, None) => throw Exception("relf is required when using BAP input")
       case (FrontendMode.Bap, Some(mainAddress)) => {

--- a/src/test/scala/DataStructureAnalysisTest.scala
+++ b/src/test/scala/DataStructureAnalysisTest.scala
@@ -46,7 +46,8 @@ class DataStructureAnalysisTest extends AnyFunSuite with CaptureOutput {
 
     val result = RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = path + ".relf", specFile = None, dumpIL = None),
+        loading =
+          ILLoadingConfig(inputFile = path + ".adt", relfFile = Some(path + ".relf"), specFile = None, dumpIL = None),
         staticAnalysis = Some(StaticAnalysisConfig()),
         boogieTranslation = BoogieGeneratorConfig(),
         outputPrefix = "boogie_out"

--- a/src/test/scala/DifferentialAnalysisTest.scala
+++ b/src/test/scala/DifferentialAnalysisTest.scala
@@ -83,7 +83,7 @@ abstract class DifferentialTest extends AnyFunSuite, CaptureOutput, TestCustomis
 
     val loading = ILLoadingConfig(
       inputFile = examplePath + testName + suffix,
-      relfFile = examplePath + testName + ".relf",
+      relfFile = Some(examplePath + testName + ".relf"),
       dumpIL = None,
       trimEarly = true /* no instances of indirectcalls in these examples */
     )

--- a/src/test/scala/InterpretTestConstProp.scala
+++ b/src/test/scala/InterpretTestConstProp.scala
@@ -52,7 +52,7 @@ class InterpretTestConstProp
   private val testPath = s"${BASILTest.rootDirectory}/src/test/correct"
   def testInterpretConstProp(testName: String, compiler: String): Unit = {
     val path = s"$testPath/$testName/$compiler/$testName"
-    val loading = ILLoadingConfig(inputFile = s"$path.adt", relfFile = s"$path.relf", dumpIL = None)
+    val loading = ILLoadingConfig(inputFile = s"$path.adt", relfFile = Some(s"$path.relf"), dumpIL = None)
 
     var ictx = IRLoading.load(loading)
     ictx = IRTransform.doCleanup(ictx)

--- a/src/test/scala/IntervalDSATest.scala
+++ b/src/test/scala/IntervalDSATest.scala
@@ -27,7 +27,7 @@ class IntervalDSATest extends AnyFunSuite with CaptureOutput {
     val path = s"${BASILTest.rootDirectory}/$relativePath"
     RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = path + ".relf"),
+        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = Some(path + ".relf")),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),
@@ -41,7 +41,7 @@ class IntervalDSATest extends AnyFunSuite with CaptureOutput {
     val path = s"${BASILTest.rootDirectory}/$relativePath"
     RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".gts", relfFile = path + ".relf"),
+        loading = ILLoadingConfig(inputFile = path + ".gts", relfFile = Some(path + ".relf")),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),
@@ -57,7 +57,7 @@ class IntervalDSATest extends AnyFunSuite with CaptureOutput {
       BASILConfig(
         loading = ILLoadingConfig(
           inputFile = path + ".gts",
-          relfFile = path + ".relf",
+          relfFile = Some(path + ".relf"),
           mainProcedureName = mainProcedure,
           trimEarly = true
         ),
@@ -74,7 +74,7 @@ class IntervalDSATest extends AnyFunSuite with CaptureOutput {
     RunUtils.loadAndTranslate(
       BASILConfig(
         context = Some(context),
-        loading = ILLoadingConfig(inputFile = "", relfFile = ""),
+        loading = ILLoadingConfig(inputFile = "", relfFile = None),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),

--- a/src/test/scala/IrreducibleLoop.scala
+++ b/src/test/scala/IrreducibleLoop.scala
@@ -18,7 +18,7 @@ class IrreducibleLoop extends AnyFunSuite with CaptureOutput {
 
   def load(conf: ILLoadingConfig): Program = {
     val bapProgram = IRLoading.loadBAP(conf.inputFile)
-    val (_, _, _, _, _, mainAddress) = IRLoading.loadReadELF(conf.relfFile, conf)
+    val (_, _, _, _, _, mainAddress) = IRLoading.loadReadELF(conf.relfFile.get, conf)
     val IRTranslator = BAPToIR(bapProgram, mainAddress)
     val IRProgram = IRTranslator.translate
     IRProgram
@@ -43,7 +43,7 @@ class IrreducibleLoop extends AnyFunSuite with CaptureOutput {
     val RELFPath = variationPath + ".relf"
     Logger.debug(variationPath)
 
-    val program: Program = load(ILLoadingConfig(ADTPath, RELFPath))
+    val program: Program = load(ILLoadingConfig(ADTPath, Some(RELFPath)))
 
     val foundLoops = LoopDetector.identify_loops(program)
 

--- a/src/test/scala/MemoryTransformTests.scala
+++ b/src/test/scala/MemoryTransformTests.scala
@@ -24,7 +24,7 @@ class MemoryTransformTests extends AnyFunSuite with CaptureOutput {
     val path = s"${BASILTest.rootDirectory}/$relativePath"
     RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = path + ".relf"),
+        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = Some(path + ".relf")),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),
@@ -39,7 +39,7 @@ class MemoryTransformTests extends AnyFunSuite with CaptureOutput {
     RunUtils.loadAndTranslate(
       BASILConfig(
         context = Some(context),
-        loading = ILLoadingConfig(inputFile = "", relfFile = ""),
+        loading = ILLoadingConfig(inputFile = "", relfFile = None),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),

--- a/src/test/scala/PCTrackingTest.scala
+++ b/src/test/scala/PCTrackingTest.scala
@@ -15,7 +15,7 @@ class PCTrackingTest extends AnyFunSuite with CaptureOutput {
       BASILConfig(
         loading = ILLoadingConfig(
           inputFile = s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.gts",
-          relfFile = s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.relf",
+          relfFile = Some(s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.relf"),
           specFile = None,
           dumpIL = None,
           pcTracking = pcTracking

--- a/src/test/scala/RemovePCTest.scala
+++ b/src/test/scala/RemovePCTest.scala
@@ -15,7 +15,7 @@ class RemovePCTest extends AnyFunSuite with CaptureOutput {
       BASILConfig(
         loading = ILLoadingConfig(
           inputFile = s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.gts",
-          relfFile = s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.relf",
+          relfFile = Some(s"${BASILTest.rootDirectory}/src/test/correct/$name/$variation/$name.relf"),
           specFile = None,
           dumpIL = None,
           pcTracking = if keepPC then PCTrackingOption.Assert else PCTrackingOption.None

--- a/src/test/scala/SVATest.scala
+++ b/src/test/scala/SVATest.scala
@@ -26,7 +26,7 @@ class SVATest extends AnyFunSuite with CaptureOutput {
     RunUtils.loadAndTranslate(
       BASILConfig(
         context = Some(context),
-        loading = ILLoadingConfig(inputFile = "", relfFile = ""),
+        loading = ILLoadingConfig(inputFile = "", relfFile = None),
         simplify = true,
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),

--- a/src/test/scala/ir/IRToDSLTest.scala
+++ b/src/test/scala/ir/IRToDSLTest.scala
@@ -110,7 +110,8 @@ class IRToDSLTest extends AnyFunSuite with CaptureOutput {
 
     val loaded = util.RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = path + ".relf", specFile = None, dumpIL = None),
+        loading =
+          ILLoadingConfig(inputFile = path + ".adt", relfFile = Some(path + ".relf"), specFile = None, dumpIL = None),
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),
         outputPrefix = "boogie_out.bpl",
@@ -164,7 +165,8 @@ class IRToDSLTest extends AnyFunSuite with CaptureOutput {
 
     val loaded = util.RunUtils.loadAndTranslate(
       BASILConfig(
-        loading = ILLoadingConfig(inputFile = path + ".adt", relfFile = path + ".relf", specFile = None, dumpIL = None),
+        loading =
+          ILLoadingConfig(inputFile = path + ".adt", relfFile = Some(path + ".relf"), specFile = None, dumpIL = None),
         staticAnalysis = None,
         boogieTranslation = BoogieGeneratorConfig(),
         outputPrefix = "boogie_out.bpl"

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -43,7 +43,7 @@ class InterpreterTests extends AnyFunSuite with CaptureOutput with BeforeAndAfte
     val compiler = "gcc"
     val loading = ILLoadingConfig(
       inputFile = s"$path/$name/$compiler/$name.adt",
-      relfFile = s"$path/$name/$compiler/$name.relf",
+      relfFile = Some(s"$path/$name/$compiler/$name.relf"),
       specFile = None,
       dumpIL = None
     )

--- a/src/test/scala/test_util/BASILTest.scala
+++ b/src/test/scala/test_util/BASILTest.scala
@@ -59,7 +59,8 @@ trait BASILTest {
       None
     }
     val config = BASILConfig(
-      loading = ILLoadingConfig(inputFile = inputPath, relfFile = RELFPath, specFile = specFile, parameterForm = false),
+      loading =
+        ILLoadingConfig(inputFile = inputPath, relfFile = Some(RELFPath), specFile = specFile, parameterForm = false),
       simplify = simplify,
       summariseProcedures = summariseProcedures,
       staticAnalysis = staticAnalysisConf,


### PR DESCRIPTION
Make --relf optional for tasks not requiring symbols. The symbol table is only really required for the spec input and DSA heuristics and the relf parser tends to be by far the most fragile part of the frontend.

When relf is not provided look for `--main-procedure-name` (default 'main') in the procedure list to set as Program.mainProcedure. This is previously all we do to detect the entrypoint, except with the relf symbol table to find a procedure address to search for.

I think eventually we should be able to retrieve all the same information from the gtirb `Module.symbols` but that's a bigger task.
