### PR TITLE
docs: fix extra /BASIL/ in URLs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils
       - run: |
           ./mill --no-server allDocs
-          echo "dir=$(realpath out/allDocs.dest)" >> "$GITHUB_OUTPUT"
+          echo "dir=$(realpath out/allDocs.dest/BASIL)" >> "$GITHUB_OUTPUT"
         id: allDocs
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
at the moment, https://uq-pac.github.io/BASIL/ is a 404 and the docs are actually uploaded [uq-pac.github.io/BASIL/BASIL](https://uq-pac.github.io/BASIL/BASIL). this is because of a mistake I made.