### PR TITLE
Update printers to match BinCaml input

### DIFF
--- a/src/main/bnfc/BasilIR.cf
+++ b/src/main/bnfc/BasilIR.cf
@@ -46,9 +46,9 @@ Decl_SharedMem . Decl ::= "memory" "shared" GlobalIdent ":" Type ;
 Decl_UnsharedMem . Decl ::= "memory" GlobalIdent ":" Type ;
 Decl_Var . Decl ::= "var" GlobalIdent ":" Type  ;
 
-separator Type "->";
+terminator Type "->";
 
-Decl_UninterpFun . Decl ::= "val" AttribSet GlobalIdent ":" "(" [Type] ")" "->" Type ;
+Decl_UninterpFun . Decl ::= "val" AttribSet GlobalIdent ":" [Type] Type ;
 Decl_Fun . Decl ::= "define-fun" AttribSet GlobalIdent"(" [Params] ")" "->" Type "=" Expr;
 Decl_ProgEmpty . Decl ::= "prog" "entry" ProcIdent AttribSet ;
 Decl_ProgWithSpec . Decl ::= "prog" "entry" ProcIdent AttribSet BeginList [ ProgSpec ] EndList ;

--- a/src/main/bnfc/BasilIR.cf
+++ b/src/main/bnfc/BasilIR.cf
@@ -46,9 +46,9 @@ Decl_SharedMem . Decl ::= "memory" "shared" GlobalIdent ":" Type ;
 Decl_UnsharedMem . Decl ::= "memory" GlobalIdent ":" Type ;
 Decl_Var . Decl ::= "var" GlobalIdent ":" Type  ;
 
-separator Type ",";
+separator Type "->";
 
-Decl_UninterpFun . Decl ::= "declare-fun" AttribSet GlobalIdent ":" "(" [Type] ")" "->" Type ;
+Decl_UninterpFun . Decl ::= "val" AttribSet GlobalIdent ":" "(" [Type] ")" "->" Type ;
 Decl_Fun . Decl ::= "define-fun" AttribSet GlobalIdent"(" [Params] ")" "->" Type "=" Expr;
 Decl_ProgEmpty . Decl ::= "prog" "entry" ProcIdent AttribSet ;
 Decl_ProgWithSpec . Decl ::= "prog" "entry" ProcIdent AttribSet BeginList [ ProgSpec ] EndList ;

--- a/src/main/scala/translating/PrettyPrinter.scala
+++ b/src/main/scala/translating/PrettyPrinter.scala
@@ -259,7 +259,7 @@ class BasilIRPrettyPrinter(
 
     val uninterp = getUninterp(p)
     val ufdecls = uninterp.map { case (n, pt, rt) =>
-      s"declare-fun ${Sigil.BASIR.globalVar}$n : (${pt.map(vtype).mkString(", ")}) -> ${vtype(rt)}"
+      s"val ${Sigil.BASIR.globalVar}$n : (${pt.map(vtype).mkString("-> ")}) -> ${vtype(rt)}"
     }
 
     Prog(

--- a/src/main/scala/translating/PrettyPrinter.scala
+++ b/src/main/scala/translating/PrettyPrinter.scala
@@ -259,7 +259,7 @@ class BasilIRPrettyPrinter(
 
     val uninterp = getUninterp(p)
     val ufdecls = uninterp.map { case (n, pt, rt) =>
-      s"val ${Sigil.BASIR.globalVar}$n : (${pt.map(vtype).mkString("-> ")}) -> ${vtype(rt)}"
+      s"val ${Sigil.BASIR.globalVar}$n : ${pt.map(vtype).mkString("-> ")} -> ${vtype(rt)}"
     }
 
     Prog(

--- a/src/test/scala/ir/ParserTest.scala
+++ b/src/test/scala/ir/ParserTest.scala
@@ -46,7 +46,7 @@ proc @main_1812 () -> ()
   block %main_basil_return_1 [
     return ();
   ]
-];"""
+];""".replaceAll("\\r\\n?", "\n")
     } {
       p.program.pprint.trim
     }

--- a/src/test/scala/ir/ParserTest.scala
+++ b/src/test/scala/ir/ParserTest.scala
@@ -3,6 +3,7 @@ package ir
 import ir.parsing.ParseBasilIL
 import org.scalatest.funsuite.AnyFunSuite
 import test_util.CaptureOutput
+import translating.PrettyPrinter.pprint
 
 import scala.collection.immutable.*
 
@@ -32,8 +33,22 @@ proc @main_1812 () -> ()
   }
 
   test("minimal + uninterp fun") {
-    ParseBasilIL.loadILString(minimal + """
+    val p = ParseBasilIL.loadILString(minimal + """
       val $FPToFixed_bv64_bv1123_bool_bv32_bv1123_bv32 : bv64 -> bv1123 -> bool -> bv32 -> bv1123 -> bv32;
     """)
+
+    assertResult {
+      """prog entry @main_1812;
+
+proc @main_1812 () -> ()
+  { .name = "main"; .address = 0x714 }
+[
+  block %main_basil_return_1 [
+    return ();
+  ]
+];"""
+    } {
+      p.program.pprint.trim
+    }
   }
 }

--- a/src/test/scala/ir/ParserTest.scala
+++ b/src/test/scala/ir/ParserTest.scala
@@ -31,9 +31,9 @@ proc @main_1812 () -> ()
     ParseBasilIL.loadILString(minimal)
   }
 
-  test("minimal + declare-fun") {
+  test("minimal + uninterp fun") {
     ParseBasilIL.loadILString(minimal + """
-      declare-fun $FPToFixed_bv64_bv1123_bool_bv32_bv1123_bv32 : (bv64, bv1123, bool, bv32, bv1123) -> bv32;
+      val $FPToFixed_bv64_bv1123_bool_bv32_bv1123_bv32 : bv64 -> bv1123 -> bool -> bv32 -> bv1123 -> bv32;
     """)
   }
 }


### PR DESCRIPTION
The output of BASIL does not match the input of BinCaml in a couple places, this updates that to output what it expects.

Uninterp function should be a more function programming looking function i.e.

`name : (a1 -> a2) -> o1`

## TODO
Variables can no longer have `.` in the name, the current idea is just to map them to be _ instead, but I don't like that idea and I would love something better.