### PR TITLE
Simplify (some) big concats

### DIFF
--- a/src/main/scala/ir/eval/SimplifyExpr.scala
+++ b/src/main/scala/ir/eval/SimplifyExpr.scala
@@ -1035,9 +1035,12 @@ def cleanupExtends(e: Expr): (Expr, Boolean) = {
     case BinaryExpr(BVCONCAT, a, Repeat(n, b)) if a == b => logSimp(e, Repeat(n + 1, a))
     case BinaryExpr(BVCONCAT, SignExtend(n, a), b) if a == b && size(b).get == 1 => logSimp(e, SignExtend(n + 1, a))
     case BinaryExpr(BVCONCAT, a, SignExtend(n, b)) if a == b && size(b).get == 1 => logSimp(e, SignExtend(n + 1, a))
-    case Repeat(n, body) if size(body).get == 1 => SignExtend(n - 1, body)
-    case SignExtend(n, Extract(1, 0, BinaryExpr(BVLSHR, a, BitVecLiteral(m, w)))) if n == m =>
-      BinaryExpr(BVASHR, Extract(n + 1, 0, a), BitVecLiteral(m, w))
+    case Repeat(n, body) if size(body).get == 1 => logSimp(e, SignExtend(n - 1, body))
+    case SignExtend(n, Extract(1, 0, BinaryExpr(BVLSHR, a, BitVecLiteral(m, _)))) if n >= m =>
+      logSimp(
+        e,
+        SignExtend((n - m).toInt, BinaryExpr(BVASHR, Extract((m + 1).toInt, 0, a), BitVecLiteral(m, (m + 1).toInt)))
+      )
 
     case BinaryExpr(BVSHL, body, BitVecLiteral(n, _)) if size(body).get <= n =>
       logSimp(e, BitVecLiteral(0, size(body).get))


### PR DESCRIPTION
You may have seen expressions like the following (using boogie syntax):
```
bvor32(bvand32((((((((((((((((((((((((((((((((bvlshr32(#R19_1209[32:0], 31bv32)[1:0] ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]) ++ bvlshr32(#R19_1209[32:0], 31bv32)[1:0]), 4227858432bv32), bvand32(bvor32(bvand32(bvor32(bvlshr32(#R19_1209[32:0], 6bv32), bvshl32(#R19_1209[32:0], 26bv32)), 4294967295bv32), 0bv32), 67108863bv32))
```
This is taken from main in cntlm. If we look closely, this is just a concatenation of the same singular bit over and over again! We could just replace it with a repeat.
```
bvor32(bvand32(repeat32_1(bvlshr32(#R19_1209[32:0], 31bv32)[1:0]), 4227858432bv32), bvand32(bvor32(bvand32(bvor32(bvlshr32(#R19_1209[32:0], 6bv32), bvshl32(#R19_1209[32:0], 26bv32)), 4294967295bv32), 0bv32), 67108863bv32))
```
But if you think about it, a repeat of a one bit value is the same thing as a sign extend.
```
bvor32(bvand32(sign_extend31_1(bvlshr32(#R19_1209[32:0], 31bv32)[1:0]), 4227858432bv32), bvand32(bvor32(bvand32(bvor32(bvlshr32(#R19_1209[32:0], 6bv32), bvshl32(#R19_1209[32:0], 26bv32)), 4294967295bv32), 0bv32), 67108863bv32))
```
But if you think about it even more, we're doing a logical right shift by 31 then taking the first bit, and then sign extending... That's just an arithmetic right shift!
```
bvor32(bvand32(bvashr32(#R19_1209[32:0], 31bv32), 4227858432bv32), bvand32(bvor32(bvand32(bvor32(bvlshr32(#R19_1209[32:0], 6bv32), bvshl32(#R19_1209[32:0], 26bv32)), 4294967295bv32), 0bv32), 67108863bv32))
```
I suspect that these big concat chain comes from somewhere in the lifting pipeline not knowing how to handle 32 bit arithmetic shifts nicely. Hopefully the simplification helps somewhere!