### PR TITLE
fix --load-directory when used with filenames with multiple dots

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -23,6 +23,9 @@ object Main {
     case Bap
   }
 
+  /** Replaces the extension of the given path with the given new extension, if
+   *  an extension is present. Otherwise, appends the extension.
+   */
   private def replacePathExtension(p: java.nio.file.Path, newExtension: String) = {
     val basename = p.getFileName().toString
 
@@ -33,6 +36,13 @@ object Main {
     }
 
     p.resolveSibling(withoutExtension + newExtension)
+  }
+
+  /** Appends the given extension onto the given path, irrespective of whether
+   *  the path has an existing extension.
+   */
+  private def addPathExtension(p: java.nio.file.Path, newExtension: String) = {
+    p.resolveSibling(p.getFileName().toString + newExtension)
   }
 
   def loadDirectory(i: ChooseInput = ChooseInput.Gtirb, d: String): ILLoadingConfig = {
@@ -52,7 +62,7 @@ object Main {
     // helper function to locate a file adjacent to the given path, with the given extension,
     // and ensure that it exists. returns None if file does not exist, otherwise Some(Path).
     val findAdjacent = (x: java.nio.file.Path, ext: String) =>
-      Some(replacePathExtension(x, ext)).filter(_.toFile.exists)
+      Some(addPathExtension(x, ext)).filter(_.toFile.exists)
 
     val results = tryName
       .flatMap(name => {

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -61,8 +61,7 @@ object Main {
 
     // helper function to locate a file adjacent to the given path, with the given extension,
     // and ensure that it exists. returns None if file does not exist, otherwise Some(Path).
-    val findAdjacent = (x: java.nio.file.Path, ext: String) =>
-      Some(addPathExtension(x, ext)).filter(_.toFile.exists)
+    val findAdjacent = (x: java.nio.file.Path, ext: String) => Some(addPathExtension(x, ext)).filter(_.toFile.exists)
 
     val results = tryName
       .flatMap(name => {


### PR DESCRIPTION
assuming you had files atomic.-O0.gts  atomic.-O0.relf  atomic.-O0.spec in a directory, previously, this would not work:

    ./mill run --load-directory-gtirb atomic/atomic/atomic.-O0.gts

the logic would incorrectly replace /two/ levels of file extension and look for files named atomic.gts and atomic.relf.

this fixes the logic to only strip off one file extension.

a test case is this zip from Aaron:
https://github.com/user-attachments/files/20717350/atomic.zip