### PR TITLE
procedure params: avoid assuming return block defined

### DIFF
--- a/src/main/scala/ir/transforms/ProcedureParameters.scala
+++ b/src/main/scala/ir/transforms/ProcedureParameters.scala
@@ -474,7 +474,7 @@ def inOutParams(
       val writes = readWrites(proc).writes
 
       val newOut = origOut ++ (if (proc == p.mainProcedure) then Seq() else lives(proc)._2.intersect(writes))
-      val liveFromReturn = newOut.filter(reachesEntry(_, proc.returnBlock.get.jump))
+      val liveFromReturn = newOut.filter(i => proc.returnBlock.map(b => reachesEntry(i, b.jump)).getOrElse(true))
 
       // filtering by reaching entry does not seem to have much effect
       val extraLive = (liveFromReturn ++ liveFromCall)


### PR DESCRIPTION
Don't use `Option.get`: fix for https://github.com/UQ-PAC/BASIL/issues/480

The function that hits the error is our old friend `errorFn`, which does not return. 

```
proc @errorFn_1964 () -> (_PC_out:bv64)
  { .name = "errorFn"; .address = 0x7ac }
[
  block %errorFn_entry [
    goto(%errorFn_loop1_3);
  ];
  block %errorFn_loop1_3 {.address = 0x7ac; .originalLabel = "wK9NYU4TTr+D8gXPiCk+7w=="} [
    goto(%errorFn_loop1_3);
  ]
];
```

