### PR TITLE
mill: update to 1.0.3

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.1-jvm
+//| mill-version: 1.0.3-jvm
 //| mvnDeps:
 //| - org.antlr:antlr4:4.9.3
 //| - com.goyeau::mill-scalafix::0.6.0


### PR DESCRIPTION
haoyi [says]:
- Lots of performance optimizations, ~halving the fixed overhead of running a build
- Mill now tab-completes flags like -j or --jobs

it looks like no changes needed

[says]: https://github.com/com-lihaoyi/mill/blob/main/changelog.adoc