### PR TITLE
add HTML and PDF output for the BNFC grammar

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra
+      - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils
       - run: ./mill --no-server allDocs
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,10 @@
 name: Docs
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 permissions:
@@ -23,12 +21,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - run: './mill allDocs'
+      - run: sudo apt-get -y install texlive-latex-recommended texlive-lang-japanese texlive-latex-extra
+      - run: ./mill --no-server allDocs
       - uses: actions/upload-pages-artifact@v3
         with:
           path: out/allDocs.dest
 
   deploy-docs:
+    if: github.ref_name == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: Doc
 on:
   workflow_dispatch:
   workflow_call:
@@ -21,7 +21,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - run: sudo apt-get -y install texlive-latex-recommended texlive-lang-japanese texlive-latex-extra
+      - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra
       - run: ./mill --no-server allDocs
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -40,6 +40,11 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: texlive-latex-recommended
+          version: 1.0
+
       - name: Compile BASIL Mill
         run: ./mill compile
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Compile docs
         run: ./mill allDocs
 
+      - if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -42,8 +42,8 @@ jobs:
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: texlive-latex-recommended
-          version: 1.0
+          packages: latexmk texlive-latex-recommended texlive-latex-extra texlive-lang-japanese
+          version: 2
 
       - name: Compile BASIL Mill
         run: ./mill compile

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -20,6 +20,15 @@ jobs:
       - name: Check all test suites have at least one tag
         run: .github/workflows/check-test-tagging.sh
 
+  Docs:
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
   Scalafmt:
     runs-on: ubuntu-latest
     steps:
@@ -42,18 +51,6 @@ jobs:
 
       - name: Compile BASIL Mill
         run: ./mill compile
-
-      - uses: zauguin/install-texlive@v4
-        with:
-          packages: >
-            scheme-basic latexmk lwarp ifptex verifycommand xpatch catchfile newunicodechar upquote comment xstring environ
-
-      - name: Compile docs
-        run: |
-          PATH=~/texlive/bin/x86_64-linux:$PATH ./mill allDocs
-
-      - if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
 
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -40,11 +40,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: texlive-latex-recommended
-          version: 1.0
-
       - name: Compile BASIL Mill
         run: ./mill compile
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -43,11 +43,10 @@ jobs:
       - name: Compile BASIL Mill
         run: ./mill compile
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: zauguin/install-texlive@v4
         with:
-          packages: latexmk texlive-latex-recommended texlive-latex-extra texlive-lang-japanese
-          version: 2
-          execute_install_scripts: true
+          packages: >
+            scheme-basic latexmk lwarp ifptex verifycommand xpatch catchfile newunicodechar upquote comment xstring environ
 
       - name: Compile docs
         run: ./mill allDocs

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,4 +1,4 @@
-name: Run Examples
+name: Test
 on:
   push:
     branches:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -40,8 +40,14 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: texlive-latex-recommended
+          version: 1.0
+
       - name: Compile BASIL Mill
         run: ./mill compile
+
       - name: Compile docs
         run: ./mill allDocs
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -49,7 +49,8 @@ jobs:
             scheme-basic latexmk lwarp ifptex verifycommand xpatch catchfile newunicodechar upquote comment xstring environ
 
       - name: Compile docs
-        run: ./mill allDocs
+        run: |
+          PATH=~/texlive/bin/x86_64-linux:$PATH ./mill allDocs
 
       - if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -47,9 +47,13 @@ jobs:
         with:
           packages: latexmk texlive-latex-recommended texlive-latex-extra texlive-lang-japanese
           version: 2
+          execute_install_scripts: true
 
       - name: Compile docs
         run: ./mill allDocs
+
+      - if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -40,19 +40,16 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Compile BASIL Mill
+        run: ./mill compile
+
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: latexmk texlive-latex-recommended texlive-latex-extra texlive-lang-japanese
           version: 2
 
-      - name: Compile BASIL Mill
-        run: ./mill compile
-
       - name: Compile docs
         run: ./mill allDocs
-
-      - if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
 
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner

--- a/basilmill/bnfc.mill
+++ b/basilmill/bnfc.mill
@@ -77,6 +77,35 @@ trait BNFCModule extends JavaModule {
     PathRef(Task.dest)
   }
 
+  def bnfcLatex = Task {
+    val args = Seq("--latex", bnfcSource().path.toString, "-m", "-o", Task.dest.toString)
+    os.call(bnfcBinary.path() +: args)
+    PathRef(Task.dest / (bnfcSource().path.baseName + ".tex"))
+  }
+
+  def bnfcHtml = Task {
+
+    // some hacky fixes
+    val lines = os.read.lines(bnfcLatex().path).flatMap {
+      case l @ s"\\documentclass$_" => Seq(l, "\\usepackage[latexmk]{lwarp}")
+      case l @ s"\\usepackage${_}{inputenc}" => Seq(l.replace("[utf8x]", "[utf8]"))
+      case l => Seq(l.replace("{$-$}", "{-}").replace("{$>$}", "{>}").replace(raw"{\texttt {#1}}", raw"``{\texttt {#1}}''"))
+    }
+
+    val tex = Task.dest / bnfcLatex().path.last
+    os.write(tex, lines.mkString("\n"))
+
+    // https://ctan.org/pkg/lwarp?lang=en
+    // https://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/lwarp/lwarp.pdf
+    os.call(Seq("pdflatex", tex.toString))
+    os.call(Seq("lwarpmk", "print"), stdout = os.Inherit)
+    os.call(Seq("lwarpmk", "html"), stdout = os.Inherit)
+    os.call(Seq("lwarpmk", "limages"))
+    os.call(Seq("lwarpmk", "clean"))
+
+    PathRef(Task.dest)
+  }
+
   private def readMakefileVar(file: Path, key: String) = {
     val value = os.read.lines(file).collect {
       case l if l.startsWith(s"$key=") => l.stripPrefix(s"$key=")

--- a/basilmill/bnfc.mill
+++ b/basilmill/bnfc.mill
@@ -84,7 +84,6 @@ trait BNFCModule extends JavaModule {
   }
 
   def bnfcHtml = Task {
-
     // some hacky fixes
     val lines = os.read.lines(bnfcLatex().path).flatMap {
       case l @ s"\\documentclass$_" => Seq(l, "\\usepackage[latexmk]{lwarp}")
@@ -97,7 +96,7 @@ trait BNFCModule extends JavaModule {
 
     // https://ctan.org/pkg/lwarp?lang=en
     // https://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/lwarp/lwarp.pdf
-    os.call(Seq("pdflatex", tex.toString))
+    os.call(Seq("latexmk", "-pdf", tex.toString))
     os.call(Seq("lwarpmk", "print"), stdout = os.Inherit)
     os.call(Seq("lwarpmk", "html"), stdout = os.Inherit)
     os.call(Seq("lwarpmk", "limages"))

--- a/build.mill
+++ b/build.mill
@@ -206,6 +206,13 @@ object `package` extends RootModule with ScalaModule {
     )
   }
 
+
+  def extraDocs = Task {
+    Map(
+      "docs/basil-il" -> bnfc.bnfcHtml(),
+    )
+  }
+
   def scalaDocExternalMappingOptions = Task {
     val defaultExternals = Seq(
       ".*scala/.*::scaladoc3::https://scala-lang.org/api/3.3_LTS/",
@@ -225,14 +232,16 @@ object `package` extends RootModule with ScalaModule {
   def allDocs = Task {
     val dest = Task.dest
 
-    def copyDoc(x: PathRef, name: String) = {
-      val p = x.path / ".." / "javadoc"
-      println("copying docs from " + p)
+    def copyDoc(p: Path, name: String) = {
+      println(s"copying docs into $name from $p")
       os.copy(p, dest / os.RelPath(name), createFolders = true)
     }
 
     docsModules().foreach {
-      case (name, src) => copyDoc(src, name)
+      case (name, src) => copyDoc(src.path / ".." / "javadoc", name)
+    }
+    extraDocs().foreach {
+      case (name, src) => copyDoc(src.path, name)
     }
     os.copy.into(docsIndex().path, dest / "api")
 

--- a/docs/static/index.html
+++ b/docs/static/index.html
@@ -21,9 +21,17 @@
             <a href="basil">basil</a>: the main Basil package.
           </span>
         </li>
-        <li><a href="basil-antlr">basil-antlr</a>: ANTLR generated components for BAP/GTIRB parsing.</li>
-        <li><a href="basil-proto">basil-proto</a>: Protobuffer generated components for the Grammatech GTIRB format.</li>
-        <li><a href="bnfc">bnfc</a>: BNFC generated components for Basil IR parsing.</li>
+        <li><a href="basil-antlr">basil-antlr</a>: ANTLR-generated components for BAP/GTIRB parsing.</li>
+        <li><a href="basil-proto">basil-proto</a>: Protobuffer-generated components for the Grammatech GTIRB format.</li>
+        <li>
+          <a href="bnfc">bnfc</a>: BNFC-generated code for Basil IL parsing.
+          <ul style="margin-bottom: 0px;">
+            <li>
+              <a href="../docs/basil-il/BasilIR.html">basil-il</a>: Basil IL language specification
+              (<a href="../docs/basil-il/BasilIR.pdf">PDF view</a>).
+            </li>
+          </ul>
+        </li>
         <li><a href="java-cup">java-cup</a>: Java CUP documentation (re-hosted).</li>
       </ul>
     </main>


### PR DESCRIPTION
This processes the BNFC grammar through its Latex output and converts that to HTML using lwarp. This is added to the Basil docs website.

This makes the docs building process more complicated, since it needs texlive. The Github Actions are split up to factor out the apt installations. The test workflow now invokes the docs.yml workflow.

![image](https://github.com/user-attachments/assets/c86ec24a-b76c-4754-929f-ebc91b014031)
