### PR TITLE
more deterministic ordering for IL serialise and sortProceduresRPO

### DIFF
--- a/src/main/scala/boogie/BExpr.scala
+++ b/src/main/scala/boogie/BExpr.scala
@@ -788,8 +788,7 @@ case class SpecGlobal(
   override val address: BigInt
 ) extends SymbolTableEntry,
       SpecGlobalOrAccess,
-      util.ProductOrdered[SpecGlobal]
-      derives ir.dsl.ToScala {
+      util.ProductOrdered[SpecGlobal] derives ir.dsl.ToScala {
   override def specGlobals: Set[SpecGlobalOrAccess] = Set(this)
 
   def sanitisedName = util.StringEscape.escape(name)

--- a/src/main/scala/boogie/BExpr.scala
+++ b/src/main/scala/boogie/BExpr.scala
@@ -774,13 +774,11 @@ trait SpecVar extends BExpr {
   }
 }
 
-trait SpecGlobalOrAccess extends SpecVar with Ordered[SpecGlobalOrAccess] {
+trait SpecGlobalOrAccess extends SpecVar {
   val toAddrVar: BExpr
   val toOldVar: BVar
   val toOldGamma: BVar
   val size: Int
-
-  def compare(that: SpecGlobalOrAccess): Int = address.compare(that.address)
 }
 
 case class SpecGlobal(
@@ -789,7 +787,9 @@ case class SpecGlobal(
   arraySize: Option[Int],
   override val address: BigInt
 ) extends SymbolTableEntry,
-      SpecGlobalOrAccess derives ir.dsl.ToScala {
+      SpecGlobalOrAccess,
+      util.ProductOrdered[SpecGlobal]
+      derives ir.dsl.ToScala {
   override def specGlobals: Set[SpecGlobalOrAccess] = Set(this)
 
   def sanitisedName = util.StringEscape.escape(name)

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -128,13 +128,14 @@ class Program(
 
     walk(mainProcedure)
 
-    var wl = procedures.toSet.diff(seen)
+    val wl = mutable.TreeSet.from(procedures)(Ordering.by(x => (x.procName, x.address)))
+    wl --= seen
 
     while (wl.nonEmpty) {
       // add the rest of the procedures
       val n = wl.find(p => p.incomingCalls().isEmpty).getOrElse(wl.head)
       walk(n)
-      wl = procedures.toSet.diff(seen)
+      wl --= seen
     }
 
     procedures.sortInPlaceBy(ordering)

--- a/src/main/scala/ir/parsing/Attrib.scala
+++ b/src/main/scala/ir/parsing/Attrib.scala
@@ -194,15 +194,15 @@ case class SymbolTableInfo(
 
   def toAttrib = {
 
-    val goffs = Attrib.List(globalOffsets.toVector.map { case (l, r) =>
+    val goffs = Attrib.List(globalOffsets.toVector.sorted.map { case (l, r) =>
       Attrib.List(Vector(Attrib.Int(l), Attrib.Int(r)))
     })
 
     Attrib.Map(
       ListMap(
-        "externalFunctions" -> Attrib.List(externalFunctions.toVector.map(_.toAttrib)),
-        "globals" -> Attrib.List(globals.toVector.map(_.toAttrib)),
-        "funcEntries" -> Attrib.List(funcEntries.toVector.map(_.toAttrib)),
+        "externalFunctions" -> Attrib.List(externalFunctions.toVector.sorted.map(_.toAttrib)),
+        "globals" -> Attrib.List(globals.toVector.sorted.map(_.toAttrib)),
+        "funcEntries" -> Attrib.List(funcEntries.toVector.sorted.map(_.toAttrib)),
         "globalOffsets" -> goffs
       )
     )

--- a/src/main/scala/specification/Specification.scala
+++ b/src/main/scala/specification/Specification.scala
@@ -11,7 +11,7 @@ trait SymbolTableEntry {
 }
 
 case class FuncEntry(override val name: String, override val size: Int, override val address: BigInt)
-    extends SymbolTableEntry derives ir.dsl.ToScala
+    extends SymbolTableEntry with util.ProductOrdered[FuncEntry] derives ir.dsl.ToScala
 
 case class Specification(
   funcs: Set[FuncEntry],
@@ -54,4 +54,4 @@ case class SubroutineSpec(
   }
 }
 
-case class ExternalFunction(name: String, offset: BigInt) derives ir.dsl.ToScala
+case class ExternalFunction(name: String, offset: BigInt) extends util.ProductOrdered[ExternalFunction] derives ir.dsl.ToScala

--- a/src/main/scala/specification/Specification.scala
+++ b/src/main/scala/specification/Specification.scala
@@ -11,7 +11,8 @@ trait SymbolTableEntry {
 }
 
 case class FuncEntry(override val name: String, override val size: Int, override val address: BigInt)
-    extends SymbolTableEntry with util.ProductOrdered[FuncEntry] derives ir.dsl.ToScala
+    extends SymbolTableEntry
+    with util.ProductOrdered[FuncEntry] derives ir.dsl.ToScala
 
 case class Specification(
   funcs: Set[FuncEntry],
@@ -54,4 +55,5 @@ case class SubroutineSpec(
   }
 }
 
-case class ExternalFunction(name: String, offset: BigInt) extends util.ProductOrdered[ExternalFunction] derives ir.dsl.ToScala
+case class ExternalFunction(name: String, offset: BigInt) extends util.ProductOrdered[ExternalFunction]
+    derives ir.dsl.ToScala

--- a/src/main/scala/translating/IRToBoogie.scala
+++ b/src/main/scala/translating/IRToBoogie.scala
@@ -958,7 +958,7 @@ class IRToBoogie(
         Set()
       }
     }
-    val assigns = oldVars.toList.sorted.map { g =>
+    val assigns = oldVars.toList.sortBy(_.address).map { g =>
       val memory = if (regionInjector.isDefined) {
         regionInjector.get.getMergedRegion(g.address, g.size) match {
           case Some(region) => BMapVar(region.name, MapBType(BitVecBType(64), BitVecBType(8)), Scope.Global)
@@ -1006,9 +1006,9 @@ class IRToBoogie(
     val indices = stores.map(_.index.toBoogie)
 
     val asserts = indices.flatMap { index =>
-      for (c <- controls.keys.view.toList.sorted) yield {
+      for (c <- controls.keys.view.toList.sortBy(_.address)) yield {
         val addrCheck = BinaryBExpr(EQ, index, c.toAddrVar)
-        val checks = controls(c).toList.sorted.map { v =>
+        val checks = controls(c).toList.sortBy(_.address).map { v =>
           BinaryBExpr(BoolIMPLIES, L(LArgs, v.toAddrVar), v.toOldGamma)
         }
         val checksAnd = if (checks.size > 1) {

--- a/src/main/scala/util/ProductOrdered.scala
+++ b/src/main/scala/util/ProductOrdered.scala
@@ -4,7 +4,8 @@ package util
  * Mixin to derive a lexicographic ordering for a case class (specifically, defining the [[Ordered]] trait).
  * This requires existing [[Ordering]] instances for each of the case class's fields.
  */
-trait ProductOrdered[T <: Product](using m: scala.deriving.Mirror.ProductOf[T], ord: Ordering[m.MirroredElemTypes]) extends Ordered[T] {
+trait ProductOrdered[T <: Product](using m: scala.deriving.Mirror.ProductOf[T], ord: Ordering[m.MirroredElemTypes])
+    extends Ordered[T] {
   this: T =>
 
   private val ordering = Ordering.by((x: T) => Tuple.fromProductTyped(x))

--- a/src/main/scala/util/ProductOrdered.scala
+++ b/src/main/scala/util/ProductOrdered.scala
@@ -1,0 +1,12 @@
+package util
+
+/**
+ * Mixin to derive a lexicographic ordering for a case class (specifically, defining the [[Ordered]] trait).
+ * This requires existing [[Ordering]] instances for each of the case class's fields.
+ */
+trait ProductOrdered[T <: Product](using m: scala.deriving.Mirror.ProductOf[T], ord: Ordering[m.MirroredElemTypes]) extends Ordered[T] {
+  this: T =>
+
+  private val ordering = Ordering.by((x: T) => Tuple.fromProductTyped(x))
+  override def compare(other: T) = ordering.compare(this, other)
+}


### PR DESCRIPTION
in sortProceduresRPO, we use a TreeSet with a custom ordering to
enforce a deterministic ordering of walking when multiple options are
available. we also reason that the `seen` set is increasing
and so the `wl` is always decreasing. therefore, we can use `--=` and
avoid re-creating it every iteration. hopefully this is right.

in the IL's attribute printing, we sort all of the maps and sets before
printing. to do so, we introduce ProductOrdered which makes it easy
to define lexicographic ordering on a case class.

i also remove a problematic `Ordered[SpecGlobalOrAccess]` instance
which only sorted by address.

with this change, the attributes of the .il files are now consistent
between gtsrelf and oldrelf.

however, the block numbering and procedure ordering still changes between old relf and gtsrelf