### PR TITLE
tests: fix exhaustivity warning

### DIFF
--- a/src/test/scala/test_util/BASILTest.scala
+++ b/src/test/scala/test_util/BASILTest.scala
@@ -106,11 +106,9 @@ trait BASILTest {
 
   def checkVerify(boogieResult: BoogieResult, expectVerify: Boolean): (Option[String], Boolean, Boolean) = {
     val failureMsg = boogieResult.kind match {
-      case BoogieResultKind.Verified(_, _) if expectVerify => None
-      case BoogieResultKind.AssertionFailed if !expectVerify => None
+      case BoogieResultKind.Verified(_, _) => Option.when(!expectVerify)("Expected verification failure, but got success.")
       case BoogieResultKind.Timeout => Some("SMT Solver timed out")
-      case BoogieResultKind.Verified(_, _) if !expectVerify => Some("Expected verification failure, but got success.")
-      case BoogieResultKind.AssertionFailed if expectVerify => Some("Expected verification success, but got failure.")
+      case BoogieResultKind.AssertionFailed => Option.when(expectVerify)("Expected verification success, but got failure.")
       case k: BoogieResultKind.Unknown => Some(k.toString)
     }
     (failureMsg, boogieResult.kind == BoogieResultKind.Verified, boogieResult.kind == BoogieResultKind.Timeout)


### PR DESCRIPTION
previously, the compiler flagged this exhaustivity warning
```
[warn] 108 |    val failureMsg = boogieResult.kind match {
[warn]     |                     ^^^^^^^^^^^^^^^^^
[warn]     |match may not be exhaustive.
[warn]     |
[warn]     |It would fail on pattern case: util.boogie_interaction.BoogieResultKind.Verified(_, _), AssertionFailed
```
because the match statement used predicate conditions. the scala compiler could not reason that the predicates covered all cases by way of law of excluded middle.

this change moves the conditionals into the rhs of the match, so exhaustivity is satisfied.