### PR TITLE
Mill command to run profiler

### DIFF
--- a/basilmill/mdbook.mill
+++ b/basilmill/mdbook.mill
@@ -14,6 +14,7 @@ trait mdbookBinary extends DownloadModule {
   def url = s"https://github.com/rust-lang/mdBook/releases/download/v${version}/mdbook-v${version}-${suffix}"
   def name = s"mdBook-$version-${System.currentTimeMillis()}$suffix"
   def mdbookSources : T[PathRef]
+  override def unzip = Some(TarGZ("mdbook"))
 
   def osName = System.getProperty("os.name")
 
@@ -38,15 +39,6 @@ trait mdbookBinary extends DownloadModule {
     s"${arch}-apple-darwin.tar.gz"
   } else {
     throw new Exception(s"unsupported os ${osName}")
-  }
-
-  override def path = Task {
-    local().getOrElse({
-      val l = remote(Task.dest)
-      os.call(Seq("tar", "-xzf", l.toString), cwd=Task.dest)
-      (Task.dest / "mdbook").toString
-    }
-    )
   }
 
   def run(args: String*) = Task.Command {

--- a/basilmill/profile.mill
+++ b/basilmill/profile.mill
@@ -1,0 +1,51 @@
+
+package build.basilmill
+
+import mill._
+
+import os.Path
+import scalalib._
+import scala.util.{Try}
+
+import $file.basilmill.util.DownloadModule
+
+
+trait ProfileRun extends ScalaModule with DownloadModule {
+
+  def url = s"https://github.com/async-profiler/async-profiler/releases/download/v${version}/async-profiler-${version}-$zipSuffix"
+  def name = "libasyncprofiler.so"
+  def version = "4.0"
+  def toUnpack = s"async-profiler-${version}-${folderSuffix}/lib/libasyncProfiler.so"
+
+  def arch = {
+    System.getProperty("os.arch") match {
+      case "amd64" => "x64"
+      case "aarch64" => "arm64"
+      case o => o
+    }
+  }
+
+  def osName = System.getProperty("os.name")
+  def zipSuffix = suffix.mkString(".")
+  def folderSuffix = suffix.head
+
+
+  def local = Task.Input {
+    Try(os.isFile(Task.workspace / toUnpack))
+      .map(Function.const(toUnpack))
+      .toEither
+      .left.map(_.toString)
+  }
+
+  def suffix = {
+    if (osName.contains("nux")) {
+      Seq(s"linux-${arch}", "tar.gz")
+    } else if (osName.contains("Mac")) {
+      Seq("macos", "zip")
+    } else {
+      throw new Exception(s"Profiling is only supported on linux, mac. Not : $osName")
+    }
+  }
+  override def unzip = Some(TarGZ(toUnpack))
+
+}

--- a/basilmill/util.mill
+++ b/basilmill/util.mill
@@ -18,6 +18,12 @@ trait DownloadModule extends Module {
   def name: String
   def url: String
   def local: Target[Either[String, String]]
+  def unzip: Option[Unzip] = None
+
+  sealed trait Unzip
+  case class TarGZ(extractedName: String) extends Unzip
+  case class Zip(extractedName: String) extends Unzip
+
 
   def mode = "rwxr-xr-x"
 
@@ -31,9 +37,21 @@ trait DownloadModule extends Module {
     p.toString
   }
 
+
   def pathref = Task(PathRef(Path(path())))
   def path = Task {
-    local().getOrElse(remote(Task.dest))
+    local().getOrElse({
+      val l = remote(Task.dest)
+      unzip.map {
+        case TarGZ(extractedName) => 
+          os.call(Seq("tar", "-xzf", l.toString), cwd=Task.dest)
+          PathRef(Task.dest / os.SubPath(extractedName)).path.toString
+        case Zip(extractedName) =>
+          os.call(Seq("unzip", l.toString), cwd=Task.dest)
+          PathRef(Task.dest / os.SubPath(extractedName)).path.toString
+      }.getOrElse(l)
+    })
+    
   }
   // using path() as the originator (instead of pathref())
   // allows us to return values which are not absolute paths

--- a/build.mill
+++ b/build.mill
@@ -7,6 +7,7 @@ import scalalib._
 import $file.basilmill.mdbook.mdbookBinary
 import $file.basilmill.bnfc.BNFCJFlexModule
 import $file.basilmill.antlr.AntlrModule
+import $file.basilmill.profile.ProfileRun
 
 import os.Path
 
@@ -302,5 +303,14 @@ object `package` extends RootModule with ScalaModule {
     os.move(newFile, tagsFile, replaceExisting = true, atomicMove = true)
   }
 
+  object asyncProf extends ProfileRun {
+    override def scalaVersion = build.scalaVersion
+  }
+
+  def runProfile(profileDest: String, args: String*) = Task.Command {
+    println(s"Profiling: you may want to set\n  sudo sysctl kernel.perf_event_paranoid=1\n  sudo sysctl kernel.kptr_restrict=0\n")
+    val prof = asyncProf.path()
+    os.call(("java", s"-agentpath:${prof}=start,event=cpu,file=${profileDest}",  "-jar", assembly().path.toString, args), stdout = os.Inherit, cwd = Task.workspace)
+  }
 
 }

--- a/docs/src/development/profiling.md
+++ b/docs/src/development/profiling.md
@@ -12,11 +12,18 @@ Alternatively, [async-profiler](https://github.com/async-profiler/async-profiler
 [flame graph](https://brendangregg.com/flamegraphs.html) showing the hot-spots in the program. Download the library from 
 the [releases tab](https://github.com/async-profiler/async-profiler/releases), compile a basil .jar with `mill assembly` and run the jar with the following arguments.
 
-Instructions for Linux and Mac:
+We have a mill task which works on Linux and Mac to download and run the assembly with async-profiler.
+
+```
+$ ./mill runProfile --profileDest profile.html -i examples/cntlm-noduk/cntlm-noduk.gts
+```
+
+Manual instructions for Linux and Mac:
+
 
 ```sh
 mill assembly
-java -agentpath:$YOUR_PATH/async-profiler-2.9-linux-x64/build/libasyncProfiler.so=start,event=cpu,file=profile.html -Xmx8G -jar out/assembly.dest/out.jar -i examples/cntlm-new/cntlm-new.adt -r examples/cntlm-new/cntlm-new.relf --analyse;
+java -agentpath:$YOUR_PATH/async-profiler-2.9-linux-x64/build/libasyncProfiler.so=start,event=cpu,file=profile.html -Xmx8G -jar out/assembly.dest/out.jar -i examples/cntlm-new/cntlm-noduk.gts -r examples/cntlm-noduk/cntlm-noduk.relf;
 firefox profile.html
 ```
 


### PR DESCRIPTION
This enables downloading and invoking basil with async-profiler through mill.

It should support Linux and mac, though I don't have a mac to test on.

```
./mill runProfile --profileDest profile.html -i examples/cntlm-noduk/cntlm-noduk.gts
```