### PR TITLE
fix bug when using --load-directory with a filename in the current dir

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -37,8 +37,14 @@ object Main {
 
   def loadDirectory(i: ChooseInput = ChooseInput.Gtirb, d: String): ILLoadingConfig = {
 
-    // at this point, `path` is the given directory with file extensions removed (if any).
-    val path = replacePathExtension(java.nio.file.Paths.get(d), "")
+    val path = {
+      val cwd = java.nio.file.Path.of(".")
+      var p = java.nio.file.Paths.get(d)
+      // manually prefix with current directory if given path is not absolute.
+      p = if p.isAbsolute() then p else cwd.resolve(p)
+      // remove file extension from path, if present.
+      replacePathExtension(p, "")
+    }
 
     // name of the parent directory.
     // e.g., in "src/test/correct/TESTCASE/gcc_O2", this would be "TESTCASE".


### PR DESCRIPTION
previously, when running

    ./mill run --load-directory-gtirb asdf.gts

to load files from the current directory, you would see an error:

Exception in thread "main" java.lang.NullPointerException:
  Cannot invoke "java.nio.file.Path.getFileName()" because
  the return value of "java.nio.file.Path.getParent()" is null
        at Main$.loadDirectory(Main.scala:45)
        at Main$.main(Main.scala:283)
        at Main.main(Main.scala)

this pr fixes using --load-directory without any directory prefix, by assuming the current working directory.

previously, this could also be worked around by using

    ./mill run --load-directory-gtirb ./asdf.gts