### PR TITLE
mill: make `ctags` a Task.Command to avoid sandbox issues

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -232,7 +232,7 @@ object `package` extends ScalaModule with BasilDocs with BasilVersion with Scala
    * Build the ctags file containing code definition locations.
    * This can be used with `./mill -w` to watch and re-build on file changes.
    */
-  def ctags = Task {
+  def ctags() = Task.Command {
     val src = Task.traverse(Seq(this, test) ++ moduleDeps)(_.allSources)().flatten
     val srcArgs = src.map(_.path).filter(os.exists(_)).map(_.toString)
 


### PR DESCRIPTION
the ctags command was broken after the mill 1.0 update which introduced task sandboxing. a Task.Command is not restricted by the sandbox.