### PR TITLE
ci: remove tmate hook

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Compile BASIL Mill
         run: ./mill compile
-      - if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
 
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner


### PR DESCRIPTION
tmate lets you get a shell into the github actions runner. but it hangs the job until you connect or it times out