### PR TITLE
use hashmap to improve dsl loading perf by 2000%

### DIFF
--- a/src/main/scala/ir/dsl/DSL.scala
+++ b/src/main/scala/ir/dsl/DSL.scala
@@ -92,25 +92,26 @@ def R(i: Int): Register = Register(s"R$i", 64)
 
 def bv_t(i: Int) = BitVecType(i)
 
-case class Resolver(program: Program) {
-  lazy val procs = program.procedures.map(p => p.name -> p).toMap
-  lazy val blocks = program.procedures.map(p => p.name -> (p.blocks.map(b => b.label -> b)).toMap).toMap
+case class CachedLabelResolver(program: Program) {
+  /* Cache of procedure idents for faster lookup on big program resolves */
+  val procs = program.procedures.map(p => p.name -> p).toMap
+  val blocks = program.procedures.map(p => p.name -> (p.blocks.map(b => b.label -> b)).toMap).toMap
 }
 
 case class DelayNameResolve(ident: String) {
-  def resolveProc(prog: Resolver): Option[Procedure] = prog.procs.get(ident)
+  def resolveProc(prog: CachedLabelResolver): Option[Procedure] = prog.procs.get(ident)
 
-  def resolveBlock(resolver: Resolver, parent: String): Option[Block] =
+  def resolveBlock(resolver: CachedLabelResolver, parent: String): Option[Block] =
     resolver.blocks.get(parent).flatMap(_.get(ident))
 }
 
 sealed trait EventuallyStatement extends DeepEquality {
-  def resolve(p: Resolver): Statement
+  def resolve(p: CachedLabelResolver): Statement
   def cloneable = this
 }
 
 case class CloneableStatement(s: NonCallStatement) extends EventuallyStatement {
-  override def resolve(p: Resolver): Statement = cloneStatement(s)
+  override def resolve(p: CachedLabelResolver): Statement = cloneStatement(s)
   override def deepEquals(o: Object) = o match {
     case CloneableStatement(os) => os.deepEquals(s)
     case _ => false
@@ -118,7 +119,7 @@ case class CloneableStatement(s: NonCallStatement) extends EventuallyStatement {
 }
 case class IdentityStatement(s: NonCallStatement) extends EventuallyStatement {
   var resolved = false
-  override def resolve(p: Resolver): Statement = {
+  override def resolve(p: CachedLabelResolver): Statement = {
     assert(
       !resolved,
       s"DSL statement '$s' has already been resolved! to make a DSL statement that can be resolved multiple times, wrap it in clonedStmt() or use .cloneable on its block."
@@ -134,14 +135,14 @@ case class IdentityStatement(s: NonCallStatement) extends EventuallyStatement {
 }
 
 trait EventuallyJump extends DeepEquality {
-  def resolve(p: Resolver, proc: String): Jump
-  def resolve(p: Program, proc: String): Jump = resolve(Resolver(p), proc)
+  def resolve(p: CachedLabelResolver, proc: String): Jump
+  def resolve(p: Program, proc: String): Jump = resolve(CachedLabelResolver(p), proc)
 }
 
 case class EventuallyIndirectCall(target: Variable, label: Option[String] = None)
     extends EventuallyStatement
     with DefaultDeepEquality {
-  override def resolve(p: Resolver): Statement = {
+  override def resolve(p: CachedLabelResolver): Statement = {
     IndirectCall(target, label)
   }
 }
@@ -153,7 +154,7 @@ case class EventuallyCall(
   label: Option[String] = None
 ) extends EventuallyStatement
     with DefaultDeepEquality {
-  override def resolve(p: Resolver): Statement = {
+  override def resolve(p: CachedLabelResolver): Statement = {
     val t = target.resolveProc(p) match {
       case Some(x) => x
       case None => throw Exception(s"can't resolve target ${target} proc in prog")
@@ -167,21 +168,21 @@ case class EventuallyCall(
 case class EventuallyGoto(targets: Iterable[DelayNameResolve], label: Option[String] = None)
     extends EventuallyJump
     with DefaultDeepEquality {
-  override def resolve(p: Resolver, proc: String): GoTo = {
-    val tgs = targets.flatMap(tn => tn.resolveBlock(p, proc))
+  override def resolve(p: CachedLabelResolver, proc: String): GoTo = {
+    val tgs = targets.map(tn => tn.resolveBlock(p, proc).getOrElse(throw Exception(s"Cannot resolve $tn")))
     GoTo(tgs, label)
   }
 }
 case class EventuallyReturn(params: Iterable[(String, Expr)], label: Option[String] = None)
     extends EventuallyJump
     with DefaultDeepEquality {
-  override def resolve(p: Resolver, proc: String) = {
+  override def resolve(p: CachedLabelResolver, proc: String) = {
     val r = SortedMap.from(params.map((n, v) => p.procs(proc).formalOutParam.find(_.name == n).get -> v))
     Return(label, r)
   }
 }
 case class EventuallyUnreachable(label: Option[String] = None) extends EventuallyJump with DefaultDeepEquality {
-  override def resolve(p: Resolver, proc: String) = Unreachable(label)
+  override def resolve(p: CachedLabelResolver, proc: String) = Unreachable(label)
 }
 
 def clonedStmt(s: NonCallStatement) = CloneableStatement(s)
@@ -250,10 +251,10 @@ case class EventuallyBlock(
 
   }
 
-  def makeResolver: (Block, (Resolver, String) => Unit) = {
+  def makeResolver: (Block, (CachedLabelResolver, String) => Unit) = {
     val tempBlock: Block = Block(label, address, List(), GoTo(List.empty))
 
-    def cont(prog: Resolver, proc: String): Block = {
+    def cont(prog: CachedLabelResolver, proc: String): Block = {
       assert(tempBlock.statements.isEmpty)
       val resolved = sl.map(_.resolve(prog))
       assert(tempBlock.statements.isEmpty)
@@ -264,8 +265,8 @@ case class EventuallyBlock(
     (tempBlock, cont)
   }
 
-  def resolve(prog: Program, proc: String): Block = resolve(Resolver(prog), proc)
-  def resolve(prog: Resolver, proc: String): Block = {
+  def resolve(prog: Program, proc: String): Block = resolve(CachedLabelResolver(prog), proc)
+  def resolve(prog: CachedLabelResolver, proc: String): Block = {
     val (b, resolve) = makeResolver
     resolve(prog, proc)
     b
@@ -322,7 +323,7 @@ case class EventuallyProcedure(
     case _ => false
   }
 
-  def makeResolver: (Procedure, Resolver => Unit) = {
+  def makeResolver: (Procedure, CachedLabelResolver => Unit) = {
 
     val (tempBlocks, resolvers) = blocks.map(_.makeResolver).unzip
 
@@ -342,7 +343,7 @@ case class EventuallyProcedure(
     val jumps: Iterable[(Block, EventuallyJump)] =
       (tempBlocks zip blocks).map((temp, b) => temp -> b.j)
 
-    def cont(prog: Resolver) = {
+    def cont(prog: CachedLabelResolver) = {
       resolvers.foreach(_(prog, tempProc.name))
       jumps.foreach((b, j) => b.replaceJump(j.resolve(prog, tempProc.name)))
       tempBlocks.headOption.foreach(b => tempProc.entryBlock = b)
@@ -351,8 +352,8 @@ case class EventuallyProcedure(
     (tempProc, cont)
   }
 
-  def resolve(p: Program): Procedure = resolve(Resolver(p))
-  def resolve(prog: Resolver): Procedure = {
+  def resolve(p: Program): Procedure = resolve(CachedLabelResolver(p))
+  def resolve(prog: CachedLabelResolver): Procedure = {
     val (p, resolver) = makeResolver
     resolver(prog)
     p
@@ -360,10 +361,10 @@ case class EventuallyProcedure(
 
   def toProg() = prog(this)
 
-  def addToProg(p: Resolver): Procedure = {
+  def addToProg(p: Program): Procedure = {
     val (proc, resolver) = makeResolver
-    p.program.addProcedure(proc)
-    resolver(p)
+    p.addProcedure(proc)
+    resolver(CachedLabelResolver(p))
     proc
   }
 
@@ -418,7 +419,7 @@ case class EventuallyProgram(
     val procs = ArrayBuffer.from(tempProcs)
 
     val p = Program(procs, procs.head, memory)
-    val reso = Resolver(p)
+    val reso = CachedLabelResolver(p)
 
     resolvers.foreach(_(reso))
     assert(ir.invariant.correctCalls(p))

--- a/src/main/scala/ir/transforms/Inline.scala
+++ b/src/main/scala/ir/transforms/Inline.scala
@@ -131,17 +131,18 @@ def inlineCall(prog: Program, c: DirectCall): Unit = {
   val (returnTemp, resolveReturnBlock) = eventuallyReturnBlock.copy(j = unreachable).makeResolver
   proc.addBlock(returnTemp)
 
+  val reso = Resolver(prog)
   // resolve internal call blocks
   val resolvers = internalBlocks.map(_.makeResolver)
   resolvers.foreach { case (block, _) => proc.addBlock(block) }
-  resolvers.foreach { case (_, resolve) => resolve(prog, proc) }
+  resolvers.foreach { case (_, resolve) => resolve(reso, proc.name) }
 
   // remove original call statement
   block.statements.remove(c)
   // link the inlined blocks to the call block and the aftercall block
-  entryResolver(prog, proc)
+  entryResolver(reso, proc.name)
   block.replaceJump(GoTo(entryTempBlock))
-  resolveReturnBlock(prog, proc)
+  resolveReturnBlock(reso, proc.name)
   returnTemp.replaceJump(GoTo(afterCallBlock))
 
   // assign the actual parameters in the caller to the renamed formal parameters in the entry block

--- a/src/main/scala/ir/transforms/Inline.scala
+++ b/src/main/scala/ir/transforms/Inline.scala
@@ -131,10 +131,10 @@ def inlineCall(prog: Program, c: DirectCall): Unit = {
   val (returnTemp, resolveReturnBlock) = eventuallyReturnBlock.copy(j = unreachable).makeResolver
   proc.addBlock(returnTemp)
 
-  val reso = Resolver(prog)
   // resolve internal call blocks
   val resolvers = internalBlocks.map(_.makeResolver)
   resolvers.foreach { case (block, _) => proc.addBlock(block) }
+  val reso = CachedLabelResolver(prog)
   resolvers.foreach { case (_, resolve) => resolve(reso, proc.name) }
 
   // remove original call statement

--- a/src/test/scala/ir/IRTest.scala
+++ b/src/test/scala/ir/IRTest.scala
@@ -75,7 +75,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
     val p = prog(
       proc(
         "main",
-        block("l_main", LocalAssign(R0, bv64(10)), LocalAssign(R1, bv64(10)), goto("newblock")),
+        block("l_main", LocalAssign(R0, bv64(10)), LocalAssign(R1, bv64(10)), goto("l_main_1")),
         block("l_main_1", LocalAssign(R0, bv64(22)), directCall("p2"), goto("returntarget")),
         block("returntarget", ret)
       ),
@@ -430,7 +430,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
 
     // these calls should not throw
     assert(prog(recursiveproc) != null)
-    assert(recursiveproc.addToProg(Resolver(emptyprog)) != null)
+    assert(recursiveproc.addToProg(emptyprog) != null)
   }
 
   test("LambdaTypes") {

--- a/src/test/scala/ir/IRTest.scala
+++ b/src/test/scala/ir/IRTest.scala
@@ -46,7 +46,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
     assert(IntraProcIRCursor.pred(blocks("lmain1")) == Set(blocks("lmain").jump))
     assert(IntraProcIRCursor.pred(blocks("lmain2")) == Set(blocks("lmain1").jump))
 
-    blocks("lmain").replaceJump(goto("lmain2").resolve(p, null))
+    blocks("lmain").replaceJump(goto("lmain2").resolve(p, "main"))
 
     assert(IntraProcIRCursor.succ(blocks("lmain").jump) == Set(blocks("lmain2")))
     // lmain1 is unreachable but still jumps to lmain2
@@ -124,14 +124,14 @@ class IRTest extends AnyFunSuite with CaptureOutput {
       LocalAssign(R0, bv64(22)),
       LocalAssign(R0, bv64(22)),
       goto("lmain2")
-    ).resolve(p, pp)
+    ).resolve(p, pp.name)
     val b1 = block(
       "newblock1",
       LocalAssign(R0, bv64(22)),
       LocalAssign(R0, bv64(22)),
       LocalAssign(R0, bv64(22)),
       goto("lmain2")
-    ).resolve(p, pp)
+    ).resolve(p, pp.name)
 
     p.procedures.head.addBlocks(Seq(b1, b2))
 
@@ -157,9 +157,9 @@ class IRTest extends AnyFunSuite with CaptureOutput {
       LocalAssign(R0, bv64(22)),
       directCall("main"),
       unreachable
-    ).resolve(p, called)
+    ).resolve(p, "called")
     val b2 = block("newblock1", LocalAssign(R0, bv64(22)), LocalAssign(R0, bv64(22)), LocalAssign(R0, bv64(22)), ret)
-      .resolve(p, called)
+      .resolve(p, "called")
 
     assert(p.mainProcedure eq p.procedures.find(_.name == "main").get)
 
@@ -176,7 +176,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
     val procs = p.nameToProcedure
 
     assert(called.incomingCalls().isEmpty)
-    val b3 = block("newblock3", LocalAssign(R0, bv64(22)), directCall("called"), unreachable).resolve(p, called)
+    val b3 = block("newblock3", LocalAssign(R0, bv64(22)), directCall("called"), unreachable).resolve(p, "called")
 
     blocks = p.labelToBlock
 
@@ -195,11 +195,11 @@ class IRTest extends AnyFunSuite with CaptureOutput {
     p.mainProcedure.replaceBlock(b3, b3)
     assert(called.incomingCalls().toSet == Set(b3.statements.last))
     assert(olds == blocks.size)
-    p.mainProcedure.addBlock(block("test", ret).resolve(p, p.mainProcedure))
+    p.mainProcedure.addBlock(block("test", ret).resolve(p, p.mainProcedure.name))
     blocks = p.labelToBlock
     assert(olds != blocks.size)
 
-    p.mainProcedure.replaceBlocks(Set(block("test", ret).resolve(p, p.mainProcedure)))
+    p.mainProcedure.replaceBlocks(Set(block("test", ret).resolve(p, p.mainProcedure.name)))
     blocks = p.labelToBlock
     assert(blocks.count(_(1).parent.name == "main") == 1)
 
@@ -219,7 +219,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
 
     assert(blocks.size > 1)
     assert(procs("main").entryBlock.isDefined)
-    procs("main").returnBlock = block("retb", ret).resolve(p, procs("main"))
+    procs("main").returnBlock = block("retb", ret).resolve(p, "main")
     assert(procs("main").returnBlock.isDefined)
     procs("main").clearBlocks()
 
@@ -430,7 +430,7 @@ class IRTest extends AnyFunSuite with CaptureOutput {
 
     // these calls should not throw
     assert(prog(recursiveproc) != null)
-    assert(recursiveproc.addToProg(emptyprog) != null)
+    assert(recursiveproc.addToProg(Resolver(emptyprog)) != null)
   }
 
   test("LambdaTypes") {


### PR DESCRIPTION
Caches the `label -> block` and `name -> procedure` mapping to avoid linear search.

The tests just reconstruct this cache every time as they usually modify the procedure and incrementally resolve. 