### PR TITLE
ci: scalatest.sh

### DIFF
--- a/scripts/scalatest.sh
+++ b/scripts/scalatest.sh
@@ -22,7 +22,7 @@
 # - to print a summary of failing tests at the end of the output, pass I to -o.
 #
 
-classes="$(./mill --ticker false show test.compile | grep '"classes"' | cut -d'"' -f4 | cut -d: -f4)"
+classes="$(./mill -i --ticker false show test.compile | grep '"classes"' | cut -d'"' -f4 | cut -d: -f4)"
 
 if ! [[ -d "$classes" ]]; then
   echo "unable to determine mill class output directory: $classes" >&2


### PR DESCRIPTION
follow up to https://github.com/UQ-PAC/BASIL/pull/569

this was missed in the first pr and can cause the same nondeterministic failures...
```python
Mill daemon exited unexpectedly!
No daemon stdout

Daemon stderr:

Error: Exception in thread "main" java.lang.Exception: Mill server process already present
	at mill.server.Server.run$$anonfun$2(Server.scala:157)
	at mill.server.Server.run$$anonfun$adapted$1(Server.scala:157)
	at scala.Option.getOrElse(Option.scala:201)
	at mill.server.Server.run(Server.scala:157)
	at mill.daemon.MillDaemonMain$.main$$anonfun$1(MillDaemonMain.scala:45)
	at mill.daemon.MillDaemonMain$.main$$anonfun$adapted$1(MillDaemonMain.scala:49)
	at mill.api.SystemStreamsUtils$.withTopLevelSystemStreamProxy(SystemStreamsUtils.scala:74)
	at mill.daemon.MillDaemonMain$.main(MillDaemonMain.scala:49)
	at mill.daemon.MillDaemonMain.main(MillDaemonMain.scala)
unable to determine mill class output directory: 
Error: Process completed with exit code 1.
```