### PR TITLE
nix-cc.sh: fix usage when given a path with spaces

### DIFF
--- a/scripts/nix-cc.sh
+++ b/scripts/nix-cc.sh
@@ -29,7 +29,7 @@ die() {
 
 xrealpath() {
   # https://stackoverflow.com/a/3915420
-  echo $(cd $(dirname $1); pwd)/$(basename $1)
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 }
 
 xmktemp() {
@@ -50,8 +50,8 @@ fi
 set -eu
 set -o pipefail
 
-inputdir="$(xrealpath $1)"
-outputdir="$(xrealpath $2)"
+inputdir="$(xrealpath "$1")"
+outputdir="$(xrealpath "$2")"
 shift
 shift
 command="${@:-gcc *.c}"
@@ -61,16 +61,18 @@ tmpdir="$(dirname "$outfile")"
 tmpinputdir="$(echo "$inputdir" | sha1sum | tr -d ' -')"
 [[ -n "$tmpinputdir" ]] || die 3 "failed to create temp dir: $tmpinputdir"
 
-tmpinputdir="$(dirname "$outfile")/$tmpinputdir"
+tmpinputdir="$(dirname "$outfile")/basil-nix-cc-input-$tmpinputdir"
 rm -rf "$tmpinputdir"
-cp -r "$inputdir" "$tmpinputdir"
+(set -x; cp -r "$inputdir" "$tmpinputdir")
 inputdir="$tmpinputdir"
 
-nix-build --extra-experimental-features "nix-command flakes" --no-out-link - <<EOF > $outfile
+# --extra-substituters https://pac-nix.cachix.org --extra-trusted-public-keys "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc=" \
+nix-build --extra-experimental-features "nix-command flakes" --no-out-link \
+  - <<EOF > $outfile
   let
     system = builtins.currentSystem;
     pac-nix = builtins.getFlake "github:katrinafyi/pac-nix";
-    pkgs = pac-nix.legacyPackages.\${system};
+    pkgs = pac-nix.packages.\${system};
     aarch64pkgs = pac-nix.inputs.nixpkgs.legacyPackages.\${system}.pkgsCross.aarch64-multiplatform;
   in aarch64pkgs.runCommand "basil-test-files" {
       nativeBuildInputs = [
@@ -84,8 +86,8 @@ nix-build --extra-experimental-features "nix-command flakes" --no-out-link - <<E
       alias clang=aarch64-unknown-linux-gnu-clang
       shopt -s expand_aliases
       mkdir \$out
+      cp -r \${$inputdir}/. .
       (set -x;
-        cp -r \${$inputdir}/. .
         ls
         : BUILDING WITH COMMAND:
         $command

--- a/scripts/nix-cc.sh
+++ b/scripts/nix-cc.sh
@@ -37,7 +37,7 @@ xmktemp() {
   mktemp -t tmp.XXXXXXXXXX
 }
 
-command -v nix >/dev/null|| die 1 "nix is required"
+command -v nix >/dev/null || die 1 "nix is required"
 
 if [[ "$@" == *'--help'* ]]; then
   usage 0
@@ -55,13 +55,23 @@ outputdir="$(xrealpath $2)"
 shift
 shift
 command="${@:-gcc *.c}"
-
 outfile=$(xmktemp)
+tmpdir="$(dirname "$outfile")"
+
+tmpinputdir="$(echo "$inputdir" | sha1sum | tr -d ' -')"
+[[ -n "$tmpinputdir" ]] || die 3 "failed to create temp dir: $tmpinputdir"
+
+tmpinputdir="$(dirname "$outfile")/$tmpinputdir"
+rm -rf "$tmpinputdir"
+cp -r "$inputdir" "$tmpinputdir"
+inputdir="$tmpinputdir"
 
 nix-build --extra-experimental-features "nix-command flakes" --no-out-link - <<EOF > $outfile
   let
-    pkgs = (builtins.getFlake "github:katrinafyi/pac-nix").lib.nixpkgs;
-    aarch64pkgs = pkgs.pkgsCross.aarch64-multiplatform;
+    system = builtins.currentSystem;
+    pac-nix = builtins.getFlake "github:katrinafyi/pac-nix";
+    pkgs = pac-nix.legacyPackages.\${system};
+    aarch64pkgs = pac-nix.inputs.nixpkgs.legacyPackages.\${system}.pkgsCross.aarch64-multiplatform;
   in aarch64pkgs.runCommand "basil-test-files" {
       nativeBuildInputs = [
         aarch64pkgs.buildPackages.gcc


### PR DESCRIPTION
quotation marks added everywhere.

nix doesn't like path literals with spaces, so they're copied into a space-less path before being passed to nix.