### PR TITLE
Fix panic in WpDual domain with FApplyExprs

### DIFF
--- a/src/main/scala/analysis/GammaDomains.scala
+++ b/src/main/scala/analysis/GammaDomains.scala
@@ -225,13 +225,13 @@ class WpDualDomain(summaries: Procedure => ProcedureSummary) extends PredicateEn
         val nb = terms.foldLeft(b) { case (acc, (l, r)) =>
           r match {
             case Some(rhs) => acc.replace(l, rhs)
-            case None => acc.remove(l, Predicate.True)
+            case None => acc.remove(l, Predicate.True) // TODO verify soundness
           }
         }
         gammas.foldLeft(nb) { case (acc, (l, r)) =>
           r match {
             case Some(rhs) => acc.replace(l, rhs)
-            case None => acc.remove(l, Predicate.True)
+            case None => acc.remove(l, Predicate.True) // TODO verify soundness
           }
         }
       }

--- a/src/main/scala/analysis/GammaDomains.scala
+++ b/src/main/scala/analysis/GammaDomains.scala
@@ -220,13 +220,19 @@ class WpDualDomain(summaries: Procedure => ProcedureSummary) extends PredicateEn
   def transfer(b: Predicate, c: Command): Predicate = {
     c match {
       case SimulAssign(assigns, _) => {
-        val terms = assigns.map((l, r) => (BVTerm.Var(l), exprToBVTerm(r).get))
-        val gammas = assigns.map((l, r) => (GammaTerm.Var(l), exprToGammaTerm(r).get))
+        val terms = assigns.map((l, r) => (BVTerm.Var(l), exprToBVTerm(r)))
+        val gammas = assigns.map((l, r) => (GammaTerm.Var(l), exprToGammaTerm(r)))
         val nb = terms.foldLeft(b) { case (acc, (l, r)) =>
-          acc.replace(l, r)
+          r match {
+            case Some(rhs) => acc.replace(l, rhs)
+            case None => acc.remove(l, Predicate.True)
+          }
         }
         gammas.foldLeft(nb) { case (acc, (l, r)) =>
-          acc.replace(l, r)
+          r match {
+            case Some(rhs) => acc.replace(l, rhs)
+            case None => acc.remove(l, Predicate.True)
+          }
         }
       }
       case a: MemoryAssign =>

--- a/src/main/scala/analysis/procedure_summaries/Predicate.scala
+++ b/src/main/scala/analysis/procedure_summaries/Predicate.scala
@@ -4,6 +4,7 @@ import boogie.*
 import ir.*
 import ir.transforms.AbstractDomain
 import util.assertion.*
+import util.functional.sequence
 
 // TODO DAG predicates (don't represent the same subexpression twice)
 
@@ -20,6 +21,8 @@ enum BVTerm {
   case Repeat(repeats: Int, body: BVTerm)
   case ZeroExtend(extension: Int, body: BVTerm)
   case SignExtend(extension: Int, body: BVTerm)
+  // TODO should params be something different?
+  case FApply(name: String, params: Seq[BVTerm], returnWidth: Int, uninterpreted: Boolean)
 
   // TODO width correctness
 
@@ -40,6 +43,8 @@ enum BVTerm {
     case Repeat(repeats, body) => BVRepeat(repeats, body.toBoogie)
     case ZeroExtend(extension, body) => BVZeroExtend(extension, body.toBoogie)
     case SignExtend(extension, body) => BVSignExtend(extension, body.toBoogie)
+    case FApply(name, params, returnWidth, uninterpreted) =>
+      BFunctionCall(name, params.map(_.toBoogie).toList, BitVecBType(returnWidth), uninterpreted)
   }
 
   /**
@@ -55,6 +60,8 @@ enum BVTerm {
     case Repeat(repeats, body) => ir.Repeat(repeats, body.toBasil)
     case ZeroExtend(extension, body) => ir.ZeroExtend(extension, body.toBasil)
     case SignExtend(extension, body) => ir.SignExtend(extension, body.toBasil)
+    case FApply(name, params, returnWidth, uninterpreted) =>
+      ir.FApplyExpr(name, params.map(_.toBasil), BitVecType(returnWidth), uninterpreted)
   }
 
   /**
@@ -72,6 +79,7 @@ enum BVTerm {
     case Repeat(repeats, body) => body.size * repeats
     case ZeroExtend(extension, body) => body.size + extension
     case SignExtend(extension, body) => body.size + extension
+    case FApply(_, _, returnWidth, _) => returnWidth
   }
 
   /**
@@ -98,6 +106,8 @@ enum BVTerm {
       case Repeat(repeats, body) => Repeat(repeats, body.simplify)
       case ZeroExtend(extension, body) => ZeroExtend(extension, body.simplify)
       case SignExtend(extension, body) => SignExtend(extension, body.simplify)
+      case FApply(name, params, returnWidth, uninterpreted) =>
+        FApply(name, params.map(_.simplify), returnWidth, uninterpreted)
       case _ => this
     }
     ret.simplified = true
@@ -118,6 +128,8 @@ enum BVTerm {
     case Repeat(repeats, body) => Repeat(repeats, body.replace(prev, cur))
     case ZeroExtend(extension, body) => ZeroExtend(extension, body.replace(prev, cur))
     case SignExtend(extension, body) => SignExtend(extension, body.replace(prev, cur))
+    case FApply(name, params, returnWidth, uninterpreted) =>
+      FApply(name, params.map(_.replace(prev, cur)), returnWidth, uninterpreted)
   }
 
   /**
@@ -132,6 +144,8 @@ enum BVTerm {
       case Repeat(repeats, body) => body.contains(term)
       case ZeroExtend(extension, body) => body.contains(term)
       case SignExtend(extension, body) => body.contains(term)
+      case FApply(name, params, returnWidth, uninterpreted) =>
+        params.exists(_.contains(term))
       case _ => false
     }
 
@@ -149,6 +163,8 @@ enum BVTerm {
       case Extract(end, start, body) => body.containsOnly(vars)
       case ZeroExtend(extension, body) => body.containsOnly(vars)
       case SignExtend(extension, body) => body.containsOnly(vars)
+      case FApply(name, params, returnWidth, uninterpreted) =>
+        params.forall(_.containsOnly(vars))
     }
   }
 
@@ -165,6 +181,7 @@ enum GammaTerm {
   case OldVar(v: Variable)
   case Uop(op: BoolUnOp, x: GammaTerm)
   case Join(s: Set[GammaTerm])
+  // TODO FApply terms?
 
   private var simplified: Boolean = false
 
@@ -780,6 +797,8 @@ def exprToBVTerm(e: Expr): Option[BVTerm] = e match {
   case Repeat(repeats, body) => exprToBVTerm(body).map(x => BVTerm.Repeat(repeats, x))
   case ZeroExtend(extension, body) => exprToBVTerm(body).map(x => BVTerm.ZeroExtend(extension, x))
   case SignExtend(extension, body) => exprToBVTerm(body).map(x => BVTerm.SignExtend(extension, x))
+  case FApplyExpr(name, params, returnType: BitVecType, uninterpreted) =>
+    sequence(params.map(x => exprToBVTerm(e))).map(BVTerm.FApply(name, _, returnType.size, uninterpreted))
   case _ => None
 }
 

--- a/src/test/scala/GammaDomainTests.scala
+++ b/src/test/scala/GammaDomainTests.scala
@@ -113,5 +113,6 @@ class GammaDomainTests extends AnyFunSuite, CaptureOutput {
     )
     val f = program.nameToProcedure("f")
     val wpDualResults = getWpDualResults(f)
+    // should have not panicked
   }
 }

--- a/src/test/scala/GammaDomainTests.scala
+++ b/src/test/scala/GammaDomainTests.scala
@@ -18,6 +18,13 @@ class GammaDomainTests extends AnyFunSuite, CaptureOutput {
     after
   }
 
+  def getWpDualResults(procedure: Procedure): Map[Block, Predicate] = {
+    reversePostOrder(procedure)
+    val domain = WpDualDomain(_ => ProcedureSummary(List(), List()))
+    val (before, after) = worklistSolver(domain).solveProc(procedure, true)
+    after
+  }
+
   def getReachabilityConditions(procedure: Procedure): Map[Block, Predicate] = {
     reversePostOrder(procedure)
     val (before, after) = worklistSolver(ReachabilityConditions()).solveProc(procedure, false)
@@ -97,5 +104,14 @@ class GammaDomainTests extends AnyFunSuite, CaptureOutput {
         .split
         .contains(Predicate.gammaLeq(GammaTerm.Var(R0), GammaTerm.OldVar(R2)))
     )
+  }
+
+  test("fApplyExpr") {
+    val program = prog(
+      proc("main", block("main", directCall("f"), goto("mainRet")), block("mainRet", ret)),
+      proc("f", block("assign", LocalAssign(R0, FApplyExpr("__VERIFIER_nondet_uint", Seq(), BitVecType(32), true), None), goto("returnBlock")), block("returnBlock", ret))
+    )
+    val f = program.nameToProcedure("f")
+    val wpDualResults = getWpDualResults(f)
   }
 }

--- a/src/test/scala/GammaDomainTests.scala
+++ b/src/test/scala/GammaDomainTests.scala
@@ -109,7 +109,15 @@ class GammaDomainTests extends AnyFunSuite, CaptureOutput {
   test("fApplyExpr") {
     val program = prog(
       proc("main", block("main", directCall("f"), goto("mainRet")), block("mainRet", ret)),
-      proc("f", block("assign", LocalAssign(R0, FApplyExpr("__VERIFIER_nondet_uint", Seq(), BitVecType(32), true), None), goto("returnBlock")), block("returnBlock", ret))
+      proc(
+        "f",
+        block(
+          "assign",
+          LocalAssign(R0, FApplyExpr("__VERIFIER_nondet_uint", Seq(), BitVecType(32), true), None),
+          goto("returnBlock")
+        ),
+        block("returnBlock", ret)
+      )
     )
     val f = program.nameToProcedure("f")
     val wpDualResults = getWpDualResults(f)


### PR DESCRIPTION
Converting an expression containing an FApplyExpr to a BVTerm was returning None and causing a panic. This pr handles uninterpreted functions in BVTerms and also removes the get call causing a panic.