### PR TITLE
fix: parser case for Decl_UninterpFun, minor improvements

### DIFF
--- a/basilmill/nativedeps.mill
+++ b/basilmill/nativedeps.mill
@@ -40,7 +40,6 @@ trait NativeDepsModule extends JavaModule {
 
     (names zip libs).map((name, lib) => {
       val newPath = Task.dest / s"$name.${plat.os.libExtension}"
-      println(s"copying to $newPath")
       os.copy(lib.path, newPath)
     })
 

--- a/basilmill/z3.mill
+++ b/basilmill/z3.mill
@@ -11,7 +11,6 @@ trait Z3Module extends NativeDepsModule {
   val z3LibNames = List("libz3", "libz3java")
 
   override def nativeMvnDeps(plat: Platform) = {
-    println("in z3")
     val soType = plat.os.libExtension
     val arch = plat.arch.mavenName
     z3LibNames.map(name =>

--- a/src/main/scala/ir/parsing/BasilEarlyBNFCVisitor.scala
+++ b/src/main/scala/ir/parsing/BasilEarlyBNFCVisitor.scala
@@ -75,8 +75,7 @@ class BasilEarlyBNFCVisitor[A]()
           decls.merge(Declarations.empty.copy(procSpecs = Map(spec)))
 
         // declarations which do not contain expressions
-        case _: syntax.Decl_UnsharedMem | _: syntax.Decl_SharedMem | _: syntax.Decl_Var | _: syntax.Decl_ProgEmpty =>
-          decls
+        case _ => decls
       }
     )
 

--- a/src/main/scala/ir/parsing/BasilMainBNFCVisitor.scala
+++ b/src/main/scala/ir/parsing/BasilMainBNFCVisitor.scala
@@ -71,11 +71,11 @@ class BasilMainBNFCVisitor[A](var decls: Declarations)
 
     val progSpec = decls.progSpec
 
-    if (procs.isEmpty) {
+    lazy val defaultProc = procs.values.headOption.getOrElse {
       throw ParseException("module must contain at least one procedure", x)
     }
 
-    val mainProc = progSpec.mainProc.fold(procs.values.head)(procs(_))
+    val mainProc = progSpec.mainProc.fold(defaultProc)(procs(_))
     val otherProcs = procs.view.values.filter(_ ne mainProc)
 
     val initialMemory = progSpec.initialMemory.map(_.toMemorySection)

--- a/src/main/scala/ir/parsing/BasilMainBNFCVisitor.scala
+++ b/src/main/scala/ir/parsing/BasilMainBNFCVisitor.scala
@@ -71,6 +71,10 @@ class BasilMainBNFCVisitor[A](var decls: Declarations)
 
     val progSpec = decls.progSpec
 
+    if (procs.isEmpty) {
+      throw ParseException("module must contain at least one procedure", x)
+    }
+
     val mainProc = progSpec.mainProc.fold(procs.values.head)(procs(_))
     val otherProcs = procs.view.values.filter(_ ne mainProc)
 

--- a/src/main/scala/ir/parsing/ParseException.scala
+++ b/src/main/scala/ir/parsing/ParseException.scala
@@ -11,11 +11,19 @@ final case class ParseException(
   val token: HasParsePosition,
   private val cause: Throwable = null
 ) extends Exception(message, cause) {
+
   import scala.reflect.Selectable.reflectiveSelectable
+
   override def toString =
     val line = token.line_num
     val col = token.col_num
     val name = token.getClass.getName
     val excname = this.getClass.getName
-    s"$excname: $message (while parsing $name at line $line, col $col)"
+
+    val location = (line, col) match {
+      case (-1, -1) => "<unknown>"
+      case _ => s"line $line, col $col"
+    }
+
+    s"$excname: $message (while parsing $name at $location)"
 }

--- a/src/test/scala/ir/ParserTest.scala
+++ b/src/test/scala/ir/ParserTest.scala
@@ -1,0 +1,44 @@
+package ir
+
+import ir.*
+import ir.dsl.*
+import org.scalactic.*
+import org.scalatest.funsuite.AnyFunSuite
+import test_util.{BASILTest, CaptureOutput}
+import translating.PrettyPrinter.*
+import util.{BASILConfig, BoogieGeneratorConfig, ILLoadingConfig, LogLevel, Logger}
+import ir.parsing.ParseBasilIL
+
+import scala.collection.immutable.*
+
+@test_util.tags.UnitTest
+class ParserTest extends AnyFunSuite with CaptureOutput {
+
+  override def withFixture(test: NoArgTest) = {
+    DeepEquality.debug.withValue(true) {
+      super.withFixture(test)
+    }
+  }
+
+  val minimal = """
+prog entry @main_1812;
+
+proc @main_1812 () -> ()
+  { .name = "main"; .address = 0x714 }
+[
+  block %main_basil_return_1 [
+    return ();
+  ]
+];
+  """;
+
+  test("minimal") {
+    ParseBasilIL.loadILString(minimal)
+  }
+
+  test("minimal + declare-fun") {
+    ParseBasilIL.loadILString(minimal + """
+      declare-fun $FPToFixed_bv64_bv1123_bool_bv32_bv1123_bv32 : (bv64, bv1123, bool, bv32, bv1123) -> bv32;
+    """)
+  }
+}

--- a/src/test/scala/ir/ParserTest.scala
+++ b/src/test/scala/ir/ParserTest.scala
@@ -1,13 +1,9 @@
 package ir
 
-import ir.*
-import ir.dsl.*
+import ir.parsing.ParseBasilIL
 import org.scalactic.*
 import org.scalatest.funsuite.AnyFunSuite
-import test_util.{BASILTest, CaptureOutput}
-import translating.PrettyPrinter.*
-import util.{BASILConfig, BoogieGeneratorConfig, ILLoadingConfig, LogLevel, Logger}
-import ir.parsing.ParseBasilIL
+import test_util.CaptureOutput
 
 import scala.collection.immutable.*
 


### PR DESCRIPTION
fixes missing case for Decl_UninterpFun by using a wildcard match. starts adding tests for parser aside from round-trip tests.

also adds a parsing exception if no procedures are found, and minorly improves this message.

also removes mill logging for .so file copying

fixes https://github.com/UQ-PAC/BASIL/issues/535