### PR TITLE
ci: cache coursier dependencies and mill build directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - run: sudo apt-get update
       - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,22 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
+
       - run: sudo apt-get update
       - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils
       - run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+
       - run: sudo apt-get update
       - run: sudo apt-get -y install latexmk texlive-latex-recommended texlive-lang-japanese texlive-latex-extra texlive-extra-utils poppler-utils
       - run: |

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - run: './mill test.compile'
       - name: Check all test suites have at least one tag
@@ -54,11 +54,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - run: ./mill fmt
 
@@ -86,11 +86,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - name: Compile BASIL Mill
         run: ./mill compile
@@ -132,11 +132,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -200,11 +200,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -238,11 +238,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -291,11 +291,11 @@ jobs:
         with:
           path: out
           key: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
           restore-keys: |
-            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            mill-${{ runner.os }}-
-            mill-
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -7,6 +7,7 @@ on:
     # running tests can be skipped for docs-only changes
     paths: ['src/**', 'basilmill/**', '**.mill', '.?mill*', '*.conf', '.github/workflows/run-examples.yml']
   workflow_dispatch:
+
 jobs:
   CheckTestTagging:
     runs-on: ubuntu-latest
@@ -16,6 +17,21 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
+
       - run: './mill test.compile'
       - name: Check all test suites have at least one tag
         run: .github/workflows/check-test-tagging.sh
@@ -25,6 +41,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
 
       - run: ./mill fmt
 
@@ -41,6 +71,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
 
       - name: Compile BASIL Mill
         run: ./mill compile
@@ -71,6 +115,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -124,6 +182,20 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
@@ -145,6 +217,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -182,6 +268,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            mill-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            mill-${{ runner.os }}-
+            mill-
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -45,6 +47,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -75,6 +79,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -119,6 +125,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -185,6 +193,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -221,6 +231,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:
@@ -272,6 +284,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
it is ridiculous that we download scala 10x every push. this should also speed up compilation time and scalafmt time by enabling incremental compilation.