### PR TITLE
ci: add link checker using lychee

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,6 @@ jobs:
             --exclude '/scala-lang\.org/api/'
             --exclude '#L\d+$'
             --no-progress
-            --verbose
           fail: false
           failIfEmpty: true
           jobSummary: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,8 +47,10 @@ jobs:
             --no-progress
           fail: false
           failIfEmpty: true
-          jobSummary: true
+          jobSummary: false
       - run: cat lychee/out.md
+      - run: |
+          sed 's|${{ steps.allDocs.outputs.dir }}||g' lychee/out.md > "$GITHUB_STEP_SUMMARY"
 
   deploy-docs:
     if: github.ref_name == 'main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,36 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils
-      - run: ./mill --no-server allDocs
+      - run: |
+          ./mill --no-server allDocs
+          echo "dir=$(realpath out/allDocs.dest)" >> "$GITHUB_OUTPUT"
+        id: allDocs
+
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: out/allDocs.dest
+          path: ${{ steps.allDocs.outputs.dir }}
+
+      - run: npm i http-server
+      - run: node_modules/.bin/http-server . -d false & # -d false means no directory listing
+        working-directory: ${{ steps.allDocs.outputs.dir }}
+
+      - uses: lycheeverse/lychee-action@v2
+        working-directory: ${{ steps.allDocs.outputs.dir }}
+        with:
+          args: >
+            api --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
+          fail: true
+          failIfEmpty: true
+          jobSummary: true
+
+      - uses: lycheeverse/lychee-action@v2
+        working-directory: ${{ steps.allDocs.outputs.dir }}
+        with:
+          args: >
+            . --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
+          fail: false
+          failIfEmpty: true
+          jobSummary: true
 
   deploy-docs:
     if: github.ref_name == 'main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,23 +31,22 @@ jobs:
         with:
           path: ${{ steps.allDocs.outputs.dir }}
 
-      - run: npm i node-static
-      - run: node_modules/.bin/static ${{ steps.allDocs.outputs.dir }} &
-
       - uses: lycheeverse/lychee-action@v2
         with:
-          args: >
-            ${{ steps.allDocs.outputs.dir }}/api --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
-          fail: true
-          failIfEmpty: true
-          jobSummary: true
-
-      - uses: lycheeverse/lychee-action@v2
-        with:
-          args: >
-            ${{ steps.allDocs.outputs.dir }} --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
+          # last two --remap arguments will append index.html onto URLs with no extension
+          # NOTE: --remap only actions the /first/ matching regex
+          args: >-
+            ${{ steps.allDocs.outputs.dir }}
+            --fallback-extensions html,htm
+            --root-dir ${{ steps.allDocs.outputs.dir }}
+            --remap 'https://uq-pac.github.io/BASIL file://${{ steps.allDocs.outputs.dir }}'
+            --remap '(\.[a-zA-Z]+)$ $1'
+            --remap '$ $1/index.html'
+            --exclude '/scala-lang\.org/api/'
+            --exclude '#L\d+$'
           fail: false
           failIfEmpty: true
+          jobSummary: true
 
   deploy-docs:
     if: github.ref_name == 'main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,15 +33,15 @@ jobs:
 
       - uses: lycheeverse/lychee-action@v2
         with:
-          # last two --remap arguments will append index.html onto URLs with no extension
+          # last two --remap arguments will append index.html onto URLs with no extension (and allowing for # fragments)
           # NOTE: this relies on --remap only actioning the /first/ matching regex
           args: >-
             ${{ steps.allDocs.outputs.dir }}
             --fallback-extensions html,htm
             --root-dir ${{ steps.allDocs.outputs.dir }}
             --remap 'https://uq-pac.github.io/BASIL file://${{ steps.allDocs.outputs.dir }}'
-            --remap '(\.[a-zA-Z]+)$ $1'
-            --remap '$ $1/index.html'
+            --remap '(\.[a-z]+(#.*)?)$ $1'
+            --remap '^file:///.* $0/index.html'
             --exclude '/scala-lang\.org/api/'
             --exclude '#L\d+$'
             --no-progress

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,19 +36,17 @@ jobs:
         working-directory: ${{ steps.allDocs.outputs.dir }}
 
       - uses: lycheeverse/lychee-action@v2
-        working-directory: ${{ steps.allDocs.outputs.dir }}
         with:
           args: >
-            api --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
+            ${{ steps.allDocs.outputs.dir }}/api --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
           fail: true
           failIfEmpty: true
           jobSummary: true
 
       - uses: lycheeverse/lychee-action@v2
-        working-directory: ${{ steps.allDocs.outputs.dir }}
         with:
           args: >
-            . --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
+            ${{ steps.allDocs.outputs.dir }} --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
           fail: false
           failIfEmpty: true
           jobSummary: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,8 @@ jobs:
         with:
           path: ${{ steps.allDocs.outputs.dir }}
 
-      - run: npm i http-server
-      - run: node_modules/.bin/http-server . -d false & # -d false means no directory listing
-        working-directory: ${{ steps.allDocs.outputs.dir }}
+      - run: npm i node-static
+      - run: node_modules/.bin/static ${{ steps.allDocs.outputs.dir }} &
 
       - uses: lycheeverse/lychee-action@v2
         with:
@@ -49,7 +48,6 @@ jobs:
             ${{ steps.allDocs.outputs.dir }} --fallback-extensions html,htm --remap "file://${{ steps.allDocs.outputs.dir }} http://127.0.0.1:8080" --remap 'https://uq-pac.github.io/BASIL http://127.0.0.1:8080'
           fail: false
           failIfEmpty: true
-          jobSummary: true
 
   deploy-docs:
     if: github.ref_name == 'main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: lycheeverse/lychee-action@v2
         with:
           # last two --remap arguments will append index.html onto URLs with no extension
-          # NOTE: --remap only actions the /first/ matching regex
+          # NOTE: this relies on --remap only actioning the /first/ matching regex
           args: >-
             ${{ steps.allDocs.outputs.dir }}
             --fallback-extensions html,htm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,9 +44,12 @@ jobs:
             --remap '$ $1/index.html'
             --exclude '/scala-lang\.org/api/'
             --exclude '#L\d+$'
+            --no-progress
+            --verbose
           fail: false
           failIfEmpty: true
           jobSummary: true
+      - run: cat lychee/out.md
 
   deploy-docs:
     if: github.ref_name == 'main'

--- a/src/main/scala/gtirb/GTIRBReadELF.scala
+++ b/src/main/scala/gtirb/GTIRBReadELF.scala
@@ -83,7 +83,7 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
       ELFNDX.Section(i)
   }
 
-  def parseRela(kind: R_AARCH64_JUMP_SLOT.type | R_AARCH64_GLOB_DAT.type, rela: Elf64Rela): ExternalFunction =
+  def parseRelaExtFunc(rela: Elf64Rela): ExternalFunction =
     val sym = gtirb.getDynSym(rela.r_sym.toInt).get
     ExternalFunction(sym.name, rela.r_offset)
 
@@ -152,7 +152,7 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
       .withDefaultValue(Nil)
 
     val offs = relas(R_AARCH64_RELATIVE).map(parseRela(R_AARCH64_RELATIVE, _))
-    val exts = (relas(R_AARCH64_GLOB_DAT) ++ relas(R_AARCH64_JUMP_SLOT)).map(parseRela(R_AARCH64_JUMP_SLOT, _))
+    val exts = (relas(R_AARCH64_GLOB_DAT) ++ relas(R_AARCH64_JUMP_SLOT)).map(parseRelaExtFunc(_))
 
     (offs.toMap, exts.toSet)
   }


### PR DESCRIPTION
this checks for broken links across the github pages site and reports the broken links to the github actions summary.

see: https://lychee.cli.rs/

broken links are not configured to fail the ci build, but we could make it so if it's all cleaned up.