### PR TITLE
 gtsrelf: include `LOCAL` globals, apply `atEnd`, and add flag to throw on mismatch

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,6 +1,7 @@
 // package scala
 
 import mainargs.{Flag, ParserForClass, arg, main}
+import gtirb.GTIRBReadELF
 import util.boogie_interaction.BoogieResultKind
 import util.{
   AnalysisResultDotLogger,
@@ -399,12 +400,14 @@ object Main {
         val realRelfFile = loadingInputs.relfFile
 
         Logger.setLevel(LogLevel.DEBUG)
-        val (relf, gtirb) = (realRelfFile, gtirbRelfFile) match {
-          case (Some(relfFile), _) =>
-            val (a, b) = IRLoading.loadReadELFWithGTIRB(relfFile, loadingInputs)
-            (Some(a), b)
-          case (None, Some(_)) => (None, Some(IRLoading.loadGTIRBReadELF(loadingInputs)))
-          case _ => throw IllegalArgumentException("--dump-relf requires either --relf or a GTIRB input")
+        val (relf, gtirb) = GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(false) {
+          (realRelfFile, gtirbRelfFile) match {
+            case (Some(relfFile), _) =>
+              val (a, b) = IRLoading.loadReadELFWithGTIRB(relfFile, loadingInputs)
+              (Some(a), b)
+            case (None, Some(_)) => (None, Some(IRLoading.loadGTIRBReadELF(loadingInputs)))
+            case _ => throw IllegalArgumentException("--dump-relf requires either --relf or a GTIRB input")
+          }
         }
 
         // skip writing files if the given path is an empty string. this checks compatibility and exits.
@@ -474,7 +477,9 @@ object Main {
 
     Logger.info(programNameVersionHeader)
 
-    val result = RunUtils.run(q)
+    val result = gtirb.GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(false) {
+      RunUtils.run(q)
+    }
     if (conf.verify.value) {
       assert(result.boogie.nonEmpty)
       var failed = false

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,7 +1,7 @@
 // package scala
 
-import mainargs.{Flag, ParserForClass, arg, main}
 import gtirb.GTIRBReadELF
+import mainargs.{Flag, ParserForClass, arg, main}
 import util.boogie_interaction.BoogieResultKind
 import util.{
   AnalysisResultDotLogger,

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -400,7 +400,7 @@ object Main {
         val realRelfFile = loadingInputs.relfFile
 
         Logger.setLevel(LogLevel.DEBUG)
-        val (relf, gtirb) = GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(false) {
+        val (relf, gtirb) = GTIRBReadELF.withWarnings {
           (realRelfFile, gtirbRelfFile) match {
             case (Some(relfFile), _) =>
               val (a, b) = IRLoading.loadReadELFWithGTIRB(relfFile, loadingInputs)
@@ -477,7 +477,7 @@ object Main {
 
     Logger.info(programNameVersionHeader)
 
-    val result = gtirb.GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(false) {
+    val result = GTIRBReadELF.withWarnings {
       RunUtils.run(q)
     }
     if (conf.verify.value) {

--- a/src/main/scala/gtirb/GTIRBReadELF.scala
+++ b/src/main/scala/gtirb/GTIRBReadELF.scala
@@ -165,7 +165,7 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
     gtirb.symbolEntriesByUuid.view.flatMap {
       case (symid, (size, "OBJECT", "GLOBAL" | "LOCAL", "DEFAULT", idx)) =>
 
-        val referentid = symid.getReferentUuid.get
+        // val addr = symid.getReferentUuid.map(_.get.address)
         val addr = symid.getReferentAddress
         addr match {
           case Some(addr) =>
@@ -200,7 +200,7 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
     }.toSet
 
   def getMainAddress(mainProcedureName: String): BigInt =
-    gtirb.symbolsByName(mainProcedureName).getReferentUuid.get.get.address
+    gtirb.symbolsByName(mainProcedureName).getReferentAddress.get
 
   def getReadELFData(mainProcedureName: String): ReadELFData = {
 

--- a/src/main/scala/gtirb/GTIRBReadELF.scala
+++ b/src/main/scala/gtirb/GTIRBReadELF.scala
@@ -8,8 +8,8 @@ import translating.{ELFBind, ELFNDX, ELFSymType, ELFSymbol, ELFVis, ReadELFData}
 import util.Logger
 
 import java.io.ByteArrayInputStream
-import scala.util.chaining.scalaUtilChainingOps
 import scala.util.DynamicVariable
+import scala.util.chaining.scalaUtilChainingOps
 
 /**
  * Responsible for interpreting the GTIRB's symbol information
@@ -259,7 +259,9 @@ object GTIRBReadELF {
 
     inline def check(b: Boolean, s: String) = {
       if (!b) {
-        Logger.warn("PLEASE REPORT THIS ISSUE! (https://github.com/UQ-PAC/BASIL/issues/509) include the gts and relf files.\ngtirb relf discrepancy, " + s)
+        Logger.warn(
+          "PLEASE REPORT THIS ISSUE! (https://github.com/UQ-PAC/BASIL/issues/509) include the gts and relf files.\ngtirb relf discrepancy, " + s
+        )
         ok = false
       }
     }

--- a/src/main/scala/gtirb/GTIRBReadELF.scala
+++ b/src/main/scala/gtirb/GTIRBReadELF.scala
@@ -159,13 +159,13 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
 
   def getGlobals(): Set[SpecGlobal] =
     gtirb.symbolEntriesByUuid.view.flatMap {
-      case (symid, (size, "OBJECT", "GLOBAL", "DEFAULT", idx)) =>
+      case (symid, (size, "OBJECT", "GLOBAL" | "LOCAL", "DEFAULT", idx)) =>
 
         val referentid = symid.getReferentUuid.get
         val referent: Option[gtirb.BlockData] = referentid.getOption
         referent match {
           case Some(blk) =>
-            Some(SpecGlobal(symid.get.name, (size * 8).toInt, None, blk.address))
+            Some(SpecGlobal(symid.get.name, (size * 8).toInt, None, symid.getReferentAddress))
 
           // if the referent is not a real block, then this is a
           // forwarding target symbol. discard, because we generate

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -50,16 +50,18 @@ trait SystemTests extends AnyFunSuite, CaptureOutput, BASILTest, TestCustomisati
   override def customiseTestsByName(name: String): Mode = Mode.Normal
 
   override def withFixture(test: NoArgTest) = {
+    import gtirb.GTIRBReadELF.RelfCompatibilityLevel.*
+
     val checkRelf = test.name match {
       // XXX: these test cases have mismatching .relf and .gts files, so incompatibilies are expected
       // until they are updated and fixed.
-      case s"incorrect/nestedifglobal/${_}" => false
+      case s"incorrect/nestedifglobal/${_}" => Silent
       // XXX: mismatches in bss_start symbols
-      case s"extraspec_correct/malloc_memcpy_strlen_memset_free/${_}" => false
-      case s"extraspec_incorrect/malloc_memcpy_strlen_memset_free/${_}" => false
-      case _ => true
+      case s"extraspec_correct/malloc_memcpy_strlen_memset_free/${_}" => Silent
+      case s"extraspec_incorrect/malloc_memcpy_strlen_memset_free/${_}" => Silent
+      case _ => Exception
     }
-    gtirb.GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(checkRelf) {
+    gtirb.GTIRBReadELF.relfCompatibilityLevel.withValue(checkRelf) {
       super.withFixture(test)
     }
   }

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -53,9 +53,10 @@ trait SystemTests extends AnyFunSuite, CaptureOutput, BASILTest, TestCustomisati
     val checkRelf = test.name match {
       // XXX: these test cases have mismatching .relf and .gts files, so incompatibilies are expected
       // until they are updated and fixed.
+      case s"incorrect/nestedifglobal/${_}" => false
+      // XXX: mismatches in bss_start symbols
       case s"extraspec_correct/malloc_memcpy_strlen_memset_free/${_}" => false
       case s"extraspec_incorrect/malloc_memcpy_strlen_memset_free/${_}" => false
-      case s"incorrect/nestedifglobal/${_}" => false
       case _ => true
     }
     gtirb.GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(checkRelf) {

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -49,6 +49,20 @@ trait SystemTests extends AnyFunSuite, CaptureOutput, BASILTest, TestCustomisati
 
   override def customiseTestsByName(name: String): Mode = Mode.Normal
 
+  override def withFixture(test: NoArgTest) = {
+    val checkRelf = test.name match {
+      // XXX: these test cases have mismatching .relf and .gts files, so incompatibilies are expected
+      // until they are updated and fixed.
+      case s"extraspec_correct/malloc_memcpy_strlen_memset_free/${_}" => false
+      case s"extraspec_incorrect/malloc_memcpy_strlen_memset_free/${_}" => false
+      case s"incorrect/nestedifglobal/${_}" => false
+      case _ => true
+    }
+    gtirb.GTIRBReadELF.enableRelfCompatibilityAssertion.withValue(checkRelf) {
+      super.withFixture(test)
+    }
+  }
+
   def runTests(folder: String, conf: TestConfig): Unit = {
     val path = testPath + folder
     val programs = getSubdirectories(path)

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -56,9 +56,6 @@ trait SystemTests extends AnyFunSuite, CaptureOutput, BASILTest, TestCustomisati
       // XXX: these test cases have mismatching .relf and .gts files, so incompatibilies are expected
       // until they are updated and fixed.
       case s"incorrect/nestedifglobal/${_}" => Silent
-      // XXX: mismatches in bss_start symbols
-      case s"extraspec_correct/malloc_memcpy_strlen_memset_free/${_}" => Silent
-      case s"extraspec_incorrect/malloc_memcpy_strlen_memset_free/${_}" => Silent
       case _ => Exception
     }
     gtirb.GTIRBReadELF.relfCompatibilityLevel.withValue(checkRelf) {


### PR DESCRIPTION
works towards https://github.com/UQ-PAC/BASIL/issues/509