### PR TITLE
ci link check: exclude rutgers personal pages

### DIFF
--- a/.github/workflows/check-doc-links.sh
+++ b/.github/workflows/check-doc-links.sh
@@ -28,7 +28,8 @@ args=(
   --index-files index.html
   --exclude '/scala-lang\.org/api/'
   --exclude '#L\d+$'
-  --exclude 'https://hdl\.handle\.net/1911/96345'
+  --exclude '^https://hdl\.handle\.net'
+  --exclude '^https://people\.cs\.rutgers\.edu/~'
   --exclude 'inkuire-big\.svg$'
   --exclude 'fonts/dejavu\.css$'
   --insecure


### PR DESCRIPTION
As reported in https://github.com/UQ-PAC/BASIL/pull/632#issuecomment-4828126135

> 
> ## Errors per input
> 
> ### Errors in /development/transforms.html
> 
> * [403] <https://people.cs.rutgers.edu/~sn349/papers/cgo-2022.pdf> | Rejected status code: 403 Forbidden (configurable with "accept" option)
> 
> ### Errors in /print.html
> 
> * [403] <https://people.cs.rutgers.edu/~sn349/papers/cgo-2022.pdf> | Error (cached)
> 