### PR TITLE
upgrade scala 3.3.4 -> 3.3.6

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -24,7 +24,7 @@ import com.goyeau.mill.scalafix.ScalafixModule
 object `package` extends RootModule with ScalaModule with BasilDocs with BasilVersion with ScalafixModule {
   // ammoniteVersion should be updated whenever scalaVersion is changed. see, for example,
   // https://mvnrepository.com/artifact/com.lihaoyi/ammonite_3.4.3 to list valid versions.
-  override def scalaVersion = "3.3.4"
+  override def scalaVersion = "3.3.6"
 
   override def ammoniteVersion = "3.0.2"
 


### PR DESCRIPTION
- changelog 3.3.5 https://github.com/scala/scala3/releases/tag/3.3.5
- changelog 3.3.6 https://github.com/scala/scala3/releases/tag/3.3.6
- changelog 2.13.15 https://github.com/scala/scala/releases/tag/v2.13.15 (3.3.5 upgrades stdlib to match 2.13.15)

Can't see anything in change logs that is going to affect us