### PR TITLE
ci: exclude difficult problematic URL and reduce timeouts

### DIFF
--- a/.github/workflows/check-doc-links.sh
+++ b/.github/workflows/check-doc-links.sh
@@ -29,11 +29,12 @@ args=(
   --remap '^file:///.* $0/index.html'
   --exclude '/scala-lang\.org/api/'
   --exclude '#L\d+$'
+  --exclude 'https://hdl\.handle\.net/1911/96345'
   --insecure
   --no-progress
   --max-concurrency 16
-  --max-retries 10
-  --timeout 120
+  --max-retries 2
+  --timeout 60
   "$@"
 )
 


### PR DESCRIPTION
every CI run does an unreasonably large amount of work. it is good to reduce false negatives.

previously, we had errors such as this

> # Summary
> 
> | Status         | Count   |
> |----------------|---------|
> | 🔍 Total       | 1252772 |
> | ✅ Successful  | 1231887 |
> | ⏳ Timeouts    | 2       |
> | 🔀 Redirected  | 0       |
> | 👻 Excluded    | 20883   |
> | ❓ Unknown     | 0       |
> | 🚫 Errors      | 0       |
> | ⛔ Unsupported | 0       |
> 
> ## Errors per input
> 
> ### Errors in /api/basil/analysis.html
> 
> * [TIMEOUT] <https://hdl.handle.net/1911/96345> | Timeout
> 
> ### Errors in /api/basil/analysis/Dominators$.html
> 
> * [TIMEOUT] <https://hdl.handle.net/1911/96345> | Timeout
> [Full Github Actions output](https://github.com/UQ-PAC/BASIL/actions/runs/17725197963?check_suite_focus=true)
> 