### PR TITLE
docs: fix cross-linking to bnfc javadocs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -188,7 +188,7 @@ object `package` extends RootModule with ScalaModule {
     // these docs paths are used for inter-project linking.
     // https://docs.scala-lang.org/scala3/guides/scaladoc/settings.html#-external-mappings
     Map(
-      "api/bnfc" -> "basil_ir/.*::javadoc",
+      "api/bnfc" -> ".*basil_ir/.*::javadoc",
       "api/basil-antlr" -> ".*Parsers/.*::javadoc",
       "api/basil-proto" -> ".*com/grammatech/gtirb.*::scaladoc3",
       "api/java-cup" -> ".*java_cup/.*::javadoc",
@@ -243,6 +243,8 @@ object `package` extends RootModule with ScalaModule {
         os.write.over(path, out)
       case _ => ()
     }
+
+    println("combined docs at " + dest)
 
     dest
   }


### PR DESCRIPTION
previously, in pages like
https://uq-pac.github.io/BASIL/api/basil/ir/parsing/BasilEarlyBNFCVisitor.html,
the links to bnfc-generated classes like Visitor would not work. this fixes those links.

old:
![image](https://github.com/user-attachments/assets/935db0a6-f13c-49bc-96cc-1fbedb32bdec)

new:
![image](https://github.com/user-attachments/assets/13dbcf19-e961-4409-b9d1-3f8507df5d5b)
