### PR TITLE
ci: sequence compile task before all other tasks

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -9,8 +9,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  Compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - uses: coursier/cache-action@v6
+        with:
+          extraMillFiles: '**/*.mill'
+          ignoreJob: true
+          ignoreMatrix: true
+
+      - uses: actions/cache@v4
+        with:
+          path: out
+          key: |
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
+          restore-keys: |
+            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
+            build-${{ runner.os }}-
+            build-
+
+      - run: ./mill compile
+      - run: ./mill test.compile
+      - run: ./mill fmt
+
   CheckTestTagging:
     runs-on: ubuntu-latest
+    needs: [Compile]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -40,6 +71,7 @@ jobs:
 
   Scalafmt:
     runs-on: ubuntu-latest
+    needs: [Compile]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,36 +97,6 @@ jobs:
       - name: Check source formatting and imports
         run: git diff --exit-code
 
-  Compile:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - uses: coursier/cache-action@v6
-        with:
-          extraMillFiles: '**/*.mill'
-          ignoreJob: true
-          ignoreMatrix: true
-
-      - uses: actions/cache@v4
-        with:
-          path: out
-          key: |
-            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-${{ hashFiles('**/*.scala') }}
-          restore-keys: |
-            build-${{ runner.os }}-${{ hashFiles('**/*.mill') }}-
-            build-${{ runner.os }}-
-            build-
-
-      - name: Compile BASIL Mill
-        run: ./mill compile
-
   # INFO: Scalatest runner arguments (i.e., arguments to scalatest.sh) can be
   # found at: https://www.scalatest.org/user_guide/using_the_runner
 
@@ -113,6 +115,7 @@ jobs:
 
   StandardSystemTests:
     runs-on: ubuntu-latest
+    needs: [Compile]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -181,6 +184,7 @@ jobs:
 
   UnitTestsWindows:
     runs-on: windows-latest
+    needs: [Compile]
 
     steps:
       - uses: actions/checkout@v4
@@ -219,6 +223,7 @@ jobs:
 
   UnitTests:
     runs-on: ubuntu-latest
+    needs: [Compile]
 
     steps:
       - uses: actions/checkout@v4
@@ -260,6 +265,7 @@ jobs:
 
   AnalysisSystemTests:
     runs-on: ubuntu-latest
+    needs: [Compile]
 
     # run 4 AnalysisSystemTests in 4 parallel github jobs.
     # the first job captures all AnalysisSystemTest and excludes all tests numbered with a different tag.

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -37,7 +37,8 @@ jobs:
 
       - run: ./mill compile
       - run: ./mill test.compile
-      - run: ./mill fmt
+      # run to warm up cache for scalafmt
+      - run: './mill semanticDbData + test.semanticDbData + mill.scalalib.scalafmt.ScalafmtModule/scalafmtClasspath + test.fix'
 
   CheckTestTagging:
     runs-on: ubuntu-latest

--- a/build.mill
+++ b/build.mill
@@ -178,8 +178,7 @@ object `package` extends ScalaModule with BasilDocs with BasilVersion with Scala
    *         e.g. https://github.com/com-lihaoyi/mill/discussions/5360"
    */
   def fmt(ev: mill.api.Evaluator): Command[Unit] = Task.Command(exclusive = true) {
-    ev.execute(Seq(fix()))
-    ev.execute(Seq(test.fix()))
+    ev.execute(Seq(fix(), test.fix()))
     ev.execute(Seq(scalafmt.reformat()))
     ()
   }


### PR DESCRIPTION
this lets other tasks use the cached output of the compile task,
so they don't need to re-build the project. previously, there was
no guaranteed sequencing so all the tasks would race to build and upload
the cache artifact.

this also lets us have one single point for producing the cache, so we
can make sure it contains all the test classes and semantic db data.