### PR TITLE
tests: unset testSuiteSuffix in SystemTestsGTIRBOfflineLifter

### DIFF
--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -273,7 +273,6 @@ class SystemTestsGTIRB extends SystemTests {
 
 @test_util.tags.StandardSystemTest
 class SystemTestsGTIRBOfflineLifter extends SystemTests {
-  override def testSuiteSuffix = ""
   runTests(
     "correct",
     TestConfig(


### PR DESCRIPTION
with the previous testSuiteSuffix = "", this would clash with the SystemTestsGTIRB and lead to non-deterministic failures when writing the boogie output collided.

removing the override returns to the default implementation, which computes a unique suffix based on the test suite name.