### PR TITLE
Loop invariant generation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Basil IR](development/basil-ir.md) Explanation of BASIL's intermediate representation
 - [Interpreter](development/interpreter.md) Explanation of IR interpreter
 - [Transform Passes](development/transforms.md) Explanation of ir transforms and simplifications
+- [Program annotations](development/summaries-invariants.md) Explanation of loop invariant and function summary generators
 
 # Development
 

--- a/docs/src/development/summaries-invariants.md
+++ b/docs/src/development/summaries-invariants.md
@@ -1,0 +1,97 @@
+# Abstract interpretation with predicates
+
+## Predicates
+
+- see [src/main/scala/analysis/procedure_summaries/Predicate.scala](https://github.com/UQ-PAC/BASIL/blob/main/src/main/scala/analysis/procedure_summaries/Predicate.scala)
+
+Predicates encode semantic information about program states.
+They are distinct to IR boolean expressions as they can explicitly encode information about the gammas of variables.
+The intended use of predicates is for representing the result of static analyses used for creating assertions, assumptions, requires clauses or ensures clauses in generated boogie code.
+As such, predicates can be translated into boogie expressions.
+
+## Predicate domains
+
+Predicate encoding domains (defined in [/src/main/scala/analysis/procedure_summaries/Predicate.scala](https://github.com/UQ-PAC/BASIL/blob/main/src/main/scala/analysis/procedure_summaries/Predicate.scala)) are abstract domains which can represent their results as predicates.
+```scala
+trait PredicateEncodingDomain[L] extends AbstractDomain[L] {
+  def toPred(x: L): Predicate
+  // ...
+}
+```
+There is a necessary soundness condition so that the generated predicates are compatable with the transfer function of a domain.
+- For forward analyses, we require that applying `toPred` then `sp` is stronger than applying the transfer function then `toPred`.
+- For backward analyses, we require that applying `toPred` then `wp` is stronger than applying the transfer function then `toPred`.
+Here `sp` refers to the strongest postcondition and `wp` refers to the weakest precondition (or perhaps wpIFRG).
+
+# Function summary generation
+
+TODO
+
+# Loop invariant generation
+
+In order for some procedures to verify it may be necessary for loop invariants to be annotated.
+Take the following program for example.
+```c
+int main() {
+    int x = 0;
+    while (x < 100) {
+        x++;
+    }
+    if (x != 100) {
+        violate_security_requirements();
+    }
+}
+```
+Without a loop invariant this program may not verify as it may be impossible to prove that `x == 100` after the loop.
+We use static analysis methods to generate loop invariants.
+For example, the loop invariant `0 <= x <= 100` can be inferred using an interval analysis.
+
+## Loop invariants in CFGs
+
+BASIL programs are not represented in a denotational way but instead with a control flow graph.
+This means that loops are not a fundamental construct and instead must be identified.
+A loop of the form
+```c
+// ...
+while (c) {
+    // ...
+}
+// ...
+```
+will be translated into a CFG that looks like the following.
+```
+           Before loop
+             ┌─────┐
+             │ ... │
+             └─────┘
+                │
+                v
+            Loop header
+           ┌───────────┐
+    ┌──────│ assert j; │<───┐
+    │      └───────────┘    │
+    │            │          │
+    v            v          │
+After loop   Loop body      │
+  ┌─────┐     ┌─────┐       │
+  │ ... │     │ ... │───────┘
+  └─────┘     └─────┘
+```
+We can encode a loop invariant as an assertion in the loop header.
+Indeed doing so encodes the requirements that the loop invariant is ensured on entry and maintained by the loop, and also encodes that the loop invariant will hold at the start of the loop body and after the loop.
+
+## Abstract interpretation for loop invariants
+
+- see [src/main/scala/analysis/InvariantGenerator.scala](https://github.com/UQ-PAC/BASIL/blob/main/src/main/scala/analysis/InvariantGenerator.scala)
+
+Any predicate encoding domain  can be used to generate loop invariants.
+The result of an analysis on some procedure will be a mapping from blocks to lattice elements.
+If the analysis is a forwards analysis, the predicate representation of the value at a block will be a property that always holds at the end of the block.
+For backwards analyses, it will instead be a property that holds at the start of the block.
+
+The `FullLoopInvariantGenerator` class performs a sequence of analyses and adds their results to the end or start of loop heads depending on if the analysis is a forwards or backwards analysis.
+To add to this list, create either a `ForwardLoopInvariantGenerator` or `BackwardLoopInvariantGenerator` object and call its `genAndAddInvariants` method.
+These singular generators take a domain as input, along with a solver to allow for using a solver which does not require either widening or narrowing.
+
+To run the loop invariant generator, run basil with `--analyse --generate-loop-invariants` and without `--no-irreducibleloops`.
+The `--analyse` flag is necessary at the moment for loop header detection.

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -172,10 +172,7 @@ object Main {
     threadSplit: Flag,
     @arg(name = "parameter-form", doc = "Lift registers to local variables passed by parameter")
     parameterForm: Flag,
-    @arg(
-      name = "summarise-procedures",
-      doc = "Generates summaries of procedures which are used in pre/post-conditions"
-    )
+    @arg(name = "summarise-procedures", doc = "Generates summaries of procedures which are used in pre/post-conditions")
     summariseProcedures: Flag,
     @arg(
       name = "generate-loop-invariants",

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -179,7 +179,7 @@ object Main {
     summariseProcedures: Flag,
     @arg(
       name = "generate-loop-invariants",
-      doc = "Generates loop invariants on loop headers (requires --analyse flag)"
+      doc = "Generates loop invariants on loop headers (requires --analyse flag without --no-irreducible-loops)"
     )
     generateLoopInvariants: Flag,
     @arg(

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -174,9 +174,14 @@ object Main {
     parameterForm: Flag,
     @arg(
       name = "summarise-procedures",
-      doc = "Generates summaries of procedures which are used in pre/post-conditions (requires --analyse flag)"
+      doc = "Generates summaries of procedures which are used in pre/post-conditions"
     )
     summariseProcedures: Flag,
+    @arg(
+      name = "generate-loop-invariants",
+      doc = "Generates loop invariants on loop headers (requires --analyse flag)"
+    )
+    generateLoopInvariants: Flag,
     @arg(
       name = "generate-rely-guarantees",
       doc = "Generates rely-guarantee conditions for each procedure that contains a return node."
@@ -353,6 +358,7 @@ object Main {
       simplify = conf.simplify.value,
       validateSimp = conf.validateSimplify.value,
       summariseProcedures = conf.summariseProcedures.value,
+      generateLoopInvariants = conf.generateLoopInvariants.value,
       generateRelyGuarantees = conf.generateRelyGuarantees.value,
       staticAnalysis = staticAnalysis,
       boogieTranslation = boogieGeneratorConfig,

--- a/src/main/scala/analysis/Domains.scala
+++ b/src/main/scala/analysis/Domains.scala
@@ -31,7 +31,7 @@ class PredProductDomain[L1, L2](d1: PredicateEncodingDomain[L1], d2: PredicateEn
     extends ProductDomain[L1, L2](d1, d2)
     with PredicateEncodingDomain[(L1, L2)] {
 
-  def toPred(x: (L1, L2)): Predicate = Predicate.and(d1.toPred(x._1), d2.toPred(x._2))
+  def toPred(x: (L1, L2)): Predicate = Predicate.and(d1.toPred(x._1), d2.toPred(x._2)).simplify
 
   override def fromPred(p: Predicate): (L1, L2) = (d1.fromPred(p), d2.fromPred(p))
 }

--- a/src/main/scala/analysis/InvariantGenerator.scala
+++ b/src/main/scala/analysis/InvariantGenerator.scala
@@ -1,13 +1,16 @@
 package analysis
 
-import util.StaticAnalysisLogger as Logger
-
-import ir.transforms.{reversePostOrder, IntraproceduralWorklistSolver, NarrowingWorklistSolver}
 import ir.*
+import ir.transforms.{IntraproceduralWorklistSolver, NarrowingWorklistSolver, reversePostOrder}
+import util.StaticAnalysisLogger as Logger
 
 /** Performs a single analysis to generate loop invariants.
  */
-class SingleLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](domain: A, solver: IntraproceduralWorklistSolver[L, A], backwards: Boolean) {
+class SingleLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](
+  domain: A,
+  solver: IntraproceduralWorklistSolver[L, A],
+  backwards: Boolean
+) {
   def generateInvariants(procedure: Procedure): Map[Block, Predicate] = {
     val (startResults, endResults) = solver.solveProc(procedure, backwards)
 
@@ -20,8 +23,15 @@ class SingleLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](domain: A
   }
 }
 
-class ForwardLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](domain: A, solver: IntraproceduralWorklistSolver[L, A]) extends SingleLoopInvariantGenerator(domain, solver, false)
-class BackwardLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](domain: A, solver: IntraproceduralWorklistSolver[L, A]) extends SingleLoopInvariantGenerator(domain, solver, true)
+class ForwardLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](
+  domain: A,
+  solver: IntraproceduralWorklistSolver[L, A]
+) extends SingleLoopInvariantGenerator(domain, solver, false)
+
+class BackwardLoopInvariantGenerator[L, A <: PredicateEncodingDomain[L]](
+  domain: A,
+  solver: IntraproceduralWorklistSolver[L, A]
+) extends SingleLoopInvariantGenerator(domain, solver, true)
 
 /** Runs a collection of analyses to produce loop invariants, then inserts them into the IR.
  */
@@ -34,9 +44,10 @@ class FullLoopInvariantGenerator(program: Program) {
     Logger.debug(procedure)
     reversePostOrder(procedure)
     val intervalDomain = DoubleIntervalDomain(Some(procedure))
-    val intervalInvariantGenerator = ForwardLoopInvariantGenerator(intervalDomain, NarrowingWorklistSolver(intervalDomain))
-    intervalInvariantGenerator.generateInvariants(procedure).foreach {
-      (block, pred) => {
+    val intervalInvariantGenerator =
+      ForwardLoopInvariantGenerator(intervalDomain, NarrowingWorklistSolver(intervalDomain))
+    intervalInvariantGenerator.generateInvariants(procedure).foreach { (block, pred) =>
+      {
         Logger.debug(block)
         Logger.debug(pred)
         block.postconditions += pred

--- a/src/main/scala/analysis/InvariantGenerator.scala
+++ b/src/main/scala/analysis/InvariantGenerator.scala
@@ -2,7 +2,7 @@ package analysis
 
 import util.StaticAnalysisLogger as Logger
 
-import ir.transforms.worklistSolver
+import ir.transforms.{reversePostOrder, worklistSolver}
 import ir.*
 
 /** Performs a single analysis to generate loop invariants.
@@ -32,6 +32,7 @@ class FullLoopInvariantGenerator(program: Program) {
 
   def addInvariantsToProc(procedure: Procedure) = {
     Logger.debug(procedure)
+    reversePostOrder(procedure)
     val intervalInvariantGenerator = ForwardLoopInvariantGenerator(DoubleIntervalDomain(Some(procedure)))
     intervalInvariantGenerator.generateInvariants(procedure).foreach {
       (block, pred) => {

--- a/src/main/scala/analysis/InvariantGenerator.scala
+++ b/src/main/scala/analysis/InvariantGenerator.scala
@@ -1,0 +1,44 @@
+package analysis
+
+import util.StaticAnalysisLogger as Logger
+
+import ir.transforms.worklistSolver
+import ir.*
+
+/** Performs a single analysis to generate loop invariants.
+ */
+class SingleLoopInvariantGenerator[L](domain: PredicateEncodingDomain[L], backwards: Boolean) {
+  def generateInvariants(procedure: Procedure): Map[Block, Predicate] = {
+    val (startResults, endResults) = worklistSolver(domain).solveProc(procedure, backwards)
+
+    Logger.debug(endResults)
+
+    (backwards match {
+      case false => endResults
+      case true => startResults
+    }).flatMap((block, l) => if block.isLoopHeader() then Some((block, domain.toPred(l))) else None)
+  }
+}
+
+class ForwardLoopInvariantGenerator[L](domain: PredicateEncodingDomain[L]) extends SingleLoopInvariantGenerator[L](domain, false)
+class BackwardLoopInvariantGenerator[L](domain: PredicateEncodingDomain[L]) extends SingleLoopInvariantGenerator[L](domain, true)
+
+/** Runs a collection of analyses to produce loop invariants, then inserts them into the IR.
+ */
+class FullLoopInvariantGenerator(program: Program) {
+  def addInvariants() = {
+    program.procedures.foreach(addInvariantsToProc(_))
+  }
+
+  def addInvariantsToProc(procedure: Procedure) = {
+    Logger.debug(procedure)
+    val intervalInvariantGenerator = ForwardLoopInvariantGenerator(DoubleIntervalDomain(Some(procedure)))
+    intervalInvariantGenerator.generateInvariants(procedure).foreach {
+      (block, pred) => {
+        Logger.debug(block)
+        Logger.debug(pred)
+        block.postconditions += pred
+      }
+    }
+  }
+}

--- a/src/main/scala/analysis/LatticeCollections.scala
+++ b/src/main/scala/analysis/LatticeCollections.scala
@@ -306,6 +306,8 @@ trait MapDomain[D, L] extends AbstractDomain[LatticeMap[D, L]] {
 
   def widenTerm(a: L, b: L, pos: Block): L = joinTerm(a, b, pos)
 
+  def narrowTerm(a: L, b: L): L = a
+
   def botTerm: L
   def topTerm: L
 
@@ -320,19 +322,43 @@ trait MapDomain[D, L] extends AbstractDomain[LatticeMap[D, L]] {
       case (_, Top()) => Top()
       case (BottomMap(a), BottomMap(b)) =>
         BottomMap(a.foldLeft(b) { case (m, (b, v)) =>
-          m + (b -> widenTerm(m.getOrElse(b, botTerm), v, pos))
+          m + (b -> widenTerm(v, m.getOrElse(b, botTerm), pos))
         })
       case (BottomMap(a), TopMap(b)) =>
         TopMap(a.foldLeft(b) { case (m, (b, v)) =>
-          m + (b -> widenTerm(m.getOrElse(b, botTerm), v, pos))
+          m + (b -> widenTerm(v, m.getOrElse(b, botTerm), pos))
         })
       case (TopMap(a), BottomMap(b)) =>
         TopMap(b.foldLeft(a) { case (m, (a, v)) =>
-          m + (a -> widenTerm(v, m.getOrElse(a, botTerm), pos))
+          m + (a -> widenTerm(m.getOrElse(a, botTerm), v, pos))
         })
       case (TopMap(a), TopMap(b)) =>
         TopMap(a.foldLeft(b) { case (m, (b, v)) =>
-          m + (b -> widenTerm(m.getOrElse(b, botTerm), v, pos))
+          m + (b -> widenTerm(v, m.getOrElse(b, botTerm), pos))
+        })
+    }
+
+  override def narrow(a: LatticeMap[D, L], b: LatticeMap[D, L]): LatticeMap[D, L] =
+    (a, b) match {
+      case (Bottom(), b) => b
+      case (a, Bottom()) => a
+      case (Top(), _) => Top()
+      case (_, Top()) => Top()
+      case (BottomMap(a), BottomMap(b)) =>
+        BottomMap(a.foldLeft(b) { case (m, (b, v)) =>
+          m + (b -> narrowTerm(v, m.getOrElse(b, botTerm)))
+        })
+      case (BottomMap(a), TopMap(b)) =>
+        TopMap(a.foldLeft(b) { case (m, (b, v)) =>
+          m + (b -> narrowTerm(v, m.getOrElse(b, botTerm)))
+        })
+      case (TopMap(a), BottomMap(b)) =>
+        TopMap(b.foldLeft(a) { case (m, (a, v)) =>
+          m + (a -> narrowTerm(m.getOrElse(a, botTerm), v))
+        })
+      case (TopMap(a), TopMap(b)) =>
+        TopMap(a.foldLeft(b) { case (m, (b, v)) =>
+          m + (b -> narrowTerm(v, m.getOrElse(b, botTerm)))
         })
     }
 

--- a/src/main/scala/analysis/NumericalDomains.scala
+++ b/src/main/scala/analysis/NumericalDomains.scala
@@ -80,9 +80,7 @@ class IntervalDomain(
     b: LatticeMap[Variable, Interval],
     pos: Block
   ): LatticeMap[Variable, Interval] =
-    if pos.isLoopHeader()
-    then widen(super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v))), b, pos)
-    else super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v)))
+    super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v)))
 
 
   override def widenTerm(a: Interval, b: Interval, pos: Block): Interval =
@@ -91,11 +89,18 @@ class IntervalDomain(
         throw Exception("Widening intervals of mismatching bitvector sizes")
       case (ConcreteInterval(l1, u1, w1), ConcreteInterval(l2, u2, w2)) if w1 == w2 =>
         ConcreteInterval(if l1 <= l2 then l1 else negInf(w1), if u1 >= u2 then u1 else inf(w1), w1)
-      case (Bottom, ConcreteInterval(l2, u2, w2)) =>
-        ???
-      case (ConcreteInterval(l1, u1, w1), Bottom) =>
-        ???
       case (a, b) => joinTerm(a, b, pos)
+    }
+
+  override def narrowTerm(a: Interval, b: Interval): Interval =
+    (a, b) match {
+      case (ConcreteInterval(l1, u1, w1), ConcreteInterval(l2, u2, w2)) if w1 != w2 =>
+        throw Exception("Widening intervals of mismatching bitvector sizes")
+      case (ConcreteInterval(l1, u1, w1), ConcreteInterval(l2, u2, w2)) if w1 == w2 =>
+        ConcreteInterval(if l1 == negInf(w1) then l2 else l1, if u1 == inf(w1) then u2 else u1, w1)
+      case (Bottom, ConcreteInterval(l2, u2, w2)) => Bottom
+      case (ConcreteInterval(l1, u1, w1), Bottom) => Bottom
+      case (a, b) => a
     }
 
   def transfer(b: LatticeMap[Variable, Interval], c: Command): LatticeMap[Variable, Interval] = {

--- a/src/main/scala/analysis/NumericalDomains.scala
+++ b/src/main/scala/analysis/NumericalDomains.scala
@@ -82,7 +82,6 @@ class IntervalDomain(
   ): LatticeMap[Variable, Interval] =
     super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v)))
 
-
   override def widenTerm(a: Interval, b: Interval, pos: Block): Interval =
     (a, b) match {
       case (ConcreteInterval(l1, u1, w1), ConcreteInterval(l2, u2, w2)) if w1 != w2 =>

--- a/src/main/scala/analysis/NumericalDomains.scala
+++ b/src/main/scala/analysis/NumericalDomains.scala
@@ -91,7 +91,11 @@ class IntervalDomain(
         throw Exception("Widening intervals of mismatching bitvector sizes")
       case (ConcreteInterval(l1, u1, w1), ConcreteInterval(l2, u2, w2)) if w1 == w2 =>
         ConcreteInterval(if l1 <= l2 then l1 else negInf(w1), if u1 >= u2 then u1 else inf(w1), w1)
-      case (a, b) => joinTerm(a, b, pos) // TODO?
+      case (Bottom, ConcreteInterval(l2, u2, w2)) =>
+        ???
+      case (ConcreteInterval(l1, u1, w1), Bottom) =>
+        ???
+      case (a, b) => joinTerm(a, b, pos)
     }
 
   def transfer(b: LatticeMap[Variable, Interval], c: Command): LatticeMap[Variable, Interval] = {

--- a/src/main/scala/analysis/NumericalDomains.scala
+++ b/src/main/scala/analysis/NumericalDomains.scala
@@ -80,7 +80,10 @@ class IntervalDomain(
     b: LatticeMap[Variable, Interval],
     pos: Block
   ): LatticeMap[Variable, Interval] =
-    super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v)))
+    if pos.isLoopHeader()
+    then widen(super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v))), b, pos)
+    else super.join(a, b, pos).filter((v, i) => liveBefore.exists(_(pos).contains(v)))
+
 
   override def widenTerm(a: Interval, b: Interval, pos: Block): Interval =
     (a, b) match {

--- a/src/main/scala/analysis/procedure_summaries/Predicate.scala
+++ b/src/main/scala/analysis/procedure_summaries/Predicate.scala
@@ -827,13 +827,13 @@ def exprToPredicate(e: Expr): Option[Predicate] = e match {
  * A domain with a conversion between abstract states and predicates.
  *
  * Abstractly, we can define a concretisation function from the set of predicates to the concrete domain, giving the set of states that satisfy the predicate.
- * For soundness, ensure that
+ * For soundness, ensure that (TODO? this may be wrong, maybe this should be written in terms of wp and sp)
  * - for may analyses, gamma_p (toPred(l)) \supset gamma_a(l) for all l of type L
  *                 and gamma_a (fromPred(p)) \supset gamma_p(p) for all predicates p
  * - for must analyses, gamma_p (toPred(l)) \subset gamma_a(l) for all l of type L
  *                 and gamma_a (fromPred(p)) \subset gamma_p(p) for all predicates p
  * where gamma_p is the predicate concretisation function and gamma_a is the domain concretisation function.
- * Intuitively, the predicate should be an approximation of the abstract state, cannot soundly be more precise than the domain itself.
+ * Intuitively, the predicate should be an approximation of the abstract state, and cannot soundly be more precise than the domain itself.
  */
 trait PredicateEncodingDomain[L] extends AbstractDomain[L] {
 

--- a/src/main/scala/analysis/procedure_summaries/Predicate.scala
+++ b/src/main/scala/analysis/procedure_summaries/Predicate.scala
@@ -20,6 +20,8 @@ enum BVTerm {
   case ZeroExtend(extension: Int, body: BVTerm)
   case SignExtend(extension: Int, body: BVTerm)
 
+  // TODO width correctness
+
   private var simplified: Boolean = false
 
   override def toString(): String = this.toBoogie.toString()

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -1,6 +1,6 @@
 package ir
 
-import analysis.{Loop, MergedRegion}
+import analysis.{Loop, MergedRegion, Predicate}
 import boogie.*
 import translating.PrettyPrinter.*
 import util.functional.Snoc
@@ -603,6 +603,9 @@ class Block private (
 
   statements.onInsert = x => x.setParent(this)
   statements.onRemove = x => x.deParent()
+
+  var preconditions: mutable.ArrayBuffer[Predicate] = mutable.ArrayBuffer()
+  var postconditions: mutable.ArrayBuffer[Predicate] = mutable.ArrayBuffer()
 
   def this(
     label: String,

--- a/src/main/scala/ir/transforms/AbsInt.scala
+++ b/src/main/scala/ir/transforms/AbsInt.scala
@@ -126,6 +126,7 @@ trait ProcedureSummaryGenerator[L, LocalDomain] extends ProcAbstractDomain[L] {
   *   The abstract domain implementing the analysis
   */
 trait IntraproceduralWorklistSolver[L, A <: AbstractDomain[L]](domain: A, widen: Boolean, narrow: Boolean) {
+
   /** Perform the analysis on a procedure and return the resulting lattice values for each block.
     *
     * @param p
@@ -261,7 +262,8 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) extends Intraprocedur
   * @param domain:
   *   The abstract domain implementing the analysis
   */
-class WideningWorklistSolver[L, A <: AbstractDomain[L]](domain: A) extends IntraproceduralWorklistSolver(domain, true, false)
+class WideningWorklistSolver[L, A <: AbstractDomain[L]](domain: A)
+    extends IntraproceduralWorklistSolver(domain, true, false)
 
 /** Intraprocedural worklist solver that widens and narrows on loop heads.
   *
@@ -274,7 +276,8 @@ class WideningWorklistSolver[L, A <: AbstractDomain[L]](domain: A) extends Intra
   * @param domain:
   *   The abstract domain implementing the analysis
   */
-class NarrowingWorklistSolver[L, A <: AbstractDomain[L]](domain: A) extends IntraproceduralWorklistSolver(domain, true, true)
+class NarrowingWorklistSolver[L, A <: AbstractDomain[L]](domain: A)
+    extends IntraproceduralWorklistSolver(domain, true, true)
 
 /** Perform an interprocedural analysis by running an intraprocedural analysis on each procedure, computing a summary
   * based on the result, and computing the fixed point of summaries over the call graph.

--- a/src/main/scala/ir/transforms/AbsInt.scala
+++ b/src/main/scala/ir/transforms/AbsInt.scala
@@ -114,7 +114,7 @@ trait ProcedureSummaryGenerator[L, LocalDomain] extends ProcAbstractDomain[L] {
   ): L
 }
 
-/** Intraprocedural worklist solver.
+/** A general worklist solver which optionally supports widening and narrowing on loop heads.
   *
   * Traverses blocks in reverse-post-order so requires [[rpoOrder()]] to have been run on the procedure.
   *
@@ -125,8 +125,7 @@ trait ProcedureSummaryGenerator[L, LocalDomain] extends ProcAbstractDomain[L] {
   * @param domain:
   *   The abstract domain implementing the analysis
   */
-class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
-
+trait IntraproceduralWorklistSolver[L, A <: AbstractDomain[L]](domain: A, widen: Boolean, narrow: Boolean) {
   /** Perform the analysis on a procedure and return the resulting lattice values for each block.
     *
     * @param p
@@ -167,7 +166,10 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
         mutable.PriorityQueue[Block]()(Ordering.by(b => b.rpoOrder))
       }
     }
-    worklist.addAll(initial)
+    val initial2 = initial.iterator.to(List)
+    worklist.addAll(initial2)
+
+    var narrowing = false
 
     def successors(b: Block) = if backwards then b.prevBlocks else b.nextBlocks
     def predecessors(b: Block) = if backwards then b.nextBlocks else b.prevBlocks
@@ -190,11 +192,14 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
 
       val prev = savedAfter.get(b)
       val x = {
-        predecessors(b).toList.flatMap(b => savedAfter.get(b).toList) match {
+        val y = predecessors(b).toList.flatMap(b => savedAfter.get(b).toList) match {
           case Nil => domain.init(b)
           case h :: Nil => h
           case h :: tl => tl.foldLeft(h)((acc, nb) => domain.join(acc, nb, b))
         }
+        if narrowing && b.isLoopHeader() then domain.narrow(savedBefore.getOrElse(b, domain.bot), y)
+        else if widen && b.isLoopHeader() then domain.widen(savedBefore.getOrElse(b, domain.bot), y, b)
+        else y
       }
       savedBefore(b) = x
       val todo = List(b)
@@ -221,10 +226,55 @@ class worklistSolver[L, A <: AbstractDomain[L]](domain: A) {
         }
         worklist.addAll(successors(lastBlock))
       }
+
+      if (narrow && !narrowing && worklist.isEmpty) {
+        worklist.addAll(initial2)
+        narrowing = true
+      }
     }
+
     if backwards then (savedAfter.toMap, savedBefore.toMap) else (savedBefore.toMap, savedAfter.toMap)
   }
 }
+
+/** Intraprocedural worklist solver.
+  *
+  * Traverses blocks in reverse-post-order so requires [[rpoOrder()]] to have been run on the procedure.
+  *
+  * @tparam L:
+  *   the lattice value type
+  * @tparam A:
+  *   The abstract domain defining the analysis using lattice value [[L]]
+  * @param domain:
+  *   The abstract domain implementing the analysis
+  */
+class worklistSolver[L, A <: AbstractDomain[L]](domain: A) extends IntraproceduralWorklistSolver(domain, false, false)
+
+/** Intraprocedural worklist solver that widens on loop heads.
+  *
+  * Traverses blocks in reverse-post-order so requires [[rpoOrder()]] to have been run on the procedure.
+  *
+  * @tparam L:
+  *   the lattice value type
+  * @tparam A:
+  *   The abstract domain defining the analysis using lattice value [[L]]
+  * @param domain:
+  *   The abstract domain implementing the analysis
+  */
+class WideningWorklistSolver[L, A <: AbstractDomain[L]](domain: A) extends IntraproceduralWorklistSolver(domain, true, false)
+
+/** Intraprocedural worklist solver that widens and narrows on loop heads.
+  *
+  * Traverses blocks in reverse-post-order so requires [[rpoOrder()]] to have been run on the procedure.
+  *
+  * @tparam L:
+  *   the lattice value type
+  * @tparam A:
+  *   The abstract domain defining the analysis using lattice value [[L]]
+  * @param domain:
+  *   The abstract domain implementing the analysis
+  */
+class NarrowingWorklistSolver[L, A <: AbstractDomain[L]](domain: A) extends IntraproceduralWorklistSolver(domain, true, true)
 
 /** Perform an interprocedural analysis by running an intraprocedural analysis on each procedure, computing a summary
   * based on the result, and computing the fixed point of summaries over the call graph.

--- a/src/main/scala/translating/IRToBoogie.scala
+++ b/src/main/scala/translating/IRToBoogie.scala
@@ -617,6 +617,8 @@ class IRToBoogie(
   def translateBlock(b: Block): BBlock = {
     val initLabel = b.meta.originalLabel.map(" (" + _ + ")").getOrElse("")
     val captureState = captureStateStatement(s"${b.label}${initLabel}")
+    val preconditions = b.preconditions.map(p => BAssert(p.toBoogie))
+    val postconditions = b.postconditions.map(p => BAssert(p.toBoogie))
 
     val statements = if (b.atomicSection.isDefined) {
       val before = if (b.atomicSection.get.isStart(b)) {
@@ -634,7 +636,7 @@ class IRToBoogie(
       b.statements.flatMap(s => translate(s, false))
     }
 
-    val cmds = List(captureState) ++ statements ++ translate(b.jump)
+    val cmds = List(captureState) ++ preconditions ++ statements ++ postconditions ++ translate(b.jump)
 
     BBlock(b.label, cmds)
   }

--- a/src/main/scala/util/BASILConfig.scala
+++ b/src/main/scala/util/BASILConfig.scala
@@ -57,6 +57,7 @@ case class BASILConfig(
   validateSimp: Boolean = false,
   dsaConfig: Option[DSAConfig] = None,
   summariseProcedures: Boolean = false,
+  generateLoopInvariants: Boolean = false,
   generateRelyGuarantees: Boolean = false,
   memoryTransform: Boolean = false,
   assertCalleeSaved: Boolean = false,

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -353,6 +353,10 @@ object IRTransform {
     modified
   }
 
+  def generateLoopInvariants(IRProgram: Program) = {
+    FullLoopInvariantGenerator(IRProgram).addInvariants()
+  }
+
   def generateRelyGuaranteeConditions(threads: List[Procedure]): Unit = {
     /* Todo: For the moment we are printing these to stdout, but in future we'd
     like to add them to the IR. */
@@ -949,9 +953,9 @@ object RunUtils {
       IRTransform.generateProcedureSummaries(ctx, ctx.program, q.loading.parameterForm || conf.simplify)
     }
 
-    if (conf.summariseProcedures) {
-      StaticAnalysisLogger.info("[!] Generating Procedure Summaries")
-      IRTransform.generateProcedureSummaries(ctx, ctx.program, q.loading.parameterForm || conf.simplify)
+    if (conf.staticAnalysis.nonEmpty && conf.generateLoopInvariants) {
+      StaticAnalysisLogger.info("[!] Generating Loop Invariants")
+      IRTransform.generateLoopInvariants(ctx.program)
     }
 
     if (q.runInterpret) {

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -953,7 +953,7 @@ object RunUtils {
       IRTransform.generateProcedureSummaries(ctx, ctx.program, q.loading.parameterForm || conf.simplify)
     }
 
-    if (conf.staticAnalysis.nonEmpty && conf.generateLoopInvariants) {
+    if (conf.staticAnalysis.exists(_.irreducibleLoops) && conf.generateLoopInvariants) {
       StaticAnalysisLogger.info("[!] Generating Loop Invariants")
       IRTransform.generateLoopInvariants(ctx.program)
     }

--- a/src/test/scala/LoopInvariantTests.scala
+++ b/src/test/scala/LoopInvariantTests.scala
@@ -2,7 +2,7 @@ import analysis.*
 import ir.*
 import ir.dsl.*
 import org.scalatest.funsuite.AnyFunSuite
-import test_util.{BASILTest, CaptureOutput}
+import test_util.CaptureOutput
 import util.IRTransform
 
 @test_util.tags.UnitTest
@@ -26,11 +26,17 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
      * assert x == 100; */
 
     val program = prog(
-      proc("main",
+      proc(
+        "main",
         block("entry", LocalAssign(R0, bv64(0)), goto("loop_head")),
         block("loop_head", goto("loop_body", "loop_exit")),
-        block("loop_body", Assume(BinaryExpr(BVULT, R0, bv64(100))), LocalAssign(R0, BinaryExpr(BVADD, R0, bv64(1))), goto("loop_head")),
-        block("loop_exit", Assume(BinaryExpr(BVUGE, R0, bv64(100))), Assert(BinaryExpr(EQ, R0, bv64(100))), ret),
+        block(
+          "loop_body",
+          Assume(BinaryExpr(BVULT, R0, bv64(100))),
+          LocalAssign(R0, BinaryExpr(BVADD, R0, bv64(1))),
+          goto("loop_head")
+        ),
+        block("loop_exit", Assume(BinaryExpr(BVUGE, R0, bv64(100))), Assert(BinaryExpr(EQ, R0, bv64(100))), ret)
       )
     )
 
@@ -38,18 +44,20 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
 
     val main = program.nameToProcedure("main")
 
-    main.blocks.foreach( b => {
+    main.blocks.foreach(b => {
       if (b.label == "loop_head") {
         assert(b.isLoopHeader())
 
         // TODO use an SMT solver to check that the generated invariant implies our expected result instead of using syntactic equality.
 
-        assert(b.postconditions.toList == List(
-          Predicate.and(
-            Predicate.BVCmp(BVULE, BVTerm.Lit(bv64(0)), BVTerm.Var(R0)),
-            Predicate.BVCmp(BVULE, BVTerm.Var(R0), BVTerm.Lit(bv64(100)))
+        assert(
+          b.postconditions.toList == List(
+            Predicate.and(
+              Predicate.BVCmp(BVULE, BVTerm.Lit(bv64(0)), BVTerm.Var(R0)),
+              Predicate.BVCmp(BVULE, BVTerm.Var(R0), BVTerm.Lit(bv64(100)))
+            )
           )
-        ))
+        )
       } else {
         assert(!b.isLoopHeader())
       }

--- a/src/test/scala/LoopInvariantTests.scala
+++ b/src/test/scala/LoopInvariantTests.scala
@@ -30,7 +30,7 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
         block("entry", LocalAssign(R0, bv64(0)), goto("loop_head")),
         block("loop_head", goto("loop_body", "loop_exit")),
         block("loop_body", Assume(BinaryExpr(BVULT, R0, bv64(100))), LocalAssign(R0, BinaryExpr(BVADD, R0, bv64(1))), goto("loop_head")),
-        block("loop_exit", Assume(BinaryExpr(BVUGE, R0, bv64(100))), Assert(BinaryExpr(BVEQ, R0, bv64(100))), ret),
+        block("loop_exit", Assume(BinaryExpr(BVUGE, R0, bv64(100))), Assert(BinaryExpr(EQ, R0, bv64(100))), ret),
       )
     )
 
@@ -44,7 +44,7 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
 
         // TODO use an SMT solver to check that the generated invariant implies our expected result instead of using syntactic equality.
 
-        assert(List(b.postconditions) == List(
+        assert(b.postconditions.toList == List(
           Predicate.and(
             Predicate.BVCmp(BVULE, BVTerm.Lit(bv64(0)), BVTerm.Var(R0)),
             Predicate.BVCmp(BVULE, BVTerm.Var(R0), BVTerm.Lit(bv64(100)))
@@ -55,9 +55,6 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
       }
     })
 
-    print(program)
-
     // TODO assert x == 100 with boogie
-    assert(false)
   }
 }

--- a/src/test/scala/LoopInvariantTests.scala
+++ b/src/test/scala/LoopInvariantTests.scala
@@ -51,7 +51,7 @@ class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
         // TODO use an SMT solver to check that the generated invariant implies our expected result instead of using syntactic equality.
 
         assert(
-          b.postconditions.toList == List(
+          b.postconditions.contains(
             Predicate.and(
               Predicate.BVCmp(BVULE, BVTerm.Lit(bv64(0)), BVTerm.Var(R0)),
               Predicate.BVCmp(BVULE, BVTerm.Var(R0), BVTerm.Lit(bv64(100)))

--- a/src/test/scala/LoopInvariantTests.scala
+++ b/src/test/scala/LoopInvariantTests.scala
@@ -1,0 +1,63 @@
+import analysis.*
+import ir.*
+import ir.dsl.*
+import org.scalatest.funsuite.AnyFunSuite
+import test_util.{BASILTest, CaptureOutput}
+import util.IRTransform
+
+@test_util.tags.UnitTest
+class LoopInvariantTests extends AnyFunSuite, CaptureOutput {
+  def genInvariants(program: Program) = {
+    val foundLoops = LoopDetector.identify_loops(program)
+    val newLoops = foundLoops.reducibleTransformIR().identifiedLoops
+    foundLoops.updateIrWithLoops()
+
+    IRTransform.generateLoopInvariants(program)
+  }
+
+  test("boundedLoop") {
+    /* x = 0;
+     * while (x < 100)
+     *   // we hope to find this invariant with an interval analysis
+     *   invariant 0 <= x <= 100 // (or x in [0, 100])
+     * {
+     *   x++;
+     * }
+     * assert x == 100; */
+
+    val program = prog(
+      proc("main",
+        block("entry", LocalAssign(R0, bv64(0)), goto("loop_head")),
+        block("loop_head", goto("loop_body", "loop_exit")),
+        block("loop_body", Assume(BinaryExpr(BVULT, R0, bv64(100))), LocalAssign(R0, BinaryExpr(BVADD, R0, bv64(1))), goto("loop_head")),
+        block("loop_exit", Assume(BinaryExpr(BVUGE, R0, bv64(100))), Assert(BinaryExpr(BVEQ, R0, bv64(100))), ret),
+      )
+    )
+
+    genInvariants(program)
+
+    val main = program.nameToProcedure("main")
+
+    main.blocks.foreach( b => {
+      if (b.label == "loop_head") {
+        assert(b.isLoopHeader())
+
+        // TODO use an SMT solver to check that the generated invariant implies our expected result instead of using syntactic equality.
+
+        assert(List(b.postconditions) == List(
+          Predicate.and(
+            Predicate.BVCmp(BVULE, BVTerm.Lit(bv64(0)), BVTerm.Var(R0)),
+            Predicate.BVCmp(BVULE, BVTerm.Var(R0), BVTerm.Lit(bv64(100)))
+          )
+        ))
+      } else {
+        assert(!b.isLoopHeader())
+      }
+    })
+
+    print(program)
+
+    // TODO assert x == 100 with boogie
+    assert(false)
+  }
+}


### PR DESCRIPTION
Implements a loop invariant generation template. Abstract domains that are able to encode their results as predicates (so boogie assertions) can be used to get loop invariants by looking at the value of an analysis result at loop headers. Adding a new analysis to the list is simple (see `analysis/InvariantGenerator.scala`).

```scala
  def addInvariantsToProc(procedure: Procedure) = {
    reversePostOrder(procedure)

    val intervals = DoubleIntervalDomain(Some(procedure))
    ForwardLoopInvariantGenerator(intervals, NarrowingWorklistSolver(intervals)).genAndAddInvariants(procedure)

    val gammas = MayGammaDomain(
      LatticeMap.TopMap(procedure.formalInParam.unsorted.map(v => (v, LatticeSet.FiniteSet(Set(v)))).toMap)
    )
    ForwardLoopInvariantGenerator(gammas, worklistSolver(gammas)).genAndAddInvariants(procedure)

    // Add more domains here
  }
```

A test case for generating constant loop bounds needed correct widening and narrowing to give an optimal invariant, so the worklist solver was extended to support this. I am unsure if I did this in the best way so I'd appreciate it if someone could give their thoughts.