### PR TITLE
docs: disable on-click link handler to improve perf and reliability

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -236,10 +236,21 @@ object `package` extends RootModule with ScalaModule {
     }
     os.copy.into(docsIndex().path, dest / "api")
 
-    // HACK: fix mill bug causing incorrect scala source links https://github.com/com-lihaoyi/mill/issues/5221
     os.walk(dest).foreach {
       case path if path.ext == "html" =>
+        // HACK: fix mill bug causing incorrect scala source links https://github.com/com-lihaoyi/mill/issues/5221
         val out = os.read(path).replace(super.millSourcePath.toString, "")
+        os.write.over(path, out)
+      case path if path.last == "ux.js" =>
+        val old = os.read(path)
+        val oldLen = old.length
+
+        // HACK: disable scaladoc's horrendous link click handler which
+        // introduces a delay and sometimes causes clicking links to fail silently 
+        val out = old.replace("""document.querySelectorAll("a")""", "[]")
+        if (oldLen == out.length)
+          println(s"warning: $path replacement did not match anything")
+
         os.write.over(path, out)
       case _ => ()
     }


### PR DESCRIPTION
scala has a long precedent of thinking that its new implementations
are better than historically-proven technologies. here, we see this
hubris in the simple act of clicking a hyperlink in the docs page.

go to a page in the (new!) online basil api docs,
[this one for example](https://uq-pac.github.io/BASIL/api/basil/ir/dsl/EventuallyIndirectCall.html).
find a link which would take you somewhere else in the same
documentation, for example `Variable`. click the link.

observe how nothing happens for a second, then the page changes
(if you're lucky). you are witnessing Scala's custom Javascript
dispatch a request to the next page and then manually stitch it into
the current webpage. and that's _if_ it works.

i have also observed the on-click handler throwing a Javascript
exception and failing to perform *any* navigation. this is a miserable
experience for the person reading documentation. at time of writing,
going [to this page](https://uq-pac.github.io/BASIL/api/basil/translating/BAPLoader$.html#checkCondition-25c)
and clicking on ExpContext will do nothing. this works with a
ctrl+click, which presumably bypasses the custom handler.

this PR corrects this self-inflicted issue by replacing the query
for all links in a page, `document.querySelectorAll("a")`, with an
empty list. this prevents any on-click handlers from being registered
to links. the links now work noticeably faster and with no chance of
failing mysteriously.

one small drawback is that the state of the tree view in the left
sidebar is not persisted across link clicks. maybe this can be fixed if
i care to properly fix their javascript.

in the meantime, this is a small price to pay to restore an internet
browser feature which has existed since netscape navigator.