### PR TITLE
docker: bump docker-flake.txt to include clang-14

### DIFF
--- a/src/test/make/docker-flake.txt
+++ b/src/test/make/docker-flake.txt
@@ -1,1 +1,1 @@
-github:katrinafyi/pac-nix/569afdf78558de82c24d25e12680157c3b0aa3df#basil-tools-docker
+github:katrinafyi/pac-nix/619d3503acda2d37d23bbb3d06412e541e510021#basil-tools-docker


### PR DESCRIPTION
docker available at https://github.com/uq-pac/BASIL/pkgs/container/basil-tools-docker/525777622?tag=flake-1bf2-619d3503

diff of pac-nix from previous docker image. https://github.com/katrinafyi/pac-nix/compare/569afdf7...619d3503

the only change to lifting tools is a minor change to aslp.