### PR TITLE
Retain order in nextBlocks and prevBlocks

### DIFF
--- a/src/main/scala/analysis/IrreducibleLoops.scala
+++ b/src/main/scala/analysis/IrreducibleLoops.scala
@@ -55,10 +55,10 @@ object LoopDetector {
     headers: Set[Block] = Set(),
 
     // Algorithm helpers
-    visitedNodes: Set[Block] = Set(),
-    nodeDFSPpos: Map[Block, Int] = Map(),
-    iloopHeaders: Map[Block, Block] = Map(),
-    edgeStack: List[LoopEdge] = List()
+    private[LoopDetector] val visitedNodes: Set[Block] = Set(),
+    private[LoopDetector] val nodeDFSPpos: Map[Block, Int] = Map(),
+    private[LoopDetector] val iloopHeaders: Map[Block, Block] = Map(),
+    private[LoopDetector] val edgeStack: List[LoopEdge] = List()
   ) {
     def irreducibleLoops: Set[Loop] = loops.values.filter(l => !l.reducible).toSet
 
@@ -79,7 +79,12 @@ object LoopDetector {
   }
 
   def identify_loops(entryBlock: Block): State = {
-    traverse_loops_dfs(State(), entryBlock, 1)
+    traverse_loops_dfs(State(), entryBlock, 1).copy(
+      visitedNodes = Set(),
+      nodeDFSPpos = Map(),
+      iloopHeaders = Map(),
+      edgeStack = List()
+    )
   }
 
   /*

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -604,7 +604,7 @@ class Block private (
   var label: String,
   val statements: IntrusiveList[Statement],
   private var _jump: Jump,
-  private val _incomingJumps: mutable.HashSet[GoTo],
+  private val _incomingJumps: mutable.LinkedHashSet[GoTo],
   var meta: Metadata
 ) extends HasParent[Procedure]
     with DeepEquality {
@@ -621,7 +621,7 @@ class Block private (
     statements: IterableOnce[Statement] = Set.empty,
     jump: Jump = Unreachable()
   ) = {
-    this(label, IntrusiveList().addAll(statements), jump, mutable.HashSet.empty, Metadata(None, address))
+    this(label, IntrusiveList().addAll(statements), jump, mutable.LinkedHashSet.empty, Metadata(None, address))
   }
 
   def address = meta.address
@@ -668,7 +668,7 @@ class Block private (
     this
   }
 
-  def incomingJumps: immutable.Set[GoTo] = _incomingJumps.toSet
+  def incomingJumps: immutable.Set[GoTo] = _incomingJumps.to(immutable.ListSet)
 
   def addIncomingJump(g: GoTo): Boolean = _incomingJumps.add(g)
 

--- a/src/main/scala/ir/Program.scala
+++ b/src/main/scala/ir/Program.scala
@@ -9,6 +9,7 @@ import util.intrusive_list.*
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{immutable, mutable}
+import scala.util.Random
 
 import eval.BitVectorEval
 
@@ -666,6 +667,16 @@ class Block private (
     }
     jump = j
     this
+  }
+
+  def internalShuffleJumps(): Unit = {
+    jump match {
+      case g: GoTo => g.internalShuffleTargets()
+      case _ => ()
+    }
+    val shuffled = Random.shuffle(_incomingJumps.toList)
+    _incomingJumps.clear()
+    _incomingJumps ++= shuffled
   }
 
   def incomingJumps: immutable.Set[GoTo] = _incomingJumps.to(immutable.ListSet)

--- a/src/main/scala/ir/Statement.scala
+++ b/src/main/scala/ir/Statement.scala
@@ -2,6 +2,8 @@ package ir
 import util.assertion.*
 import util.intrusive_list.IntrusiveListElement
 
+import scala.util.Random
+
 import collection.immutable.SortedMap
 import collection.immutable.ListSet
 import collection.mutable
@@ -290,6 +292,12 @@ class GoTo private (_targets: mutable.LinkedHashSet[Block], var label: Option[St
   def this(targets: Iterable[Block], label: Option[String] = None) = this(mutable.LinkedHashSet.from(targets), label)
 
   def this(target: Block) = this(mutable.Set(target), None)
+
+  def internalShuffleTargets(): Unit = {
+    val shuffled = Random.shuffle(_targets.toList)
+    _targets.clear()
+    _targets ++= shuffled
+  }
 
   def targets: Set[Block] = _targets.to(ListSet)
 

--- a/src/main/scala/ir/Statement.scala
+++ b/src/main/scala/ir/Statement.scala
@@ -3,6 +3,7 @@ import util.assertion.*
 import util.intrusive_list.IntrusiveListElement
 
 import collection.immutable.SortedMap
+import collection.immutable.ListSet
 import collection.mutable
 
 /*
@@ -290,7 +291,7 @@ class GoTo private (_targets: mutable.LinkedHashSet[Block], var label: Option[St
 
   def this(target: Block) = this(mutable.Set(target), None)
 
-  def targets: Set[Block] = _targets.toSet
+  def targets: Set[Block] = _targets.to(ListSet)
 
   override def deepEquals(o: Object): Boolean = o match {
     case GoTo(tgts, lbl) => tgts.map(_.label).toSet == targets.map(_.label).toSet && lbl == label

--- a/src/test/scala/IrreducibleLoop.scala
+++ b/src/test/scala/IrreducibleLoop.scala
@@ -33,6 +33,8 @@ class IrreducibleLoop extends AnyFunSuite with CaptureOutput {
     assert(!boogieResult.contains("found unreachable code"))
   }
 
+  def shuffleNextPrevBlocks(p: ir.Procedure) = p.blocks.foreach { b => b.internalShuffleJumps() }
+
   def runTest(path: String, name: String): Unit = {
     val variationPath = path + "/" + name
     val ADTPath = variationPath + ".adt"
@@ -40,6 +42,7 @@ class IrreducibleLoop extends AnyFunSuite with CaptureOutput {
     Logger.debug(variationPath)
 
     val program: Program = load(ILLoadingConfig(ADTPath, Some(RELFPath)))
+    ir.transforms.clearParams(program)
 
     val foundLoops = LoopDetector.identify_loops(program)
 
@@ -49,6 +52,20 @@ class IrreducibleLoop extends AnyFunSuite with CaptureOutput {
     )
 
     foundLoops.identifiedLoops.foreach(l => Logger.debug(s"found loops${System.lineSeparator()}$l"))
+
+    // loop headers for irreducible loops can be arbitrarily-chosen. shuffling the
+    // order of nextBlocks/prevBlocks affects this choice.
+    val clone = ir.dsl.IRToDSL.convertProgram(program).resolve
+    clone.procedures.foreach(shuffleNextPrevBlocks(_))
+    val cloneFoundLoops = LoopDetector.identify_loops(clone)
+    assert {
+      // in the reordered clone, every header should be either a header of the original analysis,
+      // OR it should be a re-entry point.
+      cloneFoundLoops.headers.map(_.label).forall { header =>
+        foundLoops.headers.map(_.label).contains(header)
+        || foundLoops.loops.values.exists { otherLoop => otherLoop.reentries.map(_.to.label).contains(header) }
+      }
+    }
 
     val newLoops = foundLoops.reducibleTransformIR()
     newLoops.identifiedLoops.foreach(l => Logger.debug(s"newloops${System.lineSeparator()}$l"))


### PR DESCRIPTION
loop headers for irreducible loops can be arbitrarily-chosen, and  the order of nextBlocks/prevBlocks affects this choice.

these sets are constructed from an order-retaining LinkedHashSet. however, they need to be immutable so they were previously converted to a HashSet which discards order. i've changed it to ListSet for now which is fine for iteration but slow for membership checks. looking at the current basil, i can't find any membership operations on these sets so it's probably fine.

in future, we could roll our own immutable.LinkedHashSet if the need arises.

i also added some code the the IrreducibleLoops test which lets you observe the different return values from the loop finder. if the assertion is replaced with set equals on the headers, then it will start failing (some of the time).

after this change, this command goes through:
```bash
./mill run -i ../basilbench/bzip2/bzip2.gts --lifter --pc assert --simplify-tv-verify --main-procedure-name BZ2_decompress --trim-early --procedure-call-depth 1 --simplify-tv-dryrun -v
```

a different approach that doesn't quote work: [0001-canonicalising-loop-representations.-HOWEVER.patch](https://github.com/user-attachments/files/22375999/0001-canonicalising-loop-representations.-HOWEVER.patch)
