### PR TITLE
ci: fix formatting job passing despite failures

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -142,13 +142,13 @@ jobs:
           set -x
           if ! "$autoformat"; then
             : Scalafmt check outcome:
-            ${{ steps.diff.outcome != 'failed' }}
+            ${{ steps.diff.outcome != 'failure' }}
 
             : Scalafmt comment outcome:
-            ${{ steps.prepare.outcome != 'failed' }}
+            ${{ steps.prepare.outcome != 'failure' }}
           else
             : Scalafmt auto-format outcome:
-            ${{ steps.prepare.outcome != 'failed' }}
+            ${{ steps.prepare.outcome != 'failure' }}
           fi
 
 


### PR DESCRIPTION
the outcome name is "failure", not "failed". i should really read the docs more carefully.

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context