### PR TITLE
Block: do not replace jump if the new jump is physically equal

### DIFF
--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -647,6 +647,8 @@ class Block private (
   }
 
   def replaceJump(j: Jump): Block = {
+    if (j eq jump)
+      return this
     if (j.hasParent) {
       val parent = j.parent
       j.deParent()


### PR DESCRIPTION
avoids running through the replaceJump logic which does a bunch of de-linking and re-linking.

although the `jump_=` also has `j ne _jump` logic, replaceJump would always first set an Unreachable jump, then set the new jump, even if the jumps were the same.
```console
$ b.replaceJump(b.jump)
  + jump = ir.Unreachable@31e3250d 
  + jump = GoTo(returntarget) 
```