### PR TITLE
tests: remove nestedifglobal exemption

### DIFF
--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -53,9 +53,7 @@ trait SystemTests extends AnyFunSuite, CaptureOutput, BASILTest, TestCustomisati
     import gtirb.GTIRBReadELF.RelfCompatibilityLevel.*
 
     val checkRelf = test.name match {
-      // XXX: these test cases have mismatching .relf and .gts files, so incompatibilies are expected
-      // until they are updated and fixed.
-      case s"incorrect/nestedifglobal/${_}" => Silent
+      // Throw by default for gtsrelf/oldrelf mismatches
       case _ => Exception
     }
     gtirb.GTIRBReadELF.relfCompatibilityLevel.withValue(checkRelf) {


### PR DESCRIPTION
committed files were re-lifted in https://github.com/UQ-PAC/BASIL/pull/510, so the special case to permit their gtsrelf/oldrelf mismatch is no longer needed.