### PR TITLE
add nix-cc.sh for quickly cross-compiling and lifting examples

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Information Flow Logic](infoflow-logic.md)
 - [Usage](usage.md) Basil binary lifting & usage guide
+  - [Quickly lifting a new example](quick-lifting.md)
 - [Compiler Explorer](compiler-explorer.md) guide to the compiler explorer basil interface
 
 # Basil IR Source Code

--- a/docs/src/quick-lifting.md
+++ b/docs/src/quick-lifting.md
@@ -1,0 +1,107 @@
+# Quickly lifting a new example
+
+This page describes [`nix-cc.sh`](https://github.com/UQ-PAC/BASIL/blob/main/scripts/nix-cc.sh),
+a quick method to compile and lift a new example for use with the Basil toolchain.
+This script automates the steps described in [usage.md](usage.md) and automatically
+fetches the required tools from the [pac-nix](https://github.com/katrinafyi/pac-nix/)
+repository.
+
+`nix-cc.sh` requires a directory of C source file(s), and it produce:
+- a compiled aarch64-linux ELF binary,
+- a readelf output,
+- an objdump output,
+- a GTIRB and gtirb-semantics output, and
+- a JSON-formatted version of the gtirb-semantics output.
+
+This includes all the files needed for Basil (namely, the gtirb-semantics and readelf outputs),
+along with some extra files which might be useful for inspecting the compiled program.
+
+## Introduction
+
+The script lives inside the scripts/ folder of the Basil repository.
+It is a Bash script which should work on both Linux and Mac OS.
+**Nix is required**.
+
+To use the script, simply pass a directory of C files and an output directory:
+```bash
+scripts/nix-cc.sh src/test/correct/arrays_simple /tmp/basil-out
+```
+The first time you run the script, it will take some time to fetch the cross-compilers
+for aarch64-linux. Subsequent runs will be much faster. This will also use about 5 GB of disk space.
+
+Once the script finishes, you can point Basil at the output directory using `--load-directory-gtirb`.
+```bash
+./mill run --load-directory-gtirb /tmp/basil-out/a.gts
+```
+Be sure to include the a.gts file, otherwise the files will not be found correctly.
+
+## Command-line arguments
+
+```
+usage: scripts/nix-cc.sh [--help] INPUTDIR OUTPUTDIR [COMMAND...]
+
+compiles C programs to aarch64-linux binaries and lifts them
+using tools provided by the pac-nix repository.
+
+this will create the files a.out a.relf a.gtirb a.gts a.json a.objdump
+in the OUTPUTDIR.
+
+positional arguments:
+  INPUTDIR     input directory (this will be copied! make sure it is not too big)
+  OUTPUTDIR    output directory to place binary and lifted files
+  COMMAND      custom compiler command and arguments. this should produce an
+                   'a.out' file (available compilers: gcc, clang)
+                   (default: gcc with all C files in directory)
+```
+
+## Example output
+
+Here is an excerpt of the output:
+```bash
+fetching github input 'github:katrinafyi/pac-nix'
+this derivation will be built:
+  /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-basil-test-files.drv
+building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-basil-test-files.drv'...
++++ cp -r /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-arrays_simple/. .
++++ ls
+arrays_simple.c  clang  config.mk  env-vars
++++ : BUILDING WITH COMMAND:
++++ aarch64-unknown-linux-gnu-gcc arrays_simple.c
++++ : ... DONE BUILDING.
++++ aarch64-unknown-linux-gnu-readelf -s -r -W a.out
++++ aarch64-unknown-linux-gnu-objdump -d a.out
++++ ddisasm a.out --ir a.gtirb
+Building the initial gtirb representation [   0ms]
+Processing module: a.out
+    disassembly              load [   1ms]    compute [   5ms]  transform [   0ms]
+    SCC analysis                              compute [   0ms]  transform [   0ms]
+    no return analysis       load [   0ms]    compute [   0ms]  transform [   0ms]
+    function inference       load [   0ms]    compute [   0ms]  transform [   0ms]
++++ gtirb-semantics a.gtirb a.gts
+Lifting
+Successfully lifted 107 instructions in 2.776012 sec (2.774692 user time) (0 failure: 0 unique opcodes) (0.00
+0000 cache hit rate)
++++ proto-json.py --auxdata yes a.gts a.json
++++ cp -r a.out a.relf a.gtirb a.gts a.json a.objdump /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-basil-test-
+files
+'a.gtirb' -> '/tmp/basil-out/a.gtirb'
+'a.gts' -> '/tmp/basil-out/a.gts'
+'a.json' -> '/tmp/basil-out/a.json'
+'a.objdump' -> '/tmp/basil-out/a.objdump'
+'a.out' -> '/tmp/basil-out/a.out'
+'a.relf' -> '/tmp/basil-out/a.relf'
+```
+
+## Important notes
+
+- The entire input directory will be copied, so it's best to make it small - only containing
+  the files relevant to the example you want.
+  If you pass a directory with too many files, this will consume more disk space.
+- The script will produce output files with non-specific names (such as a.out).
+  Be aware of this when choosing the output directory.
+- Built binaries will live in the Nix store, taking up disk space. To remove old files,
+  you can use `nix-store --gc`.
+- Nix does caching of builds. If you run the script multiple times without changing the
+  input directory, it may skip the bulid entirely. The (cached) output will still be copied
+  into the output directory.
+

--- a/docs/src/quick-lifting.md
+++ b/docs/src/quick-lifting.md
@@ -7,7 +7,7 @@ fetches the required tools from the [pac-nix](https://github.com/katrinafyi/pac-
 repository.
 
 `nix-cc.sh` requires a directory of C source file(s), and it produce:
-- a compiled aarch64-linux ELF binary,
+- a cross-compiled aarch64-linux ELF binary,
 - a readelf output,
 - an objdump output,
 - a GTIRB and gtirb-semantics output, and
@@ -15,6 +15,11 @@ repository.
 
 This includes all the files needed for Basil (namely, the gtirb-semantics and readelf outputs),
 along with some extra files which might be useful for inspecting the compiled program.
+
+Compared to other methods, nix-cc.sh is
+- self-contained and isolated in a sandbox, which should ensure consistency across platforms,
+- correctly configured with the aarch64 C libraries, and
+- it runs natively on your computer, so it should be faster than emulation or virtual machines.
 
 ## Introduction
 
@@ -79,11 +84,9 @@ Processing module: a.out
     function inference       load [   0ms]    compute [   0ms]  transform [   0ms]
 +++ gtirb-semantics a.gtirb a.gts
 Lifting
-Successfully lifted 107 instructions in 2.776012 sec (2.774692 user time) (0 failure: 0 unique opcodes) (0.00
-0000 cache hit rate)
+Successfully lifted 107 instructions in 2.776012 sec (2.774692 user time) (0 failure: 0 unique opcodes) (0.00 0000 cache hit rate)
 +++ proto-json.py --auxdata yes a.gts a.json
-+++ cp -r a.out a.relf a.gtirb a.gts a.json a.objdump /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-basil-test-
-files
++++ cp -r a.out a.relf a.gtirb a.gts a.json a.objdump /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-basil-test-files
 'a.gtirb' -> '/tmp/basil-out/a.gtirb'
 'a.gts' -> '/tmp/basil-out/a.gts'
 'a.json' -> '/tmp/basil-out/a.json'

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -30,7 +30,7 @@ instructions are given [here](development/readme.md) as to how to add new tests.
 The instructions below are for if you want to use the BASIL tool with new binary files.
 
 BASIL takes as input:
-- a .gts file, containing the ddisasm CFG and the ASLp semantics, 
+- a .gts file, containing the ddisasm CFG and the ASLp semantics,
 - a .relf file, containing the symbol table, and
 - (optionally) a .spec file containing manually-written specifications
   (see [the secret\_write.spec][spec] for an example).
@@ -39,6 +39,8 @@ The steps below describe the dependencies required,
 then the steps to obtain these input files
 and run BASIL.
 
+**See also:** [Quickly lifting a new example](quick-lifting.md)
+
 <!-- These instructions are automated in [lift.sh](../../scripts/lift.sh). -->
 
 [tests]: /src/test/correct
@@ -46,8 +48,8 @@ and run BASIL.
 
 ### Requirements
 
-These instructions assume a Linux-GNU OS, BASIL itself will happily run on Windows, 
-and the lifting machinery is known to work under WSL. 
+These instructions assume a Linux-GNU OS, BASIL itself will happily run on Windows,
+and the lifting machinery is known to work under WSL.
 
 - AArch64 cross-compilation toolchain (e.g. GCC or clang)
 - AArch64 readelf (e.g. `aarch64-linux-gnu-readelf`)
@@ -78,7 +80,7 @@ See also: [development: building](development/readme.md#building)
 ### Preparation
 
 1. Compile a C program into an Aarch64 binary, for example:
-   
+
    ```bash
    aarch64-linux-gnu-gcc x.c
    ```
@@ -143,7 +145,7 @@ See also: [development: building](development/readme.md#building)
      }
    },
    ```
-   
+
 4. Obtain the symbol table with readelf.
    ```
    aarch64-linux-gnu-readelf -s -r -W a.out > a.relf
@@ -174,12 +176,12 @@ boogie /useArrayAxioms out.bpl
 
 The `/useArrayAxioms` flag is necessary for Boogie versions 2.16.8 and greater;
 for earlier versions it can be removed.
-This improves the verification speed by using Boogie's axiomatic encoding of arrays rather than Z3's. 
-The axiomatic encoding is faster (1) because it does not support extensionality, and (2) because it sacrifices completeness. 
-This makes the most difference in SAT (non-verifying) cases. 
+This improves the verification speed by using Boogie's axiomatic encoding of arrays rather than Z3's.
+The axiomatic encoding is faster (1) because it does not support extensionality, and (2) because it sacrifices completeness.
+This makes the most difference in SAT (non-verifying) cases.
 We don't have reason to believe array extensionality is necessary for any of our proofs.
 
-If using the built-in array theories, Z3's array extensionality reasoning can be disabled by 
+If using the built-in array theories, Z3's array extensionality reasoning can be disabled by
 passing the `smt.array.extensional=false` configuration to Z3 through Boogie's CLI:
 
 ```

--- a/scripts/nix-cc.sh
+++ b/scripts/nix-cc.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+prog="$0"
+
+usage() {
+  cat <<EOF
+usage: $prog [--help] INPUTDIR OUTPUTDIR [COMMAND...]
+
+compiles C programs to aarch64-linux binaries and lifts them
+using tools provided by the pac-nix repository.
+
+this will create the files a.out a.relf a.gtirb a.gts a.json a.objdump
+in the OUTPUTDIR.
+
+positional arguments:
+  INPUTDIR     input directory (this will be copied! make sure it is not too big)
+  OUTPUTDIR    output directory to place binary and lifted files
+  COMMAND      custom compiler command and arguments. this should produce an
+                   'a.out' file (available compilers: gcc, clang)
+                   (default: gcc with all C files in directory)
+EOF
+  exit $1
+}
+
+die() {
+  echo $2 >&2
+  exit ${1:-1}
+}
+
+xrealpath() {
+  # https://stackoverflow.com/a/3915420
+  echo $(cd $(dirname $1); pwd)/$(basename $1)
+}
+
+xmktemp() {
+  # https://ss64.com/mac/mktemp.html
+  mktemp -t tmp.XXXXXXXXXX
+}
+
+command -v nix >/dev/null|| die 1 "nix is required"
+
+if [[ "$@" == *'--help'* ]]; then
+  usage 0
+fi
+
+if [[ "$#" -lt 2 ]]; then
+  usage 1 >&2
+fi
+
+set -eu
+set -o pipefail
+
+inputdir="$(xrealpath $1)"
+outputdir="$(xrealpath $2)"
+shift
+shift
+command="${@:-gcc *.c}"
+
+outfile=$(xmktemp)
+
+nix-build --extra-experimental-features "nix-command flakes" --no-out-link - <<EOF > $outfile
+  let
+    pkgs = (builtins.getFlake "github:katrinafyi/pac-nix").lib.nixpkgs;
+    aarch64pkgs = pkgs.pkgsCross.aarch64-multiplatform;
+  in aarch64pkgs.runCommand "basil-test-files" {
+      nativeBuildInputs = [
+        aarch64pkgs.buildPackages.gcc
+        aarch64pkgs.buildPackages.clang
+        pkgs.ddisasm
+        pkgs.gtirb-semantics
+      ];
+    } ''
+      alias gcc=aarch64-unknown-linux-gnu-gcc
+      alias clang=aarch64-unknown-linux-gnu-clang
+      shopt -s expand_aliases
+      mkdir \$out
+      (set -x;
+        cp -r \${$inputdir}/. .
+        ls
+        : BUILDING WITH COMMAND:
+        $command
+        : ... DONE BUILDING.
+        aarch64-unknown-linux-gnu-readelf -s -r -W a.out > a.relf
+        aarch64-unknown-linux-gnu-objdump -d a.out > a.objdump
+        ddisasm a.out --ir a.gtirb
+        gtirb-semantics a.gtirb a.gts
+        proto-json.py --auxdata yes a.gts a.json
+        cp -r a.out a.relf a.gtirb a.gts a.json a.objdump \$out
+      )
+    ''
+EOF
+
+nixout="$(cat $outfile)"
+[[ -n "$nixout" ]] || die 2 "nix build did not print an output path?"
+
+# copy files into given outputdir and add writable permissions.
+# we cannot use --no-preserve=mode because macos doesn't have that.
+mkdir -p $outputdir
+cd $nixout
+
+files=(*)
+cp -rv "${files[@]}" $outputdir
+cd $outputdir
+chmod u+rw "${files[@]}"

--- a/scripts/nix-cc.sh
+++ b/scripts/nix-cc.sh
@@ -84,7 +84,7 @@ nix-build --extra-experimental-features "nix-command flakes" --no-out-link - <<E
         aarch64-unknown-linux-gnu-objdump -d a.out > a.objdump
         ddisasm a.out --ir a.gtirb
         gtirb-semantics a.gtirb a.gts
-        proto-json.py --auxdata yes a.gts a.json
+        proto-json.py --auxdata a.gts a.json
         cp -r a.out a.relf a.gtirb a.gts a.json a.objdump \$out
       )
     ''


### PR DESCRIPTION

This PR adds `nix-cc.sh`, a quick method to compile and lift a new example
for use with the Basil toolchain.
This script automates the steps described in [usage.md](usage.md) and automatically
fetches the required tools from the [pac-nix](https://github.com/katrinafyi/pac-nix/) repository.