### PR TITLE
GTIRB loader fixes

### DIFF
--- a/src/main/scala/gtirb/GTIRBReadELF.scala
+++ b/src/main/scala/gtirb/GTIRBReadELF.scala
@@ -149,18 +149,23 @@ class GTIRBReadELF(protected val gtirb: GTIRBResolver) {
    * Returns relocations as a tuple of relocation offsets and external functions.
    */
   def getRelocations(): (Map[BigInt, BigInt], Set[ExternalFunction]) = {
-    def getSectionBytes(sectionName: String) =
-      gtirb.sectionsByName(sectionName).byteIntervals.head.contents
+    def getSectionBytes(sectionName: String): List[Elf64Rela] = {
+      if (gtirb.sectionsByName.contains(sectionName)) {
+        gtirb.sectionsByName(sectionName).byteIntervals.head.contents.pipe(parseRelaTab)
+      } else {
+        List()
+      }
+    }
 
-    val relaDyns = getSectionBytes(".rela.dyn").pipe(parseRelaTab)
-    val relaPlts = getSectionBytes(".rela.plt").pipe(parseRelaTab)
+    val relaDyns = getSectionBytes(".rela.dyn")
+    val relaPlts = getSectionBytes(".rela.plt")
 
     val relas = (relaDyns ++ relaPlts)
       .groupBy(x => parseAarch64RelaType(x.r_type))
       .withDefaultValue(Nil)
 
     val offs = relas(R_AARCH64_RELATIVE).map(parseRela(R_AARCH64_RELATIVE, _))
-    val exts = (relas(R_AARCH64_GLOB_DAT) ++ relas(R_AARCH64_JUMP_SLOT)).map(parseRelaExtFunc(_))
+    val exts = (relas(R_AARCH64_GLOB_DAT) ++ relas(R_AARCH64_JUMP_SLOT)).map(parseRelaExtFunc)
 
     (offs.toMap, exts.toSet)
   }

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -532,7 +532,7 @@ class GTIRBToIR(
       case EdgeLabel(false, false, Type_Branch, _) =>
         // indirect jump to external subroutine, another block in procedure, or non-returning call to another procedure
         if (proxies.contains(edge.targetUuid)) {
-          handleProxyBlockEdge(block, edge)
+          handleProxyBlockEdge(block, edge, procedures)
         } else if (uuidToBlock.contains(edge.targetUuid)) {
           // resolved indirect jump
           val target = uuidToBlock(edge.targetUuid)
@@ -601,7 +601,7 @@ class GTIRBToIR(
           val label = handlePCAssign(block)
           (Some(DirectCall(target, label)), Unreachable())
         } else if (proxies.contains(edge.targetUuid)) {
-          handleProxyBlockEdge(block, edge)
+          handleProxyBlockEdge(block, edge, procedures)
         } else {
           throw Exception(
             s"edge from ${block.label} to ${b64encode(edge.targetUuid)} does not point to a known procedure entrance"
@@ -614,7 +614,7 @@ class GTIRBToIR(
     }
   }
 
-  private def handleProxyBlockEdge(block: Block, edge: Edge): (Option[Call], Jump) = {
+  private def handleProxyBlockEdge(block: Block, edge: Edge, procedures: ArrayBuffer[Procedure]): (Option[Call], Jump) = {
     val proxySymbols = nodeUUIDToSymbols.getOrElse(edge.targetUuid, mutable.Set())
     if (proxySymbols.isEmpty) {
       // indirect call with no further information

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -532,35 +532,7 @@ class GTIRBToIR(
       case EdgeLabel(false, false, Type_Branch, _) =>
         // indirect jump to external subroutine, another block in procedure, or non-returning call to another procedure
         if (proxies.contains(edge.targetUuid)) {
-          val proxySymbols = nodeUUIDToSymbols.getOrElse(edge.targetUuid, mutable.Set())
-          if (proxySymbols.isEmpty) {
-            // indirect call with no further information
-            val target = block.statements.last match {
-              case LocalAssign(lhs: GlobalVar, rhs: GlobalVar, _) if lhs.name == "_PC" => rhs
-              case _ =>
-                throw Exception(s"no assignment to program counter found before indirect call in block ${block.label}")
-            }
-            val label = handlePCAssign(block)
-            (Some(IndirectCall(target, label)), Unreachable())
-          } else if (proxySymbols.size > 1) {
-            // TODO requires further consideration once encountered
-            throw Exception(
-              s"multiple uuidToSymbol ${proxySymbols.map(_.name).mkString(", ")} associated with proxy block ${edge.targetUuid}, target of indirect call from block ${block.label}"
-            )
-          } else {
-            // indirect call to external procedure with name
-            val externalName = proxySymbols.head.name
-            val target = if (externalProcedures.contains(externalName)) {
-              externalProcedures(externalName)
-            } else {
-              val proc = Procedure(externalName)
-              externalProcedures += (externalName -> proc)
-              procedures += proc
-              proc
-            }
-            val label = handlePCAssign(block)
-            (Some(DirectCall(target, label)), Unreachable())
-          }
+          handleProxyBlockEdge(block, edge)
         } else if (uuidToBlock.contains(edge.targetUuid)) {
           // resolved indirect jump
           val target = uuidToBlock(edge.targetUuid)
@@ -574,12 +546,12 @@ class GTIRBToIR(
           } else {
             // TODO - jump is to a block in the middle of another procedure - need to either split or merge procedures
             throw Exception(
-              s"indirect jump from ${block.label} to ${edge.targetUuid} points to a block in the middle of another procedure"
+              s"indirect jump from ${block.label} to ${b64encode(edge.targetUuid)} points to a block in the middle of another procedure"
             )
           }
         } else {
           throw Exception(
-            s"edge from ${block.label} to ${edge.targetUuid} does not point to a known block or proxy block"
+            s"edge from ${block.label} to ${b64encode(edge.targetUuid)} does not point to a known block or proxy block"
           )
         }
       case EdgeLabel(false, true, Type_Branch, _) =>
@@ -601,7 +573,7 @@ class GTIRBToIR(
           val label = handlePCAssign(block)
           (None, GoTo(mutable.Set(target), label))
         } else {
-          throw Exception(s"edge from ${block.label} to ${edge.targetUuid} does not point to a known block")
+          throw Exception(s"edge from ${block.label} to ${b64encode(edge.targetUuid)} does not point to a known block")
         }
       case EdgeLabel(false, _, Type_Return, _) =>
         // return statement, value of 'direct' is just whether DDisasm has resolved the return target
@@ -619,7 +591,7 @@ class GTIRBToIR(
           val target = uuidToBlock(edge.targetUuid)
           (None, GoTo(mutable.Set(target)))
         } else {
-          throw Exception(s"edge from ${block.label} to ${edge.targetUuid} does not point to a known block")
+          throw Exception(s"edge from ${block.label} to ${b64encode(edge.targetUuid)} does not point to a known block")
         }
       case EdgeLabel(false, true, Type_Call, _) =>
         // call that will not return according to DDisasm even though R30 may be set
@@ -628,15 +600,49 @@ class GTIRBToIR(
           val target = entranceUUIDtoProcedure(edge.targetUuid)
           val label = handlePCAssign(block)
           (Some(DirectCall(target, label)), Unreachable())
+        } else if (proxies.contains(edge.targetUuid)) {
+          handleProxyBlockEdge(block, edge)
         } else {
           throw Exception(
-            s"edge from ${block.label} to ${edge.targetUuid} does not point to a known procedure entrance"
+            s"edge from ${block.label} to ${b64encode(edge.targetUuid)} does not point to a known procedure entrance"
           )
         }
 
       // case EdgeLabel(false, false, Type_Call, _) => probably what a blr instruction should be
 
       case _ => throw Exception(s"cannot handle ${edge.getLabel} from block ${block.label}")
+    }
+  }
+
+  private def handleProxyBlockEdge(block: Block, edge: Edge): (Option[Call], Jump) = {
+    val proxySymbols = nodeUUIDToSymbols.getOrElse(edge.targetUuid, mutable.Set())
+    if (proxySymbols.isEmpty) {
+      // indirect call with no further information
+      val target = block.statements.last match {
+        case LocalAssign(lhs: GlobalVar, rhs: GlobalVar, _) if lhs.name == "_PC" => rhs
+        case _ =>
+          throw Exception(s"no assignment to program counter found before indirect call in block ${block.label}")
+      }
+      val label = handlePCAssign(block)
+      (Some(IndirectCall(target, label)), Unreachable())
+    } else if (proxySymbols.size > 1) {
+      // TODO requires further consideration once encountered
+      throw Exception(
+        s"multiple uuidToSymbol ${proxySymbols.map(_.name).mkString(", ")} associated with proxy block ${b64encode(edge.targetUuid)}, target of indirect call from block ${block.label}"
+      )
+    } else {
+      // indirect call to external procedure with name
+      val externalName = proxySymbols.head.name
+      val target = if (externalProcedures.contains(externalName)) {
+        externalProcedures(externalName)
+      } else {
+        val proc = Procedure(externalName)
+        externalProcedures += (externalName -> proc)
+        procedures += proc
+        proc
+      }
+      val label = handlePCAssign(block)
+      (Some(DirectCall(target, label)), Unreachable())
     }
   }
 

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -905,7 +905,13 @@ class GTIRBToIR(
         val assume = Assume(tempIf.cond, checkSecurity = true)
         val call = DirectCall(target)
         val body: ArrayBuffer[Statement] = ArrayBuffer(assume).appendedAll(tempIf.thenStmts).append(call)
-        Block(newLabel, None, body, Unreachable())
+        // check if target procedure is returning
+        val returning = if (target.blocks.exists(b => b.jump.isInstanceOf[Return])) {
+          GoTo(procedure.returnBlock)
+        } else {
+          Unreachable()
+        }
+        Block(newLabel, None, body, returning)
       } else {
         newBlockCondition(block, uuidToBlock(branch.targetUuid), tempIf.cond, tempIf.thenStmts)
       }

--- a/src/main/scala/translating/GTIRBToIR.scala
+++ b/src/main/scala/translating/GTIRBToIR.scala
@@ -614,7 +614,11 @@ class GTIRBToIR(
     }
   }
 
-  private def handleProxyBlockEdge(block: Block, edge: Edge, procedures: ArrayBuffer[Procedure]): (Option[Call], Jump) = {
+  private def handleProxyBlockEdge(
+    block: Block,
+    edge: Edge,
+    procedures: ArrayBuffer[Procedure]
+  ): (Option[Call], Jump) = {
     val proxySymbols = nodeUUIDToSymbols.getOrElse(edge.targetUuid, mutable.Set())
     if (proxySymbols.isEmpty) {
       // indirect call with no further information
@@ -885,11 +889,26 @@ class GTIRBToIR(
       case i: TempIf => i
       case i => throw Exception(s"last statement of block ${block.label} is not an if statement: $i")
     }
-
-    val trueBlock = newBlockCondition(block, uuidToBlock(branch.targetUuid), tempIf.cond, tempIf.thenStmts)
     val falseBlock =
       newBlockCondition(block, uuidToBlock(fallthrough.targetUuid), UnaryExpr(BoolNOT, tempIf.cond), tempIf.elseStmts)
 
+    val trueBlock =
+      if (
+        entranceUUIDtoProcedure.contains(branch.targetUuid) && entranceUUIDtoProcedure(branch.targetUuid) != procedure
+      ) {
+        // Conditional branch is jumping to the start of another procedure - weird
+        // Create DirectCall instead of GoTo as a starting point
+        // A more sophisticated approach would be to detect this weird case and inline the other procedure if it's just
+        // a single block with no other calls but that's more of a hassle
+        val target = entranceUUIDtoProcedure(branch.targetUuid)
+        val newLabel = s"${block.label}_goto_${target.name}"
+        val assume = Assume(tempIf.cond, checkSecurity = true)
+        val call = DirectCall(target)
+        val body: ArrayBuffer[Statement] = ArrayBuffer(assume).appendedAll(tempIf.thenStmts).append(call)
+        Block(newLabel, None, body, Unreachable())
+      } else {
+        newBlockCondition(block, uuidToBlock(branch.targetUuid), tempIf.cond, tempIf.thenStmts)
+      }
     val newBlocks = ArrayBuffer(trueBlock, falseBlock)
     procedure.addBlocks(newBlocks)
     block.statements.remove(tempIf)


### PR DESCRIPTION
Fixes some weird edge cases with the GTIRB loader encountered in #626 

- Can now handle case where '.rela.dyn' and '.rela.plt' sections are absent
- Properly prints UUIDs when throwing an exception
- Handles non-returning calls to external library functions instead of failing to recognise them (this doesn't mean non-returning call control flow issues are gone, just that the call is properly created instead of crashing)
- Handles bizarre case where a conditional branch jumps outside the procedure, by replacing the goto with a call