### PR TITLE
add top to symvalues domain

### DIFF
--- a/src/main/scala/analysis/data_structure_analysis/SymbolicValueAnalysis.scala
+++ b/src/main/scala/analysis/data_structure_analysis/SymbolicValueAnalysis.scala
@@ -263,7 +263,7 @@ class SymValSetDomain[T <: Offsets](using val offsetDomain: OffsetDomain[T]) ext
   def transform(s: SymValSet[T], f: T => T)(implicit dummyImplicit: DummyImplicit): SymValSet[T] = {
     SymValSet(s.state.view.mapValues(f).toMap)
   }
-  override def top: SymValSet[T] = SymValSet(Map.empty.withDefaultValue(offsetDomain.top))
+  override def top: SymValSet[T] = ???
   override def bot: SymValSet[T] = SymValSet(Map.empty)
 }
 


### PR DESCRIPTION
Attempts to fix crashes seen in SVA when exprs evaluate to top in the abstract domain and calling `toOffsets`, e.g. in cntlm-O3 `https://github.com/agle/basilbench/tree/main/cntlm-noduk`

`./mill run -i ../tvbins/cntlm-noduk/cntlm-noduk.gts --lifter --dump-il cntlm --simplify --dsa= `

Just joins a `Constant -> top` to the symvalset domain if adding a top constant, theoretically with split-globals it should probably also map all the global bases to top since they could alias? Regardless the assertion should be enough to justify keeping them separate. 