### PR TITLE
allow TempIf in the middle of blocks, given unique branching behaviour

### DIFF
--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -248,28 +248,39 @@ class GTIRBToIR(
     Program(procedures, intialProc, initialMemory)
   }
 
+  /** Determines if all paths through the given isnStmts have the same branching behaviour.
+   *  Returns true if all paths branch, or false if all paths do not branch.
+   *  Throws an error if some paths branch but some do not.
+   */
+  private def findUniqueBranchBehaviour(isnStmts: immutable.Seq[Statement]): Boolean =
+    isnStmts.exists {
+      case stmt @ LocalAssign(Register("_PC", 64), _, _) => true
+      case tempif: TempIf =>
+        val thenbranches = findUniqueBranchBehaviour(tempif.thenStmts)
+        val elsebranches = findUniqueBranchBehaviour(tempif.elseStmts)
+        if (thenbranches != elsebranches)
+          throw Exception("conflicting branch behaviours in non-trailing TempIf: " + tempif)
+        thenbranches
+      case _ => false
+    }
+
   private def insertPCIncrement(isnStmts: immutable.Seq[Statement]): immutable.Seq[Statement] = {
     isnStmts match {
       case Snoc(initial, x: TempIf) =>
-        // we only need to recurse on the last statement in each stmt list.
+        // recurse on the last statement in each stmt list.
+        // this allows for differing branch behaviours within trailing TempIf
+        // statements, as happens in conditional jumps for example.
         initial :+ TempIf(x.cond, insertPCIncrement(x.thenStmts), insertPCIncrement(x.elseStmts))
       case _ => {
-        val branchTaken = isnStmts.exists {
-          case LocalAssign(Register("_PC", 64), _, _) => true
-          case _: TempIf => throw Exception("encountered TempIf not at end of statement list: " + isnStmts)
-          case _ => false
-        }
-        val increment =
-          if branchTaken then None
-          else
-            Some(
-              LocalAssign(
-                Register("_PC", 64),
-                BinaryExpr(BVADD, Register("_PC", 64), BitVecLiteral(4, 64)),
-                Some("pc-tracking")
-              )
-            )
-        increment ++: isnStmts
+        val increment = LocalAssign(
+          Register("_PC", 64),
+          BinaryExpr(BVADD, Register("_PC", 64), BitVecLiteral(4, 64)),
+          Some("pc-tracking")
+        )
+
+        val branchTaken = findUniqueBranchBehaviour(isnStmts)
+        val incrementIfNotBranched = if branchTaken then None else Some(increment)
+        incrementIfNotBranched ++: isnStmts
       }
     }
   }


### PR DESCRIPTION
allows TempIf to occur in the middle of blocks, but only if both sides of the tempif branch or both sides do not branch.

this allows handling of, for example, `casal w0, w4, [x3]` 0x88e0fc64 which looks like this:
```
AtomicStart.0 {{  }} (  ) ;
constant bits ( 32 ) Exp16__6 = Mem.read.0 {{ 4 }} ( __array _R [ 3 ],4,9 ) ;
if eq_bits.0 {{ 32 }} ( Exp16__6,__array _R [ 0 ] [ 0 +: 32 ] ) then {
  Mem.set.0 {{ 4 }} ( __array _R [ 3 ],4,9,__array _R [ 4 ] [ 0 +: 32 ] ) ;
}
AtomicEnd.0 {{  }} (  ) ;
__array _R [ 0 ] = ZeroExtend.0 {{ 32,64 }} ( Exp16__6,64 ) ;
```

i wish i could write a unit test for this, but alas...

Fixes: https://github.com/UQ-PAC/BASIL/issues/454