### PR TITLE
fix: confusion of Extract arguments in ExprEval

### DIFF
--- a/src/main/scala/ir/eval/BitVectorEval.scala
+++ b/src/main/scala/ir/eval/BitVectorEval.scala
@@ -149,13 +149,22 @@ object BitVectorEval {
   /** ((_ extract i j) (_ BitVec m) (_ BitVec n))
     *
     * extraction of bits i down to j from a bitvector of size m to yield a new bitvector of size n, where n = i - j + 1
+    * ```
+    * [[((_ extract i j) s))]] := λx:[0, i-j+1). [[s]](j + x)
+    * where s is of sort (_ BitVec l), 0 ≤ j ≤ i < l.
+    * ```
+    *
+    * That is, `smt_extract(hi, lo, e)` where `hi` and `lo` are both *inclusive*.
     */
   def smt_extract(i: Int, j: Int, s: BitVecLiteral): BitVecLiteral = {
     require(i >= j)
     BitVecLiteral((s.value >> j) & ((BigInt(1) << (i - j + 1)) - 1), i - j + 1)
   }
 
-  /** Boogie unintuitively uses a slightly different extract operator to SMT-Lib. We are matching the Boogie semantics
+  /** Boogie unintuitively uses a slightly different extract operator to SMT-Lib. We are matching the Boogie semantics.
+    *
+    * I gather this means `boogie_extract(hi_exclusive, lo, e)`, where `hi_exclusive` is exclusive
+    * (unlike [[smt_extract]]).
     */
   def boogie_extract(i: Int, j: Int, s: BitVecLiteral): BitVecLiteral = smt_extract(i - 1, j, s)
 

--- a/src/main/scala/ir/eval/ExprEval.scala
+++ b/src/main/scala/ir/eval/ExprEval.scala
@@ -189,7 +189,7 @@ def fastPartialEvalExprTopLevel(exp: Expr): (Expr, Boolean) = {
       logSimp(exp, if (evalBoolLogBinExpr(op, l.value, r.value)) then TrueLiteral else FalseLiteral)
     case ZeroExtend(e, l: BitVecLiteral) => logSimp(exp, BitVectorEval.smt_zero_extend(e, l))
     case SignExtend(e, l: BitVecLiteral) => logSimp(exp, BitVectorEval.smt_sign_extend(e, l))
-    case Extract(e, b, l: BitVecLiteral) => logSimp(exp, BitVectorEval.boogie_extract(e, b, l))
+    case Extract(e, b, l: BitVecLiteral) => logSimp(exp, BitVectorEval.boogie_extract(b, e, l))
     case Repeat(reps, b: BitVecLiteral) => {
       debugAssert(reps > 0)
       if (reps == 1) logSimp(exp, b)


### PR DESCRIPTION
i'm so tired of thinking about this. it's been years T_T

this time, the bug was because the Basil IR Extract has a different parameter order to the `boogie_extract` and `smt_extract` functions.