### PR TITLE
Use generated exprs to test expression evaluation against smt solver

### DIFF
--- a/src/main/scala/util/z3/z3process.scala
+++ b/src/main/scala/util/z3/z3process.scala
@@ -8,9 +8,17 @@ enum SatResult {
   case Unknown(s: String, errors: List[String])
 }
 
-def checkSATSMT2(smt: String, softTimeoutMillis: Option[Int] = None): SatResult = {
+def checkSATSMT2(smt: String, softTimeoutMillis: Option[Int] = None, timeoutSec: Option[Int] = None): SatResult = {
+  val t = timeoutSec match {
+    case Some(n) => Seq(s"-T:$n")
+    case _ => Seq()
+  }
+  val softT = softTimeoutMillis match {
+    case Some(n) => Seq(s"-t:$n")
+    case None => Seq()
+  }
   val cmd =
-    Seq("z3", "-smt2", "-in") ++ (if softTimeoutMillis.isDefined then Seq(s"-t:${softTimeoutMillis.get}") else Seq())
+    Seq("z3", "-smt2", "-in") ++ t ++ softT
   val output = (cmd #< ByteArrayInputStream(smt.getBytes("UTF-8"))).!!
   val errors = output.split("\n").filter(_.trim.startsWith("(error")).toList
   val outputStripped = output.stripLineEnd

--- a/src/test/scala/BitVectorSMTTest.scala
+++ b/src/test/scala/BitVectorSMTTest.scala
@@ -1,12 +1,18 @@
 import ir.*
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.*
 import org.scalatest.funsuite.*
+import test_util.{CaptureOutput, ExprGen}
 import translating.BasilIRToSMT2
 import translating.PrettyPrinter.*
+import util.Logger
 import util.z3.*
 
 @test_util.tags.UnitTest
-class BitVectorEvalTest extends AnyFunSuite {
+class BitVectorEvalTest
+    extends AnyFunSuite
+    with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+    with CaptureOutput {
 
   def genSMT(size: Int) = {
     val max = BitVecType(size).maxValue.toInt
@@ -67,5 +73,20 @@ class BitVectorEvalTest extends AnyFunSuite {
     }
   }
 
+  implicit lazy val arbExpr: Arbitrary[Expr] = Arbitrary(for {
+    sz <- Gen.oneOf(List(30, 31, 32, 33, 60, 63, 64, 65, 66, 70, 90, 128, 126))
+    e <- ExprGen.genExpr(Some(sz))
+  } yield (e))
+
+  test("interp exprs smt") {
+    forAll(minSuccessful(30)) { (exp: Expr) =>
+      val test = BinaryExpr(NEQ, exp, ir.eval.evaluateExpr(exp).get)
+      val q = BasilIRToSMT2.exprUnsat(test, None, false)
+      Logger.info("assert: " + test)
+      util.z3.checkSATSMT2(q, Some(30000)) == SatResult.UNSAT
+    }
+  }
+
   genSMT(2)
+
 }

--- a/src/test/scala/BitVectorSMTTest.scala
+++ b/src/test/scala/BitVectorSMTTest.scala
@@ -84,7 +84,6 @@ class BitVectorEvalTest
       val q = BasilIRToSMT2.exprUnsat(test, None, false)
       Logger.info("assert: " + test)
       assert(util.z3.checkSATSMT2(q, None, Some(5)) == SatResult.UNSAT)
-      false
     }
   }
 

--- a/src/test/scala/BitVectorSMTTest.scala
+++ b/src/test/scala/BitVectorSMTTest.scala
@@ -75,7 +75,7 @@ class BitVectorEvalTest
 
   implicit lazy val arbExpr: Arbitrary[Expr] = Arbitrary(for {
     sz <- Gen.oneOf(List(30, 31, 32, 33, 60, 63, 64, 65, 66, 70, 90, 128, 126))
-    e <- ExprGen.genExpr(Some(sz))
+    e <- ExprGen.genNonLiteralExpr(Some(sz))
   } yield (e))
 
   test("interp exprs smt") {
@@ -83,7 +83,8 @@ class BitVectorEvalTest
       val test = BinaryExpr(NEQ, exp, ir.eval.evaluateExpr(exp).get)
       val q = BasilIRToSMT2.exprUnsat(test, None, false)
       Logger.info("assert: " + test)
-      util.z3.checkSATSMT2(q, Some(30000)) == SatResult.UNSAT
+      assert(util.z3.checkSATSMT2(q, None, Some(5)) == SatResult.UNSAT)
+      false
     }
   }
 

--- a/src/test/scala/ExprGen.scala
+++ b/src/test/scala/ExprGen.scala
@@ -95,10 +95,10 @@ object ExprGen {
   }
 
   def genExpr(size: Option[Int] = None, depthLimit: Int = 10): Gen[Expr] =
-    if (size.exists(_ <= 1) || depthLimit <= 0) then genValue(size) else Gen.oneOf(genBinExp(size, depthLimit - 1), genUnExp(size), genValue(size))
+    if (size.exists(_ <= 1) || depthLimit <= 0) then genValue(size)
+    else Gen.oneOf(genBinExp(size, depthLimit - 1), genUnExp(size), genValue(size))
 
-  def genNonLiteralExpr(size: Option[Int] = None, depthLimit : Int = 3): Gen[Expr] =
+  def genNonLiteralExpr(size: Option[Int] = None, depthLimit: Int = 3): Gen[Expr] =
     if (size.exists(_ <= 1)) then genValue(size) else Gen.oneOf(genBinExp(size, depthLimit), genUnExp(size))
-
 
 }

--- a/src/test/scala/ExprGen.scala
+++ b/src/test/scala/ExprGen.scala
@@ -1,0 +1,100 @@
+package test_util
+import ir.*
+import org.scalacheck.Gen
+
+object ExprGen {
+
+  def arbBinOp =
+    Gen.oneOf(
+      BVAND,
+      BVOR,
+      BVADD,
+      BVMUL,
+      BVSHL,
+      BVLSHR,
+      BVNAND,
+      BVNOR,
+      BVXOR,
+      BVXNOR,
+      BVSUB,
+      BVASHR, // broken
+      BVUREM, // broken
+      BVSREM, // broken
+      BVSMOD, // broken
+      BVUDIV, // broken
+      BVSDIV // broken
+    )
+
+  def arbBinComp = Gen.oneOf(BVULE, BVUGT, BVULT, BVUGE, BVSLT, BVSLE, BVSGT, BVSGE, EQ, NEQ, BVCOMP)
+
+  def genValue(givenSize: Option[Int] = None) = for {
+    genSize <- Gen.chooseNum(1, 70)
+    size = givenSize.getOrElse(genSize)
+    maxVal = BitVecType(size).maxValue
+    value <- Gen.chooseNum(BigInt(0), maxVal)
+  } yield (BitVecLiteral(value, size))
+
+  def genUnExp(size: Option[Int] = None) = for {
+    v <- genValue(size)
+    op <- Gen.oneOf(BVNOT, BVNEG)
+  } yield (UnaryExpr(op, v))
+
+  def genExt(givenSize: Option[Int] = None) =
+    if givenSize.exists(_ < 1) then {
+      genValue(givenSize)
+    } else
+      for {
+        genSize <- Gen.chooseNum(1, 70)
+        size = givenSize.getOrElse(genSize)
+        amount <- Gen.chooseNum(0, size - 1)
+        sizeLeft = size - amount
+        v <- if (sizeLeft > 1) then genExpr(Some(sizeLeft)) else genValue(Some(sizeLeft))
+        vv <- genExpr(Some(amount))
+        op <- Gen.oneOf(ZeroExtend(amount, v), SignExtend(amount, v), BinaryExpr(BVCONCAT, v, vv))
+      } yield (op)
+
+  def genBinComp() = for {
+    op <- arbBinComp
+    genSize <- Gen.chooseNum(1, 70)
+    l <- genExpr(Some(genSize))
+    r <- genExpr(Some(genSize))
+  } yield (BinaryExpr(op, l, r))
+
+  def genBinExp(givenSize: Option[Int] = None): Gen[Expr] = {
+    def genBV(min: BigInt, max: BigInt, size: Int) = for {
+      v <- Gen.chooseNum(min, max)
+    } yield BitVecLiteral(v, size)
+    for {
+      genSize <- Gen.chooseNum(1, 70)
+      size = givenSize.getOrElse(genSize)
+      op <- Gen.oneOf(arbBinOp, arbBinComp)
+      maxVal = (BigInt(2).pow(size) - 1)
+      smallMax = maxVal.min(255)
+      rhs <- op match {
+        case BVSDIV => genBV(BigInt(1), maxVal, size)
+        case BVUDIV => genBV(BigInt(1), maxVal, size)
+        case BVSREM => genBV(BigInt(1), maxVal, size)
+        case BVSMOD => genBV(BigInt(1), maxVal, size)
+        case BVSHL => genBV(BigInt(0), smallMax, size)
+        case BVLSHR => genBV(BigInt(0), smallMax, size)
+        case BVASHR => genBV(BigInt(0), smallMax, size)
+        case _ => genExpr(Some(size))
+      }
+      lhs <- genExpr(Some(size))
+      expr = BinaryExpr(op, lhs, rhs)
+      nexpr <- expr.getType match {
+        case BoolType if size != 1 =>
+          Gen.oneOf(ZeroExtend(size - 1, UnaryExpr(BoolToBV1, expr)), SignExtend(size - 1, UnaryExpr(BoolToBV1, expr)))
+        case BoolType => Gen.const(UnaryExpr(BoolToBV1, expr))
+        case BitVecType(bvsz) if size > bvsz => Gen.oneOf(ZeroExtend(size - bvsz, expr), SignExtend(size - bvsz, expr))
+        case BitVecType(sz) if size == sz => Gen.const(expr)
+        case x => throw Exception(s"TYPE $x DOES NOT MATCH EXPECTED $size $expr")
+      }
+      // rhs <- Gen.chooseNum(BigInt(minBound), (BigInt(2).pow(sizeRhs) - 1))
+    } yield nexpr
+  }
+
+  def genExpr(size: Option[Int] = None): Gen[Expr] =
+    if (size.exists(_ <= 1)) then genValue(size) else Gen.oneOf(genBinExp(size), genUnExp(size), genValue(size))
+
+}

--- a/src/test/scala/TestKnownBitsInterpreter.scala
+++ b/src/test/scala/TestKnownBitsInterpreter.scala
@@ -6,7 +6,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.*
 import org.scalatest.funsuite.*
 import org.scalatestplus.scalacheck.*
-import test_util.TestValueDomainWithInterpreter
+import test_util.{ExprGen, TestValueDomainWithInterpreter}
 import translating.PrettyPrinter.*
 
 @test_util.tags.UnitTest
@@ -166,102 +166,9 @@ class TestKnownBitsInterpreter
     testInterpret(BigInt("ffffffffffffffff", 16), BigInt("ffffffffffffffff", 16))
   }
 
-  def arbBinOp =
-    Gen.oneOf(
-      BVAND,
-      BVOR,
-      BVADD,
-      BVMUL,
-      BVSHL,
-      BVLSHR,
-      BVNAND,
-      BVNOR,
-      BVXOR,
-      BVXNOR,
-      BVSUB,
-      BVASHR, // broken
-      BVUREM, // broken
-      BVSREM, // broken
-      BVSMOD, // broken
-      BVUDIV, // broken
-      BVSDIV // broken
-    )
-
-  def arbBinComp = Gen.oneOf(BVULE, BVUGT, BVULT, BVUGE, BVSLT, BVSLE, BVSGT, BVSGE, EQ, NEQ, BVCOMP)
-
-  def genValue(givenSize: Option[Int] = None) = for {
-    genSize <- Gen.chooseNum(1, 70)
-    size = givenSize.getOrElse(genSize)
-    maxVal = BitVecType(size).maxValue
-    value <- Gen.chooseNum(BigInt(0), maxVal)
-  } yield (BitVecLiteral(value, size))
-
-  def genUnExp(size: Option[Int] = None) = for {
-    v <- genValue(size)
-    op <- Gen.oneOf(BVNOT, BVNEG)
-  } yield (UnaryExpr(op, v))
-
-  def genExt(givenSize: Option[Int] = None) =
-    if givenSize.exists(_ < 1) then {
-      genValue(givenSize)
-    } else
-      for {
-        genSize <- Gen.chooseNum(1, 70)
-        size = givenSize.getOrElse(genSize)
-        amount <- Gen.chooseNum(0, size - 1)
-        sizeLeft = size - amount
-        v <- if (sizeLeft > 1) then genExpr(Some(sizeLeft)) else genValue(Some(sizeLeft))
-        vv <- genExpr(Some(amount))
-        op <- Gen.oneOf(ZeroExtend(amount, v), SignExtend(amount, v), BinaryExpr(BVCONCAT, v, vv))
-      } yield (op)
-
-  def genBinComp() = for {
-    op <- arbBinComp
-    genSize <- Gen.chooseNum(1, 70)
-    l <- genExpr(Some(genSize))
-    r <- genExpr(Some(genSize))
-  } yield (BinaryExpr(op, l, r))
-
-  def genBinExp(givenSize: Option[Int] = None): Gen[Expr] = {
-    def genBV(min: BigInt, max: BigInt, size: Int) = for {
-      v <- Gen.chooseNum(min, max)
-    } yield BitVecLiteral(v, size)
-    for {
-      genSize <- Gen.chooseNum(1, 70)
-      size = givenSize.getOrElse(genSize)
-      op <- Gen.oneOf(arbBinOp, arbBinComp)
-      maxVal = (BigInt(2).pow(size) - 1)
-      smallMax = maxVal.min(255)
-      rhs <- op match {
-        case BVSDIV => genBV(BigInt(1), maxVal, size)
-        case BVUDIV => genBV(BigInt(1), maxVal, size)
-        case BVSREM => genBV(BigInt(1), maxVal, size)
-        case BVSMOD => genBV(BigInt(1), maxVal, size)
-        case BVSHL => genBV(BigInt(0), smallMax, size)
-        case BVLSHR => genBV(BigInt(0), smallMax, size)
-        case BVASHR => genBV(BigInt(0), smallMax, size)
-        case _ => genExpr(Some(size))
-      }
-      lhs <- genExpr(Some(size))
-      expr = BinaryExpr(op, lhs, rhs)
-      nexpr <- expr.getType match {
-        case BoolType if size != 1 =>
-          Gen.oneOf(ZeroExtend(size - 1, UnaryExpr(BoolToBV1, expr)), SignExtend(size - 1, UnaryExpr(BoolToBV1, expr)))
-        case BoolType => Gen.const(UnaryExpr(BoolToBV1, expr))
-        case BitVecType(bvsz) if size > bvsz => Gen.oneOf(ZeroExtend(size - bvsz, expr), SignExtend(size - bvsz, expr))
-        case BitVecType(sz) if size == sz => Gen.const(expr)
-        case x => throw Exception(s"TYPE $x DOES NOT MATCH EXPECTED $size $expr")
-      }
-      // rhs <- Gen.chooseNum(BigInt(minBound), (BigInt(2).pow(sizeRhs) - 1))
-    } yield nexpr
-  }
-
-  def genExpr(size: Option[Int] = None): Gen[Expr] =
-    if (size.exists(_ <= 1)) then genValue(size) else Gen.oneOf(genBinExp(size), genUnExp(size), genValue(size))
-
   implicit lazy val arbExpr: Arbitrary[Expr] = Arbitrary(for {
     sz <- Gen.chooseNum(0, 70)
-    e <- genExpr(Some(sz))
+    e <- ExprGen.genExpr(Some(sz))
   } yield (e))
 
   def evaluateAbstract(e: Expr): TNum = TNumDomain().evaluateExprToTNum(Map(), e)

--- a/src/test/scala/TestKnownBitsInterpreter.scala
+++ b/src/test/scala/TestKnownBitsInterpreter.scala
@@ -168,7 +168,7 @@ class TestKnownBitsInterpreter
 
   implicit lazy val arbExpr: Arbitrary[Expr] = Arbitrary(for {
     sz <- Gen.chooseNum(0, 70)
-    e <- ExprGen.genExpr(Some(sz))
+    e <- ExprGen.genNonLiteralExpr(Some(sz))
   } yield (e))
 
   def evaluateAbstract(e: Expr): TNum = TNumDomain().evaluateExprToTNum(Map(), e)


### PR DESCRIPTION
Reuses the scalacheck-based expr generator to test the interpreter against z3 with more complex expressions:

```
- interp exprs smt
  + [INFO]   assert: neq(sign_extend(62, bvcomp(bvand(bvudiv(bvnot(0x0:bv63), 0x1:bv63), 0x7fffffffffffffff:bv63), 0x0:bv63)), 0x0:bv63) 
  + [INFO]   assert: neq(bvnand(0x15e32bf08bbb32fbcf:bv70, 0x1a00f75631050b732d:bv70), 0x2fffdcaffefefd8cf2:bv70) 
  + [INFO]   assert: neq(bvnot(0x19b5ae9950e0e6cf316dc7b480b9ea8f:bv128), 0xe64a5166af1f1930ce92384b7f461570:bv128) 
  + [INFO]   assert: neq(zero_extend(62, booltobv1(bvule(0x1:bv63, 0x0:bv63))), 0x0:bv63) 
  + [INFO]   assert: neq(bvsmod(bvneg(0x1:bv31), 0x7fffffff:bv31), 0x0:bv31) 
  + [INFO]   assert: neq(bvnot(0x1:bv33), 0x1fffffffe:bv33) 
  + [INFO]   assert: neq(bvnot(0x1:bv70), 0x3ffffffffffffffffe:bv70) 
  + [INFO]   assert: neq(bvnot(0x0:bv60), 0xfffffffffffffff:bv60) 
  + [INFO]   assert: neq(bvneg(0x1:bv70), 0x3fffffffffffffffff:bv70) 
  + [INFO]   assert: neq(zero_extend(30, booltobv1(bvsle(0x69b19af1:bv31, bvnot(0x1f793f2e:bv31)))), 0x0:bv31) 
  + [INFO]   assert: neq(bvshl(sign_extend(89, booltobv1(bvuge(0x3ffffffffffffffffffffff:bv90, 0x2f68ea76c42885ff0c88b73:bv90))), 0x36:bv90), 0x3ffffffffc0000000000000:bv90) 
  + [INFO]   assert: neq(zero_extend(30, booltobv1(bvuge(sign_extend(30, booltobv1(bvuge(0x1e5c3fde:bv31, 0x2db1d16d:bv31))), 0x3677dc24:bv31))), 0x0:bv31) 
  + [INFO]   assert: neq(zero_extend(32, booltobv1(bvule(bvudiv(bvneg(0x0:bv33), 0x1:bv33), bvneg(0x1ffffffff:bv33)))), 0x1:bv33) 
  + [INFO]   assert: neq(bvnot(0x3766a351d19a7bc29005d934c8fcd504:bv126), 0x8995cae2e65843d6ffa26cb37032afb:bv126) 
  + [INFO]   assert: neq(zero_extend(31, bvcomp(0xffffffff:bv32, bvnor(bvneg(0x1:bv32), 0x99c9e959:bv32))), 0x0:bv32) 
  + [INFO]   assert: neq(bvneg(0x1b28bc4a:bv31), 0x64d743b6:bv31) 
  + [INFO]   assert: neq(bvneg(0x0:bv32), 0x0:bv32) 
  + [INFO]   assert: neq(sign_extend(59, booltobv1(bvult(0xfb24180c63f4525:bv60, 0xfffffffffffffff:bv60))), 0xfffffffffffffff:bv60) 
  + [INFO]   assert: neq(bvneg(0x0:bv33), 0x0:bv33) 
  + [INFO]   assert: neq(bvnot(0x0:bv128), 0xffffffffffffffffffffffffffffffff:bv128) 
  + [INFO]   assert: neq(bvlshr(sign_extend(59, booltobv1(bvsge(bvnot(0x880b8e6f8e11f8:bv60), bvlshr(0x25aa40786bf3cdc:bv60, 0x1:bv60)))), 0xd6:bv60), 0x0:bv60) 
  + [INFO]   assert: neq(bvsdiv(bvneg(0x2899bb9d09f3db10bafec32:bv90), 0x3ffffffffffffffffffffff:bv90), 0x2899bb9d09f3db10bafec32:bv90) 
  + [INFO]   assert: neq(bvneg(0x395dda0f03f38d333:bv66), 0x6a225f0fc0c72ccd:bv66) 
  + [INFO]   assert: neq(bvxor(bvnot(0x0:bv65), bvnot(0xfa98ca06c1f394b1:bv65)), 0xfa98ca06c1f394b1:bv65) 
  + [INFO]   assert: neq(bvneg(0x0:bv64), 0x0:bv64) 
  + [INFO]   assert: neq(bvneg(0xfc564e010da8d8de2bcafc0be1cd2ca2:bv128), 0x3a9b1fef2572721d43503f41e32d35e:bv128) 
  + [INFO]   assert: neq(sign_extend(31, booltobv1(bvult(bvnot(0x0:bv32), bvashr(0xb7fc0d74:bv32, 0x1:bv32)))), 0x0:bv32) 
  + [INFO]   assert: neq(sign_extend(125, booltobv1(bvult(0x1c1420a28cbe4d2ff5fe8c84371b8c78:bv126, bvneg(0x3efb140cc8e88070a548614899a189b6:bv126)))), 0x0:bv126) 
  + [INFO]   assert: neq(bvxnor(sign_extend(63, bvcomp(bvnand(0xffffffffffffffff:bv64, bvneg(0x0:bv64)), 0x3b6c08abd2135a4e:bv64)), bvor(0xb694a734c9dc99bd:bv64, bvnot(0x97e2c00a92ef616e:bv64))), 0x162400a12236042:bv64) 
  + [INFO]   assert: neq(bvneg(0x28ade1bb:bv30), 0x17521e45:bv30) 

```